### PR TITLE
Update APIs based on feedback.

### DIFF
--- a/app/src/main/java/sample/okta/android/LaunchFragment.kt
+++ b/app/src/main/java/sample/okta/android/LaunchFragment.kt
@@ -31,7 +31,7 @@ internal class LaunchFragment : BaseFragment<FragmentLaunchBinding>(
         super.onViewCreated(view, savedInstanceState)
 
         lifecycleScope.launch {
-            if (CredentialBootstrap.credential().token != null) {
+            if (CredentialBootstrap.defaultCredential().token != null) {
                 binding.loggedInTextView.visibility = View.VISIBLE
                 binding.dashboardButton.visibility = View.VISIBLE
                 binding.dashboardButton.setOnClickListener {

--- a/app/src/main/java/sample/okta/android/browser/BrowserViewModel.kt
+++ b/app/src/main/java/sample/okta/android/browser/BrowserViewModel.kt
@@ -34,8 +34,8 @@ class BrowserViewModel : ViewModel() {
         viewModelScope.launch {
             _state.value = BrowserState.Loading
 
-            val credential = CredentialBootstrap.credential()
-            val webAuthenticationClient = credential.oidcClient.createWebAuthenticationClient()
+            val credential = CredentialBootstrap.defaultCredential()
+            val webAuthenticationClient = CredentialBootstrap.oidcClient.createWebAuthenticationClient()
             var scopes = credential.scopes()
             if (addDeviceSsoScope) {
                 scopes = scopes + setOf("device_sso")
@@ -47,6 +47,7 @@ class BrowserViewModel : ViewModel() {
                     _state.value = BrowserState.Error("Failed to start login flow.")
                 }
                 is OidcClientResult.Success -> {
+                    credential.storeToken(token = result.result)
                     _state.value = BrowserState.Token
                 }
             }

--- a/app/src/main/java/sample/okta/android/dashboard/DashboardFragment.kt
+++ b/app/src/main/java/sample/okta/android/dashboard/DashboardFragment.kt
@@ -51,7 +51,7 @@ internal class DashboardFragment : BaseFragment<FragmentDashboardBinding>(
     private val onBackPressedCallback = object : OnBackPressedCallback(true) {
         override fun handleOnBackPressed() {
             lifecycleScope.launch {
-                viewModel.setCredential(CredentialBootstrap.credential())
+                viewModel.setCredential(CredentialBootstrap.defaultCredential())
             }
         }
     }
@@ -59,7 +59,7 @@ internal class DashboardFragment : BaseFragment<FragmentDashboardBinding>(
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         viewModel.credentialLiveData.observe(viewLifecycleOwner) { credential ->
             lifecycleScope.launch {
-                val defaultCredential = CredentialBootstrap.credential()
+                val defaultCredential = CredentialBootstrap.defaultCredential()
                 onBackPressedCallback.isEnabled = defaultCredential != credential
 
                 binding.credentialName.text = if (defaultCredential == credential) "Default" else "TokenExchange"

--- a/app/src/main/java/sample/okta/android/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/sample/okta/android/dashboard/DashboardViewModel.kt
@@ -52,11 +52,11 @@ internal class DashboardViewModel(private val credentialMetadataNameValue: Strin
     init {
         viewModelScope.launch {
             credential = if (credentialMetadataNameValue == null) {
-                CredentialBootstrap.credential()
+                CredentialBootstrap.defaultCredential()
             } else {
                 CredentialBootstrap.credentialDataSource.listCredentials().firstOrNull { credential ->
                     credential.metadata[SampleHelper.CREDENTIAL_NAME_METADATA_KEY] == credentialMetadataNameValue
-                } ?: CredentialBootstrap.credential()
+                } ?: CredentialBootstrap.defaultCredential()
             }
             setCredential(credential)
         }
@@ -118,7 +118,7 @@ internal class DashboardViewModel(private val credentialMetadataNameValue: Strin
     fun logoutOfWeb(context: Context) {
         viewModelScope.launch {
             val idToken = credential.token?.idToken ?: return@launch
-            when (val result = credential.oidcClient.createWebAuthenticationClient().logoutOfBrowser(context, idToken)) {
+            when (val result = CredentialBootstrap.oidcClient.createWebAuthenticationClient().logoutOfBrowser(context, idToken)) {
                 is OidcClientResult.Error -> {
                     Timber.e(result.exception, "Failed to start logout flow.")
                     _requestStateLiveData.value = RequestState.Result(result.exception.message ?: "An error occurred.")

--- a/app/src/main/java/sample/okta/android/deviceauthorization/DeviceAuthorizationViewModel.kt
+++ b/app/src/main/java/sample/okta/android/deviceauthorization/DeviceAuthorizationViewModel.kt
@@ -37,7 +37,7 @@ internal class DeviceAuthorizationViewModel : ViewModel() {
         _state.value = DeviceAuthorizationState.Loading
 
         viewModelScope.launch {
-            val deviceAuthorizationFlow = CredentialBootstrap.credential().oidcClient.createDeviceAuthorizationFlow()
+            val deviceAuthorizationFlow = CredentialBootstrap.oidcClient.createDeviceAuthorizationFlow()
             when (val result = deviceAuthorizationFlow.start()) {
                 is OidcClientResult.Error -> {
                     _state.value = DeviceAuthorizationState.Error(result.exception.message ?: "An error occurred.")
@@ -56,6 +56,7 @@ internal class DeviceAuthorizationViewModel : ViewModel() {
                 _state.value = DeviceAuthorizationState.Error(result.exception.message ?: "An error occurred.")
             }
             is OidcClientResult.Success -> {
+                CredentialBootstrap.defaultCredential().storeToken(token = result.result)
                 _state.value = DeviceAuthorizationState.Token
             }
         }

--- a/app/src/main/java/sample/okta/android/resourceowner/ResourceOwnerViewModel.kt
+++ b/app/src/main/java/sample/okta/android/resourceowner/ResourceOwnerViewModel.kt
@@ -32,12 +32,13 @@ internal class ResourceOwnerViewModel : ViewModel() {
         _state.value = ResourceOwnerState.Loading
 
         viewModelScope.launch {
-            val resourceOwnerFlow = CredentialBootstrap.credential().oidcClient.createResourceOwnerFlow()
+            val resourceOwnerFlow = CredentialBootstrap.oidcClient.createResourceOwnerFlow()
             when (val result = resourceOwnerFlow.start(username, password)) {
                 is OidcClientResult.Error -> {
                     _state.value = ResourceOwnerState.Error(result.exception.message ?: "An error occurred.")
                 }
                 is OidcClientResult.Success -> {
+                    CredentialBootstrap.defaultCredential().storeToken(token = result.result)
                     _state.value = ResourceOwnerState.Token
                 }
             }

--- a/app/src/main/java/sample/okta/android/tokenexchange/TokenExchangeViewModel.kt
+++ b/app/src/main/java/sample/okta/android/tokenexchange/TokenExchangeViewModel.kt
@@ -41,13 +41,13 @@ class TokenExchangeViewModel : ViewModel() {
         _state.value = TokenExchangeState.Loading
 
         viewModelScope.launch {
-            val credential = CredentialBootstrap.credential()
+            val credential = CredentialBootstrap.defaultCredential()
             val credentialDataSource = CredentialBootstrap.credentialDataSource
             val tokenExchangeCredential = credentialDataSource.listCredentials().firstOrNull { c ->
                 c.metadata[SampleHelper.CREDENTIAL_NAME_METADATA_KEY] == NAME_METADATA_VALUE
             } ?: credentialDataSource.createCredential()
             tokenExchangeCredential.storeToken(metadata = mapOf(Pair(SampleHelper.CREDENTIAL_NAME_METADATA_KEY, NAME_METADATA_VALUE)))
-            val tokenExchangeFlow = tokenExchangeCredential.oidcClient.createTokenExchangeFlow()
+            val tokenExchangeFlow = CredentialBootstrap.oidcClient.createTokenExchangeFlow()
             val idToken = credential.token?.idToken
             if (idToken == null) {
                 _state.value = TokenExchangeState.Error("Missing Id Token")
@@ -63,6 +63,7 @@ class TokenExchangeViewModel : ViewModel() {
                     _state.value = TokenExchangeState.Error(result.exception.message ?: "An error occurred.")
                 }
                 is OidcClientResult.Success -> {
+                    tokenExchangeCredential.storeToken(token = result.result)
                     _state.value = TokenExchangeState.Token(NAME_METADATA_VALUE)
                 }
             }

--- a/auth-foundation-bootstrap/src/main/java/com/okta/authfoundationbootstrap/CredentialBootstrap.kt
+++ b/auth-foundation-bootstrap/src/main/java/com/okta/authfoundationbootstrap/CredentialBootstrap.kt
@@ -15,6 +15,7 @@
  */
 package com.okta.authfoundationbootstrap
 
+import com.okta.authfoundation.client.OidcClient
 import com.okta.authfoundation.credential.Credential
 import com.okta.authfoundation.credential.CredentialDataSource
 import com.okta.authfoundation.util.CoalescingOrchestrator
@@ -47,6 +48,14 @@ object CredentialBootstrap {
         }
 
     /**
+     * The singleton [OidcClient].
+     */
+    val oidcClient: OidcClient
+        get() {
+            return credentialDataSource.oidcClient
+        }
+
+    /**
      * Initializes [CredentialBootstrap] with a [CredentialDataSource].
      *
      * @param credentialDataSource the [CredentialDataSource] to associate with [CredentialBootstrap] as a singleton.
@@ -57,8 +66,10 @@ object CredentialBootstrap {
 
     /**
      * The default [Credential] associated with the associated [CredentialDataSource].
+     *
+     * This will get the default [Credential] if one exists, or create the default [Credential] is there is not an existing one.
      */
-    suspend fun credential(): Credential {
+    suspend fun defaultCredential(): Credential {
         return credentialCoalescingOrchestrator.get()
     }
 

--- a/auth-foundation-bootstrap/src/test/java/com/okta/authfoundationbootstrap/CredentialBootstrapTest.kt
+++ b/auth-foundation-bootstrap/src/test/java/com/okta/authfoundationbootstrap/CredentialBootstrapTest.kt
@@ -41,7 +41,7 @@ class CredentialBootstrapTest {
 
     @Test fun testCredentialFailsBeforeInitialize(): Unit = runBlocking {
         val exception = assertFailsWith<IllegalStateException> {
-            CredentialBootstrap.credential()
+            CredentialBootstrap.defaultCredential()
         }
         assertThat(exception).hasMessageThat().isEqualTo("CredentialBoostrap not initialized. Please call initialize before attempting to access properties and methods.")
     }
@@ -54,8 +54,8 @@ class CredentialBootstrapTest {
 
     @Test fun testCredentialReturnsSameInstance(): Unit = runBlocking {
         initialize()
-        val credential1 = CredentialBootstrap.credential()
-        val credential2 = CredentialBootstrap.credential()
+        val credential1 = CredentialBootstrap.defaultCredential()
+        val credential2 = CredentialBootstrap.defaultCredential()
         assertThat(credential1).isNotNull()
         assertThat(credential1).isSameInstanceAs(credential2)
         assertThat(CredentialBootstrap.credentialDataSource.listCredentials()).hasSize(1)
@@ -68,9 +68,9 @@ class CredentialBootstrapTest {
 
     @Test fun testDeletedCredentialCreatesNewCredential(): Unit = runBlocking {
         initialize()
-        val credential1 = CredentialBootstrap.credential()
+        val credential1 = CredentialBootstrap.defaultCredential()
         credential1.delete()
-        val credential2 = CredentialBootstrap.credential()
+        val credential2 = CredentialBootstrap.defaultCredential()
         assertThat(credential1).isNotNull()
         assertThat(credential2).isNotNull()
         assertThat(credential1).isNotSameInstanceAs(credential2)
@@ -80,7 +80,7 @@ class CredentialBootstrapTest {
     @Test fun testCredentialOnlyReturnsDefaultCredential(): Unit = runBlocking {
         initialize()
         val credential1 = CredentialBootstrap.credentialDataSource.createCredential()
-        val credential2 = CredentialBootstrap.credential()
+        val credential2 = CredentialBootstrap.defaultCredential()
         assertThat(credential1).isNotNull()
         assertThat(credential2).isNotNull()
         assertThat(credential1).isNotSameInstanceAs(credential2)
@@ -89,8 +89,8 @@ class CredentialBootstrapTest {
 
     @Test fun testCredentialReturnsSameInstanceWhenAsync(): Unit = runBlocking {
         initialize()
-        val credential1 = async(Dispatchers.IO) { CredentialBootstrap.credential() }
-        val credential2 = async(Dispatchers.IO) { CredentialBootstrap.credential() }
+        val credential1 = async(Dispatchers.IO) { CredentialBootstrap.defaultCredential() }
+        val credential2 = async(Dispatchers.IO) { CredentialBootstrap.defaultCredential() }
         assertThat(credential1.await()).isNotNull()
         assertThat(credential1.await()).isSameInstanceAs(credential2.await())
         assertThat(CredentialBootstrap.credentialDataSource.listCredentials()).hasSize(1)

--- a/auth-foundation/src/main/java/com/okta/authfoundation/credential/Credential.kt
+++ b/auth-foundation/src/main/java/com/okta/authfoundation/credential/Credential.kt
@@ -15,6 +15,7 @@
  */
 package com.okta.authfoundation.credential
 
+import androidx.annotation.VisibleForTesting
 import com.okta.authfoundation.client.OidcClient
 import com.okta.authfoundation.client.OidcClientResult
 import com.okta.authfoundation.client.dto.OidcIntrospectInfo
@@ -53,10 +54,9 @@ class Credential internal constructor(
 
     /**
      * The [OidcClient] associated with this [Credential].
-     *
-     * This is the [OidcClient] that should be used for all other operations related to this [Credential].
      */
-    val oidcClient: OidcClient = oidcClient.withCredential(this)
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal val oidcClient: OidcClient = oidcClient.withCredential(this)
 
     /**
      * The current [Token] that's stored and associated with this [Credential].

--- a/auth-foundation/src/main/java/com/okta/authfoundation/credential/CredentialDataSource.kt
+++ b/auth-foundation/src/main/java/com/okta/authfoundation/credential/CredentialDataSource.kt
@@ -18,6 +18,7 @@ package com.okta.authfoundation.credential
 import android.content.Context
 import android.os.Build
 import androidx.annotation.RequiresApi
+import com.okta.authfoundation.InternalAuthFoundationApi
 import com.okta.authfoundation.client.OidcClient
 import com.okta.authfoundation.credential.events.CredentialCreatedEvent
 import com.okta.authfoundation.util.CoalescingOrchestrator
@@ -30,7 +31,7 @@ import java.util.UUID
  * This is intended to be held as a singleton, and used throughout the lifecycle of the application.
  */
 class CredentialDataSource internal constructor(
-    private val oidcClient: OidcClient,
+    @property:InternalAuthFoundationApi val oidcClient: OidcClient,
     private val storage: TokenStorage,
 ) {
     companion object {

--- a/legacy-token-migration-sample/src/main/java/sample/okta/android/legacy/browser/BrowserViewModel.kt
+++ b/legacy-token-migration-sample/src/main/java/sample/okta/android/legacy/browser/BrowserViewModel.kt
@@ -34,14 +34,14 @@ class BrowserViewModel : ViewModel() {
         viewModelScope.launch {
             _state.value = BrowserState.Loading
 
-            val credential = CredentialBootstrap.credential()
-            val webAuthenticationClient = credential.oidcClient.createWebAuthenticationClient()
+            val webAuthenticationClient = CredentialBootstrap.oidcClient.createWebAuthenticationClient()
             when (val result = webAuthenticationClient.login(context)) {
                 is OidcClientResult.Error -> {
                     Timber.e(result.exception, "Failed to login.")
                     _state.value = BrowserState.Error("Failed to login.")
                 }
                 is OidcClientResult.Success -> {
+                    CredentialBootstrap.defaultCredential().storeToken(token = result.result)
                     _state.value = BrowserState.Token
                 }
             }

--- a/legacy-token-migration-sample/src/main/java/sample/okta/android/legacy/dashboard/DashboardViewModel.kt
+++ b/legacy-token-migration-sample/src/main/java/sample/okta/android/legacy/dashboard/DashboardViewModel.kt
@@ -48,7 +48,7 @@ internal class DashboardViewModel : ViewModel() {
 
     init {
         viewModelScope.launch {
-            credential = CredentialBootstrap.credential()
+            credential = CredentialBootstrap.defaultCredential()
             _credentialLiveData.value = credential
             getUserInfo()
         }
@@ -84,7 +84,7 @@ internal class DashboardViewModel : ViewModel() {
     fun logoutOfWeb(context: Context) {
         viewModelScope.launch {
             val idToken = credential.token?.idToken ?: return@launch
-            when (val result = credential.oidcClient.createWebAuthenticationClient().logoutOfBrowser(context, idToken)) {
+            when (val result = CredentialBootstrap.oidcClient.createWebAuthenticationClient().logoutOfBrowser(context, idToken)) {
                 is OidcClientResult.Error -> {
                     Timber.e(result.exception, "Failed to start logout flow.")
                     _requestStateLiveData.value = RequestState.Result(result.exception.message ?: "An error occurred.")

--- a/legacy-token-migration-sample/src/main/java/sample/okta/android/legacy/launch/LaunchFragment.kt
+++ b/legacy-token-migration-sample/src/main/java/sample/okta/android/legacy/launch/LaunchFragment.kt
@@ -65,7 +65,7 @@ internal class LaunchFragment : BaseFragment<FragmentLaunchBinding>(
                     findNavController().navigate(LaunchFragmentDirections.launchToLegacyDashboard())
                 }
             }
-            if (CredentialBootstrap.credential().token != null) {
+            if (CredentialBootstrap.defaultCredential().token != null) {
                 binding.loggedInTextView.visibility = View.VISIBLE
                 binding.dashboardButton.visibility = View.VISIBLE
                 binding.dashboardButton.setOnClickListener {

--- a/legacy-token-migration-sample/src/main/java/sample/okta/android/legacy/launch/LaunchViewModel.kt
+++ b/legacy-token-migration-sample/src/main/java/sample/okta/android/legacy/launch/LaunchViewModel.kt
@@ -35,7 +35,7 @@ internal class LaunchViewModel : ViewModel() {
             when (val result = LegacyTokenMigration.migrate(
                 context = context,
                 sessionClient = SampleWebAuthClientHelper.webAuthClient.sessionClient,
-                credential = CredentialBootstrap.credential(),
+                credential = CredentialBootstrap.defaultCredential(),
             )) {
                 is LegacyTokenMigration.Result.Error -> {
                     Timber.d(result.exception, "Token migration failed.")

--- a/legacy-token-migration/src/main/java/com/okta/legacytokenmigration/LegacyTokenMigration.kt
+++ b/legacy-token-migration/src/main/java/com/okta/legacytokenmigration/LegacyTokenMigration.kt
@@ -21,6 +21,7 @@ import androidx.annotation.VisibleForTesting
 import com.okta.authfoundation.credential.Credential
 import com.okta.authfoundation.credential.Token
 import com.okta.oidc.clients.sessions.SessionClient
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 /**
@@ -44,7 +45,7 @@ object LegacyTokenMigration {
      * @return a [Result] with the outcome of the migration.
      */
     suspend fun migrate(context: Context, sessionClient: SessionClient, credential: Credential): Result {
-        return withContext(credential.oidcClient.configuration.computeDispatcher) {
+        return withContext(Dispatchers.IO) {
             val sharedPreferences = context.sharedPreferences()
             if (sharedPreferences.hasMarkedTokensAsMigrated()) {
                 return@withContext Result.PreviouslyMigrated

--- a/legacy-token-migration/src/test/java/com/okta/legacytokenmigration/LegacyTokenMigrationTest.kt
+++ b/legacy-token-migration/src/test/java/com/okta/legacytokenmigration/LegacyTokenMigrationTest.kt
@@ -55,9 +55,7 @@ class LegacyTokenMigrationTest {
     }
 
     private fun mockCredential(): Credential {
-        return mock {
-            on { oidcClient } doReturn oktaRule.createOidcClient()
-        }
+        return mock()
     }
 
     private fun mockSessionClient(token: Tokens?): SessionClient {

--- a/migrate.md
+++ b/migrate.md
@@ -30,7 +30,7 @@ import com.okta.oidc.clients.sessions.SessionClient
 
 val context: Context = TODO("Supplied by the developer.")
 val sessionClient: SessionClient = TODO("Supplied by the developer.")
-val credential: Credential = CredentialBootstrap.credential()
+val credential: Credential = CredentialBootstrap.defaultCredential()
 
 when (val result = LegacyTokenMigration.migrate(context, sessionClient, credential)) {
     is LegacyTokenMigration.Result.Error -> TODO("An error occurred: ${result.exception}")


### PR DESCRIPTION
- Credential.oidcClient is now an implementation detail, and not publicly accessible.
- Minting tokens no longer automatically stores tokens, it's now an explicit action.
- Renamed CredentialBootstrap.credential to CredentialBootstrap.defaultCredential.
- Added CredentialBootstrap.oidcClient to preserve ease of use.