### PR TITLE
Add a type for Id Token Validation Parameters.

### DIFF
--- a/auth-foundation/api/auth-foundation.api
+++ b/auth-foundation/api/auth-foundation.api
@@ -79,11 +79,16 @@ public final class com/okta/authfoundation/client/DeviceSecretValidator$Error : 
 }
 
 public abstract interface class com/okta/authfoundation/client/IdTokenValidator {
-	public abstract fun validate (Lcom/okta/authfoundation/client/OidcClient;Lcom/okta/authfoundation/jwt/Jwt;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun validate (Lcom/okta/authfoundation/client/OidcClient;Lcom/okta/authfoundation/jwt/Jwt;Lcom/okta/authfoundation/client/IdTokenValidator$Parameters;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class com/okta/authfoundation/client/IdTokenValidator$Error : java/lang/IllegalStateException {
 	public fun <init> (Ljava/lang/String;)V
+}
+
+public final class com/okta/authfoundation/client/IdTokenValidator$Parameters {
+	public final fun getMaxAge ()Ljava/lang/Integer;
+	public final fun getNonce ()Ljava/lang/String;
 }
 
 public final class com/okta/authfoundation/client/OidcClient {

--- a/auth-foundation/src/main/java/com/okta/authfoundation/client/TokenValidator.kt
+++ b/auth-foundation/src/main/java/com/okta/authfoundation/client/TokenValidator.kt
@@ -35,8 +35,10 @@ internal class TokenValidator(
             oidcClient.configuration.idTokenValidator.validate(
                 oidcClient = oidcClient,
                 idToken = idToken,
-                nonce = nonce,
-                maxAge = maxAge,
+                parameters = IdTokenValidator.Parameters(
+                    nonce = nonce,
+                    maxAge = maxAge,
+                ),
             )
 
             if (jwksResult != null) {

--- a/auth-foundation/src/test/java/com/okta/authfoundation/client/DefaultIdTokenValidatorTest.kt
+++ b/auth-foundation/src/test/java/com/okta/authfoundation/client/DefaultIdTokenValidatorTest.kt
@@ -34,7 +34,7 @@ class DefaultIdTokenValidatorTest {
         val client = oktaRule.createOidcClient(oktaRule.createEndpoints("https://example-test.okta.com".toHttpUrl().newBuilder()))
         val idTokenClaims = IdTokenClaims()
         val idToken = client.createJwtBuilder().createJwt(claims = idTokenClaims)
-        idTokenValidator.validate(client, idToken, null, null)
+        idTokenValidator.validate(client, idToken, IdTokenValidator.Parameters(null, null))
     }
 
     @Test fun testValidIdTokenWithNoPathInIssuer(): Unit = runBlocking {
@@ -46,21 +46,21 @@ class DefaultIdTokenValidatorTest {
         )
         val idTokenClaims = IdTokenClaims(issuer = "https://example-test.okta.com")
         val idToken = client.createJwtBuilder().createJwt(claims = idTokenClaims)
-        idTokenValidator.validate(client, idToken, null, null)
+        idTokenValidator.validate(client, idToken, IdTokenValidator.Parameters(null, null))
     }
 
     @Test fun testValidIdTokenWithNonce(): Unit = runBlocking {
         val client = oktaRule.createOidcClient(oktaRule.createEndpoints("https://example-test.okta.com".toHttpUrl().newBuilder()))
         val idTokenClaims = IdTokenClaims(nonce = "6ccdb66d-ad56-4072-b864-7a8fe73c0ac2")
         val idToken = client.createJwtBuilder().createJwt(claims = idTokenClaims)
-        idTokenValidator.validate(client, idToken, "6ccdb66d-ad56-4072-b864-7a8fe73c0ac2", null)
+        idTokenValidator.validate(client, idToken, IdTokenValidator.Parameters("6ccdb66d-ad56-4072-b864-7a8fe73c0ac2", null))
     }
 
     @Test fun testValidIdTokenWithNonceAndMaxAge(): Unit = runBlocking {
         val client = oktaRule.createOidcClient(oktaRule.createEndpoints("https://example-test.okta.com".toHttpUrl().newBuilder()))
         val idTokenClaims = IdTokenClaims(nonce = "6ccdb66d-ad56-4072-b864-7a8fe73c0ac2")
         val idToken = client.createJwtBuilder().createJwt(claims = idTokenClaims)
-        idTokenValidator.validate(client, idToken, "6ccdb66d-ad56-4072-b864-7a8fe73c0ac2", 300)
+        idTokenValidator.validate(client, idToken, IdTokenValidator.Parameters("6ccdb66d-ad56-4072-b864-7a8fe73c0ac2", 300))
     }
 
     @Test fun testInvalidIssuer() {
@@ -169,8 +169,7 @@ class DefaultIdTokenValidatorTest {
                 idTokenValidator.validate(
                     client,
                     client.createJwtBuilder().createJwt(algorithm = algorithm, claims = idTokenClaims),
-                    nonce,
-                    maxAge,
+                    IdTokenValidator.Parameters(nonce, maxAge),
                 )
             }
             fail()

--- a/auth-foundation/src/test/java/com/okta/authfoundation/client/DefaultIdTokenValidatorWithCustomizedGracePeriodTest.kt
+++ b/auth-foundation/src/test/java/com/okta/authfoundation/client/DefaultIdTokenValidatorWithCustomizedGracePeriodTest.kt
@@ -40,7 +40,7 @@ class DefaultIdTokenValidatorWithCustomizedGracePeriodTest {
         val client = oktaRule.createOidcClient(oktaRule.createEndpoints("https://example-test.okta.com".toHttpUrl().newBuilder()))
         val idTokenClaims = IdTokenClaims()
         val idToken = client.createJwtBuilder().createJwt(claims = idTokenClaims)
-        idTokenValidator.validate(client, idToken, null, null)
+        idTokenValidator.validate(client, idToken, IdTokenValidator.Parameters(null, null))
     }
 
     @Test fun testIssuedAtTooFarBeforeNow() {
@@ -69,8 +69,7 @@ class DefaultIdTokenValidatorWithCustomizedGracePeriodTest {
                 idTokenValidator.validate(
                     client,
                     client.createJwtBuilder().createJwt(algorithm = algorithm, claims = idTokenClaims),
-                    nonce,
-                    maxAge,
+                    IdTokenValidator.Parameters(nonce, maxAge),
                 )
             }
             fail()

--- a/auth-foundation/src/test/java/com/okta/authfoundation/client/OidcClientIdTokenValidationFailureTest.kt
+++ b/auth-foundation/src/test/java/com/okta/authfoundation/client/OidcClientIdTokenValidationFailureTest.kt
@@ -31,7 +31,7 @@ class OidcClientIdTokenValidationFailureTest {
     private val mockPrefix = "client_test_responses"
 
     @get:Rule val oktaRule = OktaRule(
-        idTokenValidator = { _, _, _, _ -> throw IllegalStateException("Failure!") }
+        idTokenValidator = { _, _, _ -> throw IllegalStateException("Failure!") }
     )
 
     @Test fun testRefreshTokenIdTokenValidationFailure(): Unit = runBlocking {

--- a/oauth2/src/test/java/com/okta/oauth2/AuthorizationCodeFlowTest.kt
+++ b/oauth2/src/test/java/com/okta/oauth2/AuthorizationCodeFlowTest.kt
@@ -32,8 +32,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
-import org.mockito.kotlin.eq
-import org.mockito.kotlin.isNull
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.reset
 import org.mockito.kotlin.verify
@@ -167,7 +166,11 @@ class AuthorizationCodeFlowTest {
             flowContext = flowContext,
         )
 
-        verify(idTokenValidator).validate(any(), any(), eq("12345689"), isNull())
+        val captor = argumentCaptor<IdTokenValidator.Parameters>()
+        verify(idTokenValidator).validate(any(), any(), captor.capture())
+        assertThat(captor.allValues).hasSize(1)
+        assertThat(captor.firstValue.nonce).isEqualTo("12345689")
+        assertThat(captor.firstValue.maxAge).isNull()
 
         val token = (result as OidcClientResult.Success<Token>).result
         assertThat(token.tokenType).isEqualTo("Bearer")
@@ -201,7 +204,11 @@ class AuthorizationCodeFlowTest {
             flowContext = flowContext,
         )
 
-        verify(idTokenValidator).validate(any(), any(), eq("12345689"), eq(300))
+        val captor = argumentCaptor<IdTokenValidator.Parameters>()
+        verify(idTokenValidator).validate(any(), any(), captor.capture())
+        assertThat(captor.allValues).hasSize(1)
+        assertThat(captor.firstValue.nonce).isEqualTo("12345689")
+        assertThat(captor.firstValue.maxAge).isEqualTo(300)
 
         val token = (result as OidcClientResult.Success<Token>).result
         assertThat(token.tokenType).isEqualTo("Bearer")

--- a/test-helpers/src/main/java/com/okta/testhelpers/OktaRule.kt
+++ b/test-helpers/src/main/java/com/okta/testhelpers/OktaRule.kt
@@ -35,7 +35,7 @@ import org.junit.runners.model.Statement
 
 @OptIn(InternalAuthFoundationApi::class)
 class OktaRule(
-    private val idTokenValidator: IdTokenValidator = IdTokenValidator { _, _, _, _ -> },
+    private val idTokenValidator: IdTokenValidator = IdTokenValidator { _, _, _ -> },
     private val accessTokenValidator: AccessTokenValidator = AccessTokenValidator { _, _, _ -> },
     private val deviceSecretValidator: DeviceSecretValidator = DeviceSecretValidator { _, _, _ -> },
 ) : TestRule {


### PR DESCRIPTION
I was testing other Authorization Servers, and noticed some Authorization Servers send back the original ID Token nonce on refresh. If we want to add more features/flexibility to IdToken validation in the future, we'll need a binary compatible way to do this, which is what this change enables.