### PR TITLE
Remove data class modifier from Token classes.

### DIFF
--- a/auth-foundation/src/main/java/com/okta/authfoundation/credential/Token.kt
+++ b/auth-foundation/src/main/java/com/okta/authfoundation/credential/Token.kt
@@ -17,11 +17,12 @@ package com.okta.authfoundation.credential
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import java.util.Objects
 
 /**
  * Token information representing a user's access to a resource server, including access token, refresh token, and other related information.
  */
-data class Token(
+class Token(
     /**
      * The string type of the token (e.g. `Bearer`).
      */
@@ -65,6 +66,52 @@ data class Token(
             idToken = idToken,
             deviceSecret = deviceSecret,
             issuedTokenType = issuedTokenType,
+        )
+    }
+
+    internal fun copy(
+        refreshToken: String? = this.refreshToken,
+        deviceSecret: String? = this.deviceSecret,
+    ): Token {
+        return Token(
+            tokenType = tokenType,
+            expiresIn = expiresIn,
+            accessToken = accessToken,
+            scope = scope,
+            refreshToken = refreshToken,
+            idToken = idToken,
+            deviceSecret = deviceSecret,
+            issuedTokenType = issuedTokenType,
+        )
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (other === this) {
+            return true
+        }
+        if (other !is Token) {
+            return false
+        }
+        return other.tokenType == tokenType &&
+            other.expiresIn == expiresIn &&
+            other.accessToken == accessToken &&
+            other.scope == scope &&
+            other.refreshToken == refreshToken &&
+            other.idToken == idToken &&
+            other.deviceSecret == deviceSecret &&
+            other.issuedTokenType == issuedTokenType
+    }
+
+    override fun hashCode(): Int {
+        return Objects.hash(
+            tokenType,
+            expiresIn,
+            accessToken,
+            scope,
+            refreshToken,
+            idToken,
+            deviceSecret,
+            issuedTokenType,
         )
     }
 }

--- a/auth-foundation/src/main/java/com/okta/authfoundation/credential/TokenStorage.kt
+++ b/auth-foundation/src/main/java/com/okta/authfoundation/credential/TokenStorage.kt
@@ -16,6 +16,7 @@
 package com.okta.authfoundation.credential
 
 import com.okta.authfoundation.AuthFoundationDefaults
+import java.util.Objects
 
 /**
  * Interface used to customize the way tokens are stored, updated, and removed throughout the lifecycle of an application.
@@ -56,7 +57,7 @@ interface TokenStorage {
     /**
      *  Represents the data to store in [TokenStorage].
      */
-    data class Entry(
+    class Entry(
         /**
          * The unique identifier for this [TokenStorage] entry.
          */
@@ -69,5 +70,25 @@ interface TokenStorage {
          *  The metadata associated with the [TokenStorage] entry.
          */
         val metadata: Map<String, String>,
-    )
+    ) {
+        override fun equals(other: Any?): Boolean {
+            if (other === this) {
+                return true
+            }
+            if (other !is Entry) {
+                return false
+            }
+            return other.identifier == identifier &&
+                other.token == token &&
+                other.metadata == metadata
+        }
+
+        override fun hashCode(): Int {
+            return Objects.hash(
+                identifier,
+                token,
+                metadata,
+            )
+        }
+    }
 }


### PR DESCRIPTION
Removing because data classes are hard to preserve binary compatibility with.