### PR TITLE
Listen for config changes in Foreground Activity.

### DIFF
--- a/web-authentication-ui/src/main/AndroidManifest.xml
+++ b/web-authentication-ui/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         <activity
             android:name=".ForegroundActivity"
             android:autoRemoveFromRecents="true"
+            android:configChanges="orientation|keyboard|keyboardHidden|screenLayout|screenSize|smallestScreenSize"
             android:launchMode="singleTop"
             android:theme="@style/NoAnimationTheme" />
 


### PR DESCRIPTION
This fixes a bug in Android 12 (API 31) which occurs when the host Activity (MainActivity) has a fixed orientation (landscape), but the Chrome Custom Tabs opens in portrait.

Since we don't have anything related to these config changes in our activities, it's safe to not recreate our activity when these happen.