### PR TITLE
Fix lingering Chrome Custom Tab.

### DIFF
--- a/web-authentication-ui/src/main/AndroidManifest.xml
+++ b/web-authentication-ui/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
         <activity
             android:name=".ForegroundActivity"
             android:autoRemoveFromRecents="true"
-            android:launchMode="singleInstance"
+            android:launchMode="singleTop"
             android:theme="@style/NoAnimationTheme" />
 
         <activity


### PR DESCRIPTION
Now when the user logs in they won't see the login page in the android back stack.