### PR TITLE
OKTA-467673 Use correct version in user agent, as well as include each SDK used.

### DIFF
--- a/auth-foundation/api/auth-foundation.api
+++ b/auth-foundation/api/auth-foundation.api
@@ -179,6 +179,11 @@ public final class com/okta/authfoundation/client/internal/NetworkUtilsKt {
 	public static synthetic fun performRequest$default (Lcom/okta/authfoundation/client/OidcClient;Lkotlinx/serialization/DeserializationStrategy;Lokhttp3/Request;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
+public final class com/okta/authfoundation/client/internal/SdkVersionsRegistry {
+	public static final field INSTANCE Lcom/okta/authfoundation/client/internal/SdkVersionsRegistry;
+	public final fun register (Ljava/lang/String;)V
+}
+
 public final class com/okta/authfoundation/credential/Credential {
 	public final fun accessTokenInterceptor ()Lokhttp3/Interceptor;
 	public final fun delete (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/auth-foundation/build.gradle
+++ b/auth-foundation/build.gradle
@@ -34,6 +34,12 @@ android {
     buildFeatures {
         buildConfig = false
     }
+
+    sourceSets {
+        main {
+            kotlin.srcDir("$buildDir/generated/sources/kotlinTemplates")
+        }
+    }
 }
 
 dependencies {
@@ -51,6 +57,7 @@ dependencies {
     testImplementation deps.kotlin.test
     testImplementation deps.mockito.core
     testImplementation deps.mockito.kotlin
+    testImplementation deps.robolectric
     testImplementation project(':test-helpers')
 
     androidTestImplementation deps.junit
@@ -61,6 +68,16 @@ dependencies {
     androidTestImplementation deps.androidx_test.runner
     androidTestImplementation deps.androidx_test.rules
     androidTestImplementation project(':test-helpers')
+}
+
+task copyKotlinTemplates(type: Copy) {
+    from("src/main/kotlinTemplates")
+    into("$buildDir/generated/sources/kotlinTemplates")
+    expand(projectVersion: project.version)
+}
+
+tasks.withType(org.jetbrains.kotlin.gradle.dsl.KotlinCompile) {
+    dependsOn(copyKotlinTemplates)
 }
 
 mavenPublishing {

--- a/auth-foundation/src/main/java/com/okta/authfoundation/client/OidcConfiguration.kt
+++ b/auth-foundation/src/main/java/com/okta/authfoundation/client/OidcConfiguration.kt
@@ -17,6 +17,7 @@ package com.okta.authfoundation.client
 
 import com.okta.authfoundation.AuthFoundationDefaults
 import com.okta.authfoundation.InternalAuthFoundationApi
+import com.okta.authfoundation.client.internal.SdkVersionsRegistry
 import com.okta.authfoundation.events.EventCoordinator
 import kotlinx.coroutines.Dispatchers
 import kotlinx.serialization.json.Json
@@ -85,7 +86,7 @@ class OidcConfiguration(
 private object OidcUserAgentInterceptor : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request().newBuilder()
-            .header("user-agent", "okta-oidc-kotlin/1.0.0")
+            .header("user-agent", SdkVersionsRegistry.userAgent)
             .build()
 
         return chain.proceed(request)

--- a/auth-foundation/src/main/java/com/okta/authfoundation/client/internal/SdkVersionsRegistry.kt
+++ b/auth-foundation/src/main/java/com/okta/authfoundation/client/internal/SdkVersionsRegistry.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.client.internal
+
+import android.os.Build
+import com.okta.authfoundation.InternalAuthFoundationApi
+import java.util.Collections
+
+@InternalAuthFoundationApi
+object SdkVersionsRegistry {
+    private val sdkVersions: MutableSet<String> = Collections.synchronizedSet(mutableSetOf<String>())
+
+    @Volatile internal var userAgent: String = ""
+        private set
+
+    init {
+        reset()
+    }
+
+    fun register(sdkVersion: String) {
+        if (sdkVersions.add(sdkVersion)) {
+            regenerateUserAgent()
+        }
+    }
+
+    private fun regenerateUserAgent() {
+        userAgent = "${sdkVersions.sorted().joinToString(separator = " ")} Android/${Build.VERSION.SDK_INT}"
+    }
+
+    internal fun reset() {
+        sdkVersions.clear()
+        sdkVersions.add(SDK_VERSION)
+        regenerateUserAgent()
+    }
+}

--- a/auth-foundation/src/main/kotlinTemplates/com/okta/authfoundation/client/internal/-InternalVersion.kt
+++ b/auth-foundation/src/main/kotlinTemplates/com/okta/authfoundation/client/internal/-InternalVersion.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.client.internal
+
+internal const val SDK_VERSION = "okta-auth-foundation-kotlin/$projectVersion"

--- a/auth-foundation/src/test/java/com/okta/authfoundation/client/internal/SdkVersionsRegistryTest.kt
+++ b/auth-foundation/src/test/java/com/okta/authfoundation/client/internal/SdkVersionsRegistryTest.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.client.internal
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class SdkVersionsRegistryTest {
+    private val defaultAndroidVersion = 16
+
+    @Before fun reset() {
+        SdkVersionsRegistry.reset()
+    }
+
+    @Test fun testUserAgentWithNoOtherVersionsRegistered() {
+        assertThat(SdkVersionsRegistry.userAgent).matches("okta-auth-foundation-kotlin/.* Android/$defaultAndroidVersion")
+    }
+
+    @Test fun testRegisterRegeneratesUserAgent() {
+        SdkVersionsRegistry.register("atest/1.0.0")
+        assertThat(SdkVersionsRegistry.userAgent).matches("atest/1.0.0 okta-auth-foundation-kotlin/.* Android/$defaultAndroidVersion")
+    }
+
+    @Test fun testRegisterRegeneratesUserAgentSorted() {
+        SdkVersionsRegistry.register("ztest/1.0.0")
+        assertThat(SdkVersionsRegistry.userAgent).matches("okta-auth-foundation-kotlin/.* ztest/1.0.0 Android/$defaultAndroidVersion")
+    }
+
+    @Test fun testRegisterCanBeCalledMultipleTimes() {
+        val testVersion = "test/1.0.0"
+        SdkVersionsRegistry.register(testVersion)
+        SdkVersionsRegistry.register(testVersion)
+        val userAgent = SdkVersionsRegistry.userAgent
+        val occurrences = userAgent.windowed(testVersion.length) {
+            if (it == testVersion)
+                1
+            else
+                0
+        }.sum()
+        assertThat(occurrences).isEqualTo(1)
+    }
+}

--- a/oauth2/build.gradle
+++ b/oauth2/build.gradle
@@ -32,6 +32,12 @@ android {
     buildFeatures {
         buildConfig = false
     }
+
+    sourceSets {
+        main {
+            kotlin.srcDir("$buildDir/generated/sources/kotlinTemplates")
+        }
+    }
 }
 
 dependencies {
@@ -48,6 +54,16 @@ dependencies {
     testImplementation deps.kotlin.test
     testImplementation deps.robolectric
     testImplementation project(':test-helpers')
+}
+
+task copyKotlinTemplates(type: Copy) {
+    from("src/main/kotlinTemplates")
+    into("$buildDir/generated/sources/kotlinTemplates")
+    expand(projectVersion: project.version)
+}
+
+tasks.withType(org.jetbrains.kotlin.gradle.dsl.KotlinCompile) {
+    dependsOn(copyKotlinTemplates)
 }
 
 mavenPublishing {

--- a/oauth2/src/main/java/com/okta/oauth2/AuthorizationCodeFlow.kt
+++ b/oauth2/src/main/java/com/okta/oauth2/AuthorizationCodeFlow.kt
@@ -19,6 +19,7 @@ import android.net.Uri
 import com.okta.authfoundation.client.OidcClient
 import com.okta.authfoundation.client.OidcClientResult
 import com.okta.authfoundation.client.OidcConfiguration
+import com.okta.authfoundation.client.internal.SdkVersionsRegistry
 import com.okta.authfoundation.credential.Token
 import okhttp3.FormBody
 import okhttp3.HttpUrl
@@ -34,6 +35,10 @@ class AuthorizationCodeFlow private constructor(
     private val oidcClient: OidcClient,
 ) {
     companion object {
+        init {
+            SdkVersionsRegistry.register(SDK_VERSION)
+        }
+
         /**
          * Initializes an authorization code flow using the [OidcClient].
          *

--- a/oauth2/src/main/java/com/okta/oauth2/DeviceAuthorizationFlow.kt
+++ b/oauth2/src/main/java/com/okta/oauth2/DeviceAuthorizationFlow.kt
@@ -18,6 +18,7 @@ package com.okta.oauth2
 import com.okta.authfoundation.client.OidcClient
 import com.okta.authfoundation.client.OidcClientResult
 import com.okta.authfoundation.client.OidcConfiguration
+import com.okta.authfoundation.client.internal.SdkVersionsRegistry
 import com.okta.authfoundation.client.internal.performRequest
 import com.okta.authfoundation.credential.Token
 import kotlinx.coroutines.delay
@@ -39,6 +40,10 @@ class DeviceAuthorizationFlow private constructor(
     private val oidcClient: OidcClient,
 ) {
     companion object {
+        init {
+            SdkVersionsRegistry.register(SDK_VERSION)
+        }
+
         /**
          * Initializes a device authorization grant flow using the [OidcClient].
          *

--- a/oauth2/src/main/java/com/okta/oauth2/RedirectEndSessionFlow.kt
+++ b/oauth2/src/main/java/com/okta/oauth2/RedirectEndSessionFlow.kt
@@ -18,6 +18,7 @@ package com.okta.oauth2
 import android.net.Uri
 import com.okta.authfoundation.client.OidcClient
 import com.okta.authfoundation.client.OidcClientResult
+import com.okta.authfoundation.client.internal.SdkVersionsRegistry
 import okhttp3.HttpUrl
 import java.util.UUID
 
@@ -30,6 +31,10 @@ class RedirectEndSessionFlow private constructor(
     private val oidcClient: OidcClient,
 ) {
     companion object {
+        init {
+            SdkVersionsRegistry.register(SDK_VERSION)
+        }
+
         /**
          * Initializes an end session redirect flow using the [OidcClient].
          *

--- a/oauth2/src/main/java/com/okta/oauth2/ResourceOwnerFlow.kt
+++ b/oauth2/src/main/java/com/okta/oauth2/ResourceOwnerFlow.kt
@@ -18,6 +18,7 @@ package com.okta.oauth2
 import com.okta.authfoundation.client.OidcClient
 import com.okta.authfoundation.client.OidcClientResult
 import com.okta.authfoundation.client.OidcConfiguration
+import com.okta.authfoundation.client.internal.SdkVersionsRegistry
 import com.okta.authfoundation.credential.Token
 import okhttp3.FormBody
 import okhttp3.Request
@@ -33,6 +34,10 @@ class ResourceOwnerFlow private constructor(
     private val oidcClient: OidcClient,
 ) {
     companion object {
+        init {
+            SdkVersionsRegistry.register(SDK_VERSION)
+        }
+
         /**
          * Initializes a resource owner flow using the [OidcClient].
          *

--- a/oauth2/src/main/java/com/okta/oauth2/TokenExchangeFlow.kt
+++ b/oauth2/src/main/java/com/okta/oauth2/TokenExchangeFlow.kt
@@ -18,6 +18,7 @@ package com.okta.oauth2
 import com.okta.authfoundation.client.OidcClient
 import com.okta.authfoundation.client.OidcClientResult
 import com.okta.authfoundation.client.OidcConfiguration
+import com.okta.authfoundation.client.internal.SdkVersionsRegistry
 import com.okta.authfoundation.credential.Token
 import okhttp3.FormBody
 import okhttp3.Request
@@ -33,6 +34,10 @@ class TokenExchangeFlow private constructor(
     private val oidcClient: OidcClient,
 ) {
     companion object {
+        init {
+            SdkVersionsRegistry.register(SDK_VERSION)
+        }
+
         /**
          * Initializes a token exchange flow using the [OidcClient].
          *

--- a/oauth2/src/main/kotlinTemplates/com/okta/oauth2/-InternalVersion.kt
+++ b/oauth2/src/main/kotlinTemplates/com/okta/oauth2/-InternalVersion.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2
+
+internal const val SDK_VERSION = "okta-oauth2-kotlin$projectVersion"

--- a/web-authentication-ui/build.gradle
+++ b/web-authentication-ui/build.gradle
@@ -46,6 +46,12 @@ android {
             includeAndroidResources = true
         }
     }
+
+    sourceSets {
+        main {
+            kotlin.srcDir("$buildDir/generated/sources/kotlinTemplates")
+        }
+    }
 }
 
 dependencies {
@@ -70,6 +76,16 @@ dependencies {
     testImplementation deps.mockito.core
     testImplementation deps.mockito.kotlin
     testImplementation project(':test-helpers')
+}
+
+task copyKotlinTemplates(type: Copy) {
+    from("src/main/kotlinTemplates")
+    into("$buildDir/generated/sources/kotlinTemplates")
+    expand(projectVersion: project.version)
+}
+
+tasks.withType(org.jetbrains.kotlin.gradle.dsl.KotlinCompile) {
+    dependsOn(copyKotlinTemplates)
 }
 
 mavenPublishing {

--- a/web-authentication-ui/src/main/java/com/okta/webauthenticationui/WebAuthenticationClient.kt
+++ b/web-authentication-ui/src/main/java/com/okta/webauthenticationui/WebAuthenticationClient.kt
@@ -21,6 +21,7 @@ import androidx.annotation.VisibleForTesting
 import com.okta.authfoundation.client.OidcClient
 import com.okta.authfoundation.client.OidcClientResult
 import com.okta.authfoundation.client.OidcConfiguration
+import com.okta.authfoundation.client.internal.SdkVersionsRegistry
 import com.okta.authfoundation.credential.Token
 import com.okta.oauth2.AuthorizationCodeFlow
 import com.okta.oauth2.AuthorizationCodeFlow.Companion.createAuthorizationCodeFlow
@@ -40,6 +41,10 @@ class WebAuthenticationClient private constructor(
     private val webAuthenticationProvider: WebAuthenticationProvider,
 ) {
     companion object {
+        init {
+            SdkVersionsRegistry.register(SDK_VERSION)
+        }
+
         /**
          * Initializes a web authentication client using the [OidcClient].
          *

--- a/web-authentication-ui/src/main/kotlinTemplates/com/okta/webauthenticationui/-InternalVersion.kt
+++ b/web-authentication-ui/src/main/kotlinTemplates/com/okta/webauthenticationui/-InternalVersion.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.webauthenticationui
+
+internal const val SDK_VERSION = "okta-web-authentication-ui-kotlin/$projectVersion"


### PR DESCRIPTION
Note this won't include oauth2 in the user agent until it's used. So if a user only refreshes tokens via auth-foundation, we won't see oauth2 in the user agent.