### PR TITLE
Refactor to ensure activities aren't leaked or lost.

### DIFF
--- a/versions.gradle
+++ b/versions.gradle
@@ -1,4 +1,5 @@
 def versions = [:]
+versions.androidx_activity = '1.4.0'
 versions.androidx_browser = '1.4.0'
 versions.androidx_test = '1.4.0'
 versions.androidx_test_ext = '1.1.3'
@@ -38,6 +39,8 @@ build_versions.target_sdk = 31
 ext.build_versions = build_versions
 
 def deps = [:]
+
+deps.androidx_activity_ktx = "androidx.activity:activity-ktx:$versions.androidx_activity"
 
 deps.androidx_browser = "androidx.browser:browser:$versions.androidx_browser"
 

--- a/web-authentication-ui/build.gradle
+++ b/web-authentication-ui/build.gradle
@@ -52,6 +52,10 @@ dependencies {
     api project(':oauth2')
     api deps.androidx_browser
 
+    implementation deps.lifecycle.viewmodel_ktx
+    implementation deps.androidx_activity_ktx
+    implementation deps.app_compat
+
     testImplementation deps.junit
     testImplementation deps.truth
     testImplementation deps.kotlin.test

--- a/web-authentication-ui/src/main/AndroidManifest.xml
+++ b/web-authentication-ui/src/main/AndroidManifest.xml
@@ -13,13 +13,14 @@
             android:name=".ForegroundActivity"
             android:autoRemoveFromRecents="true"
             android:launchMode="singleInstance"
-            android:theme="@android:style/Theme.Translucent.NoTitleBar" />
+            android:theme="@style/NoAnimationTheme" />
 
         <activity
             android:name=".RedirectActivity"
             android:autoRemoveFromRecents="true"
             android:exported="true"
-            android:launchMode="singleTop">
+            android:launchMode="singleTop"
+            android:theme="@style/NoAnimationTheme">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 

--- a/web-authentication-ui/src/main/java/com/okta/webauthenticationui/ForegroundViewModel.kt
+++ b/web-authentication-ui/src/main/java/com/okta/webauthenticationui/ForegroundViewModel.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.webauthenticationui
+
+import android.app.Activity
+import android.net.Uri
+import androidx.annotation.VisibleForTesting
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
+import okhttp3.HttpUrl
+
+internal class ForegroundViewModel : ViewModel() {
+    companion object {
+        // Needs to be inside the companion object due to the tests. Since this is accessed in init, we'd either need to pass it in the
+        // constructor, or make it static. Since it's for tests only, making it static was the easier solution, which is why I chose
+        // it.
+        @VisibleForTesting var redirectCoordinator: RedirectCoordinator = SingletonRedirectCoordinator
+    }
+
+    sealed class State {
+        object AwaitingInitialization : State()
+        object Error : State()
+        class LaunchBrowser(val url: HttpUrl) : State()
+        object AwaitingBrowserCallback : State()
+    }
+
+    private val _stateLiveData = MutableLiveData<State>(State.AwaitingInitialization)
+    val stateLiveData: LiveData<State> = _stateLiveData
+
+    init {
+        viewModelScope.launch {
+            when (val result = redirectCoordinator.runInitializationFunction()) {
+                is RedirectInitializationResult.Error -> {
+                    _stateLiveData.value = State.Error
+                }
+                is RedirectInitializationResult.Success -> {
+                    // Need to post so when we get the result back instantly, we don't resume, and cancel right away.
+                    _stateLiveData.postValue(State.LaunchBrowser(result.url))
+                }
+            }
+        }
+    }
+
+    fun launchBrowser(activity: Activity, url: HttpUrl) {
+        _stateLiveData.value = State.AwaitingBrowserCallback
+        if (!redirectCoordinator.launchWebAuthenticationProvider(activity, url)) {
+            activity.finish()
+        }
+    }
+
+    fun onResume(activity: Activity) {
+        if (stateLiveData.value == State.AwaitingBrowserCallback) {
+            redirectCoordinator.emit(null)
+            activity.finish()
+        }
+    }
+
+    fun onRedirect(data: Uri?) {
+        redirectCoordinator.emit(data)
+    }
+
+    fun flowCancelled() {
+        redirectCoordinator.emit(null)
+    }
+}

--- a/web-authentication-ui/src/main/java/com/okta/webauthenticationui/RedirectInitializationResult.kt
+++ b/web-authentication-ui/src/main/java/com/okta/webauthenticationui/RedirectInitializationResult.kt
@@ -15,14 +15,9 @@
  */
 package com.okta.webauthenticationui
 
-import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
+import okhttp3.HttpUrl
 
-internal class RedirectActivity : AppCompatActivity() {
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        val redirectIntent = ForegroundActivity.redirectIntent(this, intent.data)
-        startActivity(redirectIntent)
-        finish()
-    }
+internal sealed class RedirectInitializationResult<T> {
+    class Success<T>(val url: HttpUrl, val flowContext: T) : RedirectInitializationResult<T>()
+    class Error<T>(val exception: Exception): RedirectInitializationResult<T>()
 }

--- a/web-authentication-ui/src/main/res/values/style.xml
+++ b/web-authentication-ui/src/main/res/values/style.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="NoAnimationTheme" parent="@style/Theme.AppCompat.NoActionBar">
+        <item name="android:windowAnimationStyle">@null</item>
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">#00000000</item>
+        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowIsFloating">true</item>
+        <item name="android:backgroundDimEnabled">false</item>
+        <item name="android:colorBackgroundCacheHint">@null</item>
+        <item name="android:windowDisablePreview">true</item>
+
+        <item name="android:windowTranslucentStatus">true</item>
+        <item name="android:windowTranslucentNavigation">true</item>
+    </style>
+</resources>

--- a/web-authentication-ui/src/test/java/com/okta/webauthenticationui/ForegroundActivityTest.kt
+++ b/web-authentication-ui/src/test/java/com/okta/webauthenticationui/ForegroundActivityTest.kt
@@ -18,32 +18,40 @@ package com.okta.webauthenticationui
 import android.app.Activity
 import android.net.Uri
 import com.google.common.truth.Truth.assertThat
-import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.ArgumentMatcher
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
-import org.mockito.kotlin.argThat
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.shadows.ShadowLooper
+import java.lang.IllegalStateException
 
 @RunWith(RobolectricTestRunner::class)
 class ForegroundActivityTest {
     @Test fun testResumeLaunchesWebAuthenticationProvider() {
         val launchedFromActivity = Robolectric.buildActivity(Activity::class.java).create().get()
-        val intent = ForegroundActivity.createIntent(launchedFromActivity, "https://example.com/redirect".toHttpUrl())
+        val intent = ForegroundActivity.createIntent(launchedFromActivity)
         val controller = Robolectric.buildActivity(ForegroundActivity::class.java, intent)
         val activity = controller.get()
         val redirectCoordinator = mock<RedirectCoordinator> {
             on { launchWebAuthenticationProvider(any(), any()) } doReturn true
+            onBlocking { runInitializationFunction() } doAnswer {
+                RedirectInitializationResult.Success(mock(), Any())
+            }
         }
-        activity.redirectCoordinator = redirectCoordinator
+        ForegroundViewModel.redirectCoordinator = redirectCoordinator
         controller.create().resume()
+
+        // Needs to run in a delay to ensure it's not instantly cancelled by onResume.
+        verify(redirectCoordinator, never()).launchWebAuthenticationProvider(any(), any())
+
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
         verify(redirectCoordinator).launchWebAuthenticationProvider(any(), any())
         assertThat(activity.isFinishing).isFalse()
         verify(redirectCoordinator, never()).emit(anyOrNull())
@@ -52,45 +60,40 @@ class ForegroundActivityTest {
 
     @Test fun testResumeFinishesWhenWebAuthenticationProviderFails() {
         val launchedFromActivity = Robolectric.buildActivity(Activity::class.java).create().get()
-        val intent = ForegroundActivity.createIntent(launchedFromActivity, "https://example.com/redirect".toHttpUrl())
+        val intent = ForegroundActivity.createIntent(launchedFromActivity)
         val controller = Robolectric.buildActivity(ForegroundActivity::class.java, intent)
         val activity = controller.get()
         val redirectCoordinator = mock<RedirectCoordinator> {
             on { launchWebAuthenticationProvider(any(), any()) } doReturn false
+            onBlocking { runInitializationFunction() } doAnswer {
+                RedirectInitializationResult.Success(mock(), Any())
+            }
         }
-        activity.redirectCoordinator = redirectCoordinator
+        ForegroundViewModel.redirectCoordinator = redirectCoordinator
         controller.create().resume()
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
         assertThat(activity.isFinishing).isTrue()
         verify(redirectCoordinator, never()).emit(anyOrNull())
         verify(redirectCoordinator, never()).emitError(any())
     }
 
-    @Test fun testResumeFinishesWhenUrlIsInvalid() {
-        val launchedFromActivity = Robolectric.buildActivity(Activity::class.java).create().get()
-        val intent = ForegroundActivity.createIntent(launchedFromActivity, "https://example.com/redirect".toHttpUrl())
-        intent.removeExtra("com.okta.webauthenticationui.ForegroundActivity.url")
-        val controller = Robolectric.buildActivity(ForegroundActivity::class.java, intent)
-        val activity = controller.get()
-        val redirectCoordinator = mock<RedirectCoordinator> {
-            on { launchWebAuthenticationProvider(any(), any()) } doReturn false
-        }
-        activity.redirectCoordinator = redirectCoordinator
-        controller.create().resume()
-        assertThat(activity.isFinishing).isTrue()
-        verify(redirectCoordinator, never()).emit(anyOrNull())
-        verify(redirectCoordinator).emitError(argThat(ExceptionMatcher(IllegalStateException("Url not provided when launching ForegroundActivity."))))
-    }
-
     @Test fun testCancellation() {
         val launchedFromActivity = Robolectric.buildActivity(Activity::class.java).create().get()
-        val intent = ForegroundActivity.createIntent(launchedFromActivity, "https://example.com/redirect".toHttpUrl())
+        val intent = ForegroundActivity.createIntent(launchedFromActivity)
         val controller = Robolectric.buildActivity(ForegroundActivity::class.java, intent)
         val activity = controller.get()
         val redirectCoordinator = mock<RedirectCoordinator> {
             on { launchWebAuthenticationProvider(any(), any()) } doReturn true
+            onBlocking { runInitializationFunction() } doAnswer {
+                RedirectInitializationResult.Success(mock(), Any())
+            }
         }
-        activity.redirectCoordinator = redirectCoordinator
-        controller.create().resume().pause().resume()
+        ForegroundViewModel.redirectCoordinator = redirectCoordinator
+        controller.create().resume()
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+        assertThat(activity.isFinishing).isFalse()
+        controller.pause().resume()
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
         assertThat(activity.isFinishing).isTrue()
         verify(redirectCoordinator).emit(null)
         verify(redirectCoordinator, never()).emitError(any())
@@ -98,14 +101,18 @@ class ForegroundActivityTest {
 
     @Test fun testRedirect() {
         val launchedFromActivity = Robolectric.buildActivity(Activity::class.java).create().get()
-        val intent = ForegroundActivity.createIntent(launchedFromActivity, "https://example.com/redirect".toHttpUrl())
+        val intent = ForegroundActivity.createIntent(launchedFromActivity)
         val controller = Robolectric.buildActivity(ForegroundActivity::class.java, intent)
         val activity = controller.get()
         val redirectCoordinator = mock<RedirectCoordinator> {
             on { launchWebAuthenticationProvider(any(), any()) } doReturn true
+            onBlocking { runInitializationFunction() } doAnswer {
+                RedirectInitializationResult.Success(mock(), Any())
+            }
         }
-        activity.redirectCoordinator = redirectCoordinator
+        ForegroundViewModel.redirectCoordinator = redirectCoordinator
         controller.create().resume()
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
         assertThat(activity.isFinishing).isFalse()
         verify(redirectCoordinator, never()).emit(anyOrNull())
         verify(redirectCoordinator, never()).emitError(any())
@@ -115,12 +122,25 @@ class ForegroundActivityTest {
         assertThat(activity.isFinishing).isTrue()
         verify(redirectCoordinator).emit(uri)
     }
-}
 
-private class ExceptionMatcher(
-    private val expected: Exception,
-) : ArgumentMatcher<Exception> {
-    override fun matches(argument: Exception): Boolean {
-        return expected.javaClass == argument.javaClass && expected.message == argument.message
+    @Test fun testNetworkFailureFinishesActivity() {
+        val launchedFromActivity = Robolectric.buildActivity(Activity::class.java).create().get()
+        val intent = ForegroundActivity.createIntent(launchedFromActivity)
+        val controller = Robolectric.buildActivity(ForegroundActivity::class.java, intent)
+        val activity = controller.get()
+        val redirectCoordinator = mock<RedirectCoordinator> {
+            on { launchWebAuthenticationProvider(any(), any()) } doReturn true
+            onBlocking { runInitializationFunction() } doAnswer {
+                RedirectInitializationResult.Error<Any>(IllegalStateException("From Test!"))
+            }
+        }
+        ForegroundViewModel.redirectCoordinator = redirectCoordinator
+        controller.create().resume()
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+
+        verify(redirectCoordinator, never()).launchWebAuthenticationProvider(any(), any())
+        assertThat(activity.isFinishing).isTrue()
+        verify(redirectCoordinator, never()).emit(anyOrNull())
+        verify(redirectCoordinator, never()).emitError(any())
     }
 }


### PR DESCRIPTION
Previously this caused an activity leak if the network request was long running, and the callbacks wouldn't have worked correctly.

This is entirely an internal refactor, no call site changes.