### PR TITLE
Accept redirects in onCreate.

### DIFF
--- a/web-authentication-ui/src/main/java/com/okta/webauthenticationui/ForegroundActivity.kt
+++ b/web-authentication-ui/src/main/java/com/okta/webauthenticationui/ForegroundActivity.kt
@@ -45,6 +45,8 @@ internal class ForegroundActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        handleRedirectIfAvailable(intent)
+
         viewModel.stateLiveData.observe(this) { state ->
             when (state) {
                 ForegroundViewModel.State.Error -> {


### PR DESCRIPTION
Some browsers (duck duck go) make it so we get the intent in onCreate.
Different implementations of WebAuthenticationProvider would also potentially affect this.