### PR TITLE
Remove the default on revoke.

### DIFF
--- a/auth-foundation/api/auth-foundation.api
+++ b/auth-foundation/api/auth-foundation.api
@@ -204,7 +204,6 @@ public final class com/okta/authfoundation/credential/Credential {
 	public final fun introspectToken (Lcom/okta/authfoundation/credential/TokenType;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun refreshToken (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun revokeToken (Lcom/okta/authfoundation/credential/RevokeTokenType;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun revokeToken$default (Lcom/okta/authfoundation/credential/Credential;Lcom/okta/authfoundation/credential/RevokeTokenType;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun scope ()Ljava/lang/String;
 	public final fun storeToken (Lcom/okta/authfoundation/credential/Token;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun storeToken$default (Lcom/okta/authfoundation/credential/Credential;Lcom/okta/authfoundation/credential/Token;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;

--- a/auth-foundation/src/main/java/com/okta/authfoundation/credential/Credential.kt
+++ b/auth-foundation/src/main/java/com/okta/authfoundation/credential/Credential.kt
@@ -175,10 +175,10 @@ class Credential internal constructor(
      *
      * > Note: OIDC Logout terminology is nuanced, see [Logout Documentation](https://github.com/okta/okta-mobile-kotlin#logout) for additional details.
      *
-     * @param tokenType the [TokenType] to revoke, defaults to [RevokeTokenType.ACCESS_TOKEN].
+     * @param tokenType the [TokenType] to revoke.
      */
     suspend fun revokeToken(
-        tokenType: RevokeTokenType = RevokeTokenType.ACCESS_TOKEN
+        tokenType: RevokeTokenType
     ): OidcClientResult<Unit> {
         val localToken = token ?: return OidcClientResult.Error(IllegalStateException("No token."))
         val token = when (tokenType) {

--- a/auth-foundation/src/main/java/com/okta/authfoundation/credential/RevokeTokenType.kt
+++ b/auth-foundation/src/main/java/com/okta/authfoundation/credential/RevokeTokenType.kt
@@ -17,6 +17,8 @@ package com.okta.authfoundation.credential
 
 /**
  * The possible token types that can be revoked.
+ *
+ * See [Logout Documentation](https://github.com/okta/okta-mobile-kotlin#logout) for additional details.
  */
 enum class RevokeTokenType {
     /**

--- a/auth-foundation/src/test/java/com/okta/authfoundation/credential/CredentialTest.kt
+++ b/auth-foundation/src/test/java/com/okta/authfoundation/credential/CredentialTest.kt
@@ -158,7 +158,7 @@ class CredentialTest {
 
     @Test fun testRevokeTokenWithNullTokenReturnsError(): Unit = runBlocking {
         val credential = oktaRule.createCredential()
-        val result = credential.revokeToken()
+        val result = credential.revokeToken(RevokeTokenType.ACCESS_TOKEN)
         assertThat(result).isInstanceOf(OidcClientResult.Error::class.java)
         val errorResult = result as OidcClientResult.Error<Unit>
         assertThat(errorResult.exception).hasMessageThat().isEqualTo("No token.")


### PR DESCRIPTION
This can be confusing as to what it's removing. Being explicit here seems like the right thing to do.