### PR TITLE
OKTA-522346 Add support for biometric backed storage.

### DIFF
--- a/auth-foundation/api/auth-foundation.api
+++ b/auth-foundation/api/auth-foundation.api
@@ -244,7 +244,9 @@ public final class com/okta/authfoundation/credential/CredentialDataSource {
 
 public final class com/okta/authfoundation/credential/CredentialDataSource$Companion {
 	public final fun createCredentialDataSource (Lcom/okta/authfoundation/client/OidcClient;Landroid/content/Context;)Lcom/okta/authfoundation/credential/CredentialDataSource;
+	public final fun createCredentialDataSource (Lcom/okta/authfoundation/client/OidcClient;Landroid/content/Context;Landroid/security/keystore/KeyGenParameterSpec;)Lcom/okta/authfoundation/credential/CredentialDataSource;
 	public final fun createCredentialDataSource (Lcom/okta/authfoundation/client/OidcClient;Lcom/okta/authfoundation/credential/TokenStorage;)Lcom/okta/authfoundation/credential/CredentialDataSource;
+	public static synthetic fun createCredentialDataSource$default (Lcom/okta/authfoundation/credential/CredentialDataSource$Companion;Lcom/okta/authfoundation/client/OidcClient;Landroid/content/Context;Landroid/security/keystore/KeyGenParameterSpec;ILjava/lang/Object;)Lcom/okta/authfoundation/credential/CredentialDataSource;
 }
 
 public final class com/okta/authfoundation/credential/RevokeAllException : java/lang/Exception {

--- a/auth-foundation/src/main/java/com/okta/authfoundation/credential/CredentialDataSource.kt
+++ b/auth-foundation/src/main/java/com/okta/authfoundation/credential/CredentialDataSource.kt
@@ -17,7 +17,9 @@ package com.okta.authfoundation.credential
 
 import android.content.Context
 import android.os.Build
+import android.security.keystore.KeyGenParameterSpec
 import androidx.annotation.RequiresApi
+import androidx.security.crypto.MasterKeys
 import com.okta.authfoundation.InternalAuthFoundationApi
 import com.okta.authfoundation.client.OidcClient
 import com.okta.authfoundation.credential.events.CredentialCreatedEvent
@@ -51,17 +53,21 @@ class CredentialDataSource internal constructor(
          * Initializes a credential data source using the [OidcClient].
          *
          * @param context the [Context] used to access Android Shared Preferences and crypto primitives to persist [Token]s.
+         * @param keyGenParameterSpec the [KeyGenParameterSpec] used for encryption.
          * @receiver the [OidcClient] used to perform the low level OIDC requests, as well as with which to use the configuration from.
          */
         @RequiresApi(Build.VERSION_CODES.M)
+        @JvmOverloads
         fun OidcClient.createCredentialDataSource(
             context: Context,
+            keyGenParameterSpec: KeyGenParameterSpec = MasterKeys.AES256_GCM_SPEC,
         ): CredentialDataSource {
             val storage = SharedPreferencesTokenStorage(
                 json = configuration.json,
                 dispatcher = configuration.ioDispatcher,
                 eventCoordinator = configuration.eventCoordinator,
-                context = context
+                context = context,
+                keyGenParameterSpec = keyGenParameterSpec,
             )
             return CredentialDataSource(this, storage)
         }


### PR DESCRIPTION
Tested by setting up `CredentialBootstrap`

```
val specBuilder = KeyGenParameterSpec.Builder(
            "com_okta_authfoundation_storage",
            KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
        )
            .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
            .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
            .setUserAuthenticationRequired(true)
            .setUserAuthenticationParameters(10, KeyProperties.AUTH_BIOMETRIC_STRONG)
            .setKeySize(256)
        val spec = specBuilder.build()
        CredentialBootstrap.initialize(oidcClient.createCredentialDataSource(this, spec))
```

And before accessing the default credential authenticating via:

```
BiometricPrompt(
                this,
                ContextCompat.getMainExecutor(requireContext()),
                object : BiometricPrompt.AuthenticationCallback() {
                    override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
                        viewModel.fetchCredential()
                    }
                }).authenticate(
                BiometricPrompt.PromptInfo.Builder()
                    .setTitle("Authenticate")
                    .setNegativeButtonText("no")
                    .setAllowedAuthenticators(BiometricManager.Authenticators.BIOMETRIC_STRONG)
                    .build(),
            )
```