### PR TITLE
Make most of OidcConfiguration internal.

### DIFF
--- a/auth-foundation/api/auth-foundation.api
+++ b/auth-foundation/api/auth-foundation.api
@@ -2,15 +2,19 @@ public final class com/okta/authfoundation/AuthFoundationDefaults {
 	public static final field INSTANCE Lcom/okta/authfoundation/AuthFoundationDefaults;
 	public final fun getAccessTokenValidator ()Lcom/okta/authfoundation/client/AccessTokenValidator;
 	public final fun getClock ()Lcom/okta/authfoundation/client/OidcClock;
+	public final fun getComputeDispatcher ()Lkotlin/coroutines/CoroutineContext;
 	public final fun getDeviceSecretValidator ()Lcom/okta/authfoundation/client/DeviceSecretValidator;
 	public final fun getEventCoordinator ()Lcom/okta/authfoundation/events/EventCoordinator;
 	public final fun getIdTokenValidator ()Lcom/okta/authfoundation/client/IdTokenValidator;
+	public final fun getIoDispatcher ()Lkotlin/coroutines/CoroutineContext;
 	public final fun getOkHttpClientFactory ()Lkotlin/jvm/functions/Function0;
 	public final fun setAccessTokenValidator (Lcom/okta/authfoundation/client/AccessTokenValidator;)V
 	public final fun setClock (Lcom/okta/authfoundation/client/OidcClock;)V
+	public final fun setComputeDispatcher (Lkotlin/coroutines/CoroutineContext;)V
 	public final fun setDeviceSecretValidator (Lcom/okta/authfoundation/client/DeviceSecretValidator;)V
 	public final fun setEventCoordinator (Lcom/okta/authfoundation/events/EventCoordinator;)V
 	public final fun setIdTokenValidator (Lcom/okta/authfoundation/client/IdTokenValidator;)V
+	public final fun setIoDispatcher (Lkotlin/coroutines/CoroutineContext;)V
 	public final fun setOkHttpClientFactory (Lkotlin/jvm/functions/Function0;)V
 }
 
@@ -120,8 +124,8 @@ public abstract interface class com/okta/authfoundation/client/OidcClock {
 }
 
 public final class com/okta/authfoundation/client/OidcConfiguration {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Lcom/okta/authfoundation/client/OidcClock;Lcom/okta/authfoundation/events/EventCoordinator;Lcom/okta/authfoundation/client/IdTokenValidator;Lcom/okta/authfoundation/client/AccessTokenValidator;Lcom/okta/authfoundation/client/DeviceSecretValidator;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Lcom/okta/authfoundation/client/OidcClock;Lcom/okta/authfoundation/events/EventCoordinator;Lcom/okta/authfoundation/client/IdTokenValidator;Lcom/okta/authfoundation/client/AccessTokenValidator;Lcom/okta/authfoundation/client/DeviceSecretValidator;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAccessTokenValidator ()Lcom/okta/authfoundation/client/AccessTokenValidator;
 	public final fun getClientId ()Ljava/lang/String;
 	public final fun getClock ()Lcom/okta/authfoundation/client/OidcClock;

--- a/auth-foundation/src/main/java/com/okta/authfoundation/AuthFoundationDefaults.kt
+++ b/auth-foundation/src/main/java/com/okta/authfoundation/AuthFoundationDefaults.kt
@@ -23,9 +23,11 @@ import com.okta.authfoundation.client.DeviceSecretValidator
 import com.okta.authfoundation.client.IdTokenValidator
 import com.okta.authfoundation.client.OidcClock
 import com.okta.authfoundation.events.EventCoordinator
+import kotlinx.coroutines.Dispatchers
 import okhttp3.Call
 import okhttp3.OkHttpClient
 import java.time.Instant
+import kotlin.coroutines.CoroutineContext
 
 /**
  *  The defaults used in various classes throughout the rest of the SDK.
@@ -37,6 +39,12 @@ import java.time.Instant
 object AuthFoundationDefaults {
     /** The default Call.Factory. */
     var okHttpClientFactory: () -> Call.Factory by NoSetAfterGetWithLazyDefaultFactory { { OkHttpClient() } }
+
+    /** The CoroutineDispatcher which should be used for IO bound tasks. */
+    var ioDispatcher: CoroutineContext by NoSetAfterGetWithLazyDefaultFactory { Dispatchers.IO }
+
+    /** The CoroutineDispatcher which should be used for compute bound tasks. */
+    var computeDispatcher: CoroutineContext by NoSetAfterGetWithLazyDefaultFactory { Dispatchers.Default }
 
     /** The default EventCoordinator. */
     var eventCoordinator: EventCoordinator by NoSetAfterGetWithLazyDefaultFactory { EventCoordinator(emptyList()) }

--- a/auth-foundation/src/main/java/com/okta/authfoundation/client/OidcConfiguration.kt
+++ b/auth-foundation/src/main/java/com/okta/authfoundation/client/OidcConfiguration.kt
@@ -19,7 +19,6 @@ import com.okta.authfoundation.AuthFoundationDefaults
 import com.okta.authfoundation.InternalAuthFoundationApi
 import com.okta.authfoundation.client.internal.SdkVersionsRegistry
 import com.okta.authfoundation.events.EventCoordinator
-import kotlinx.coroutines.Dispatchers
 import kotlinx.serialization.json.Json
 import okhttp3.Call
 import okhttp3.Interceptor
@@ -32,39 +31,61 @@ import kotlin.coroutines.CoroutineContext
  *
  * This class is used to define the configuration, as defined in your Okta application settings, that will be used to interact with the OIDC Authorization Server.
  */
-class OidcConfiguration(
+class OidcConfiguration @InternalAuthFoundationApi constructor(
     /** The application's client ID. */
-    val clientId: String,
+    @property:InternalAuthFoundationApi val clientId: String,
 
     /** The default access scopes required by the client, can be overridden when logging in. */
-    val defaultScope: String,
+    @property:InternalAuthFoundationApi val defaultScope: String,
 
     /** The Call.Factory which makes calls to the okta server. */
-    okHttpClientFactory: () -> Call.Factory = AuthFoundationDefaults.okHttpClientFactory,
+    okHttpClientFactory: () -> Call.Factory,
 
     /** The CoroutineDispatcher which should be used for IO bound tasks. */
-    val ioDispatcher: CoroutineContext = Dispatchers.IO,
+    @property:InternalAuthFoundationApi val ioDispatcher: CoroutineContext,
 
     /** The CoroutineDispatcher which should be used for compute bound tasks. */
-    val computeDispatcher: CoroutineContext = Dispatchers.Default,
+    @property:InternalAuthFoundationApi val computeDispatcher: CoroutineContext,
 
     /** The OidcClock which is used for all time related functions in the SDK. */
-    val clock: OidcClock = AuthFoundationDefaults.clock,
+    @property:InternalAuthFoundationApi val clock: OidcClock,
 
     /** The EventCoordinator which the OidcClient should emit events to. */
-    val eventCoordinator: EventCoordinator = AuthFoundationDefaults.eventCoordinator,
+    @property:InternalAuthFoundationApi val eventCoordinator: EventCoordinator,
 
     /** The IdTokenValidator used to validate the Id Token Jwt when tokens are minted. */
-    val idTokenValidator: IdTokenValidator = AuthFoundationDefaults.idTokenValidator,
+    @property:InternalAuthFoundationApi val idTokenValidator: IdTokenValidator,
 
     /** The AccessTokenValidator used to validate the Access Token when tokens are minted. */
-    val accessTokenValidator: AccessTokenValidator = AuthFoundationDefaults.accessTokenValidator,
+    @property:InternalAuthFoundationApi val accessTokenValidator: AccessTokenValidator,
 
     /** The DeviceSecretValidator used to validate the device secret when tokens are minted. */
-    val deviceSecretValidator: DeviceSecretValidator = AuthFoundationDefaults.deviceSecretValidator,
+    @property:InternalAuthFoundationApi
+    val deviceSecretValidator: DeviceSecretValidator,
 ) {
+    /**
+     * Used to create an OidcConfiguration.
+     */
+    constructor(
+        /** The application's client ID. */
+        clientId: String,
+        /** The default access scopes required by the client, can be overridden when logging in. */
+        defaultScope: String,
+    ) : this(
+        clientId = clientId,
+        defaultScope = defaultScope,
+        okHttpClientFactory = AuthFoundationDefaults.okHttpClientFactory,
+        ioDispatcher = AuthFoundationDefaults.ioDispatcher,
+        computeDispatcher = AuthFoundationDefaults.computeDispatcher,
+        clock = AuthFoundationDefaults.clock,
+        eventCoordinator = AuthFoundationDefaults.eventCoordinator,
+        idTokenValidator = AuthFoundationDefaults.idTokenValidator,
+        accessTokenValidator = AuthFoundationDefaults.accessTokenValidator,
+        deviceSecretValidator = AuthFoundationDefaults.deviceSecretValidator
+    )
+
     /** The Call.Factory which makes calls to the okta server. */
-    val okHttpClient: Call.Factory by lazy {
+    @property:InternalAuthFoundationApi val okHttpClient: Call.Factory by lazy {
         addInterceptor(okHttpClientFactory())
     }
 

--- a/auth-foundation/src/test/java/com/okta/authfoundation/client/NetworkUtilsTest.kt
+++ b/auth-foundation/src/test/java/com/okta/authfoundation/client/NetworkUtilsTest.kt
@@ -213,15 +213,9 @@ class NetworkingTest {
 
     @Test fun testPerformRequestHasNoTagWithNoCredential(): Unit = runBlocking {
         val interceptor = RecordingInterceptor()
-        val configuration = OidcConfiguration(
-            clientId = "unit_test_client_id",
-            defaultScope = "openid email profile offline_access",
-            okHttpClientFactory = {
-                val builder = oktaRule.okHttpClient.newBuilder()
-                builder.addInterceptor(interceptor)
-                builder.build()
-            }
-        )
+        val builder = oktaRule.okHttpClient.newBuilder()
+        builder.addInterceptor(interceptor)
+        val configuration = oktaRule.createConfiguration(builder.build())
         val oidcClient = OidcClient.create(configuration, oktaRule.createEndpoints())
         oktaRule.enqueue(
             path("/test"),
@@ -242,15 +236,9 @@ class NetworkingTest {
 
     @Test fun testPerformRequestHasTagWhenCredentialIsAttachedToOidcClient(): Unit = runBlocking {
         val interceptor = RecordingInterceptor()
-        val configuration = OidcConfiguration(
-            clientId = "unit_test_client_id",
-            defaultScope = "openid email profile offline_access",
-            okHttpClientFactory = {
-                val builder = oktaRule.okHttpClient.newBuilder()
-                builder.addInterceptor(interceptor)
-                builder.build()
-            }
-        )
+        val builder = oktaRule.okHttpClient.newBuilder()
+        builder.addInterceptor(interceptor)
+        val configuration = oktaRule.createConfiguration(builder.build())
         val credential = mock<Credential>()
         val oidcClient = OidcClient.create(configuration, oktaRule.createEndpoints())
             .withCredential(credential)

--- a/test-helpers/build.gradle
+++ b/test-helpers/build.gradle
@@ -24,6 +24,7 @@ android {
     }
     kotlinOptions {
         jvmTarget = '1.8'
+        freeCompilerArgs += ["-Xopt-in=kotlin.RequiresOptIn"]
     }
 }
 

--- a/test-helpers/src/main/java/com/okta/testhelpers/OktaRule.kt
+++ b/test-helpers/src/main/java/com/okta/testhelpers/OktaRule.kt
@@ -15,6 +15,7 @@
  */
 package com.okta.testhelpers
 
+import com.okta.authfoundation.InternalAuthFoundationApi
 import com.okta.authfoundation.client.AccessTokenValidator
 import com.okta.authfoundation.client.DeviceSecretValidator
 import com.okta.authfoundation.client.IdTokenValidator
@@ -30,10 +31,11 @@ import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
 
+@OptIn(InternalAuthFoundationApi::class)
 class OktaRule(
-    idTokenValidator: IdTokenValidator = IdTokenValidator { _, _, _, _ -> },
-    accessTokenValidator: AccessTokenValidator = AccessTokenValidator { _, _, _ -> },
-    deviceSecretValidator: DeviceSecretValidator = DeviceSecretValidator { _, _, _ -> },
+    private val idTokenValidator: IdTokenValidator = IdTokenValidator { _, _, _, _ -> },
+    private val accessTokenValidator: AccessTokenValidator = AccessTokenValidator { _, _, _ -> },
+    private val deviceSecretValidator: DeviceSecretValidator = DeviceSecretValidator { _, _, _ -> },
 ) : TestRule {
     private val mockWebServer: OktaMockWebServer = OktaMockWebServer()
 
@@ -45,7 +47,11 @@ class OktaRule(
     val eventHandler: RecordingEventHandler = RecordingEventHandler()
     val clock: TestClock = TestClock()
 
-    val configuration: OidcConfiguration = OidcConfiguration(
+    val configuration: OidcConfiguration = createConfiguration()
+
+    fun createConfiguration(
+        okHttpClient: OkHttpClient = this.okHttpClient
+    ) = OidcConfiguration(
         clientId = "unit_test_client_id",
         defaultScope = "openid email profile offline_access",
         okHttpClientFactory = { okHttpClient },


### PR DESCRIPTION
This simplifies options for developers integrating.