### PR TITLE
Credential.tokenStateFlow

### DIFF
--- a/auth-foundation/api/auth-foundation.api
+++ b/auth-foundation/api/auth-foundation.api
@@ -222,6 +222,7 @@ public final class com/okta/authfoundation/credential/Credential {
 	public final fun getAccessTokenIfValid (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getTags ()Ljava/util/Map;
 	public final fun getToken ()Lcom/okta/authfoundation/credential/Token;
+	public final fun getTokenFlow ()Lkotlinx/coroutines/flow/Flow;
 	public final fun getUserInfo (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getValidAccessToken (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun hashCode ()I

--- a/auth-foundation/build.gradle
+++ b/auth-foundation/build.gradle
@@ -61,6 +61,7 @@ dependencies {
     testImplementation deps.mockito.core
     testImplementation deps.mockito.kotlin
     testImplementation deps.robolectric
+    testImplementation deps.turbine
     testImplementation project(':test-helpers')
 
     androidTestImplementation deps.junit

--- a/auth-foundation/src/main/java/com/okta/authfoundation/credential/Credential.kt
+++ b/auth-foundation/src/main/java/com/okta/authfoundation/credential/Credential.kt
@@ -32,6 +32,8 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.dropWhile
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.transformWhile
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -94,10 +96,13 @@ class Credential internal constructor(
      * Returns a [Flow] that emits the current [Token] that's stored and associated with this [Credential].
      */
     fun getTokenFlow(): Flow<Token?> {
-        return state.transformWhile {
-            emit(it.token)
-            it !is CredentialState.Deleted
-        }
+        return state
+            .transformWhile {
+                emit(it)
+                it !is CredentialState.Deleted
+            }
+            .dropWhile { it !is CredentialState.Data }
+            .map { it.token }
     }
 
     /**

--- a/auth-foundation/src/main/java/com/okta/authfoundation/credential/Credential.kt
+++ b/auth-foundation/src/main/java/com/okta/authfoundation/credential/Credential.kt
@@ -81,17 +81,6 @@ class Credential internal constructor(
         }
 
     /**
-     * A [Flow] that emits the current [Token] that's stored and associated with this [Credential].
-     */
-    val tokenFlow: Flow<Token?>
-        get() {
-            return state.transformWhile {
-                emit(it.token)
-                it !is CredentialState.Deleted
-            }
-        }
-
-    /**
      * The tags associated with this [Credential].
      *
      * This can be used when calling [Credential.storeToken] to associate this [Credential] with data relevant to your application.
@@ -100,6 +89,16 @@ class Credential internal constructor(
         get() {
             return Collections.unmodifiableMap(state.value.tags)
         }
+
+    /**
+     * Returns a [Flow] that emits the current [Token] that's stored and associated with this [Credential].
+     */
+    fun getTokenFlow(): Flow<Token?> {
+        return state.transformWhile {
+            emit(it.token)
+            it !is CredentialState.Deleted
+        }
+    }
 
     /**
      * Performs the OIDC User Info call, which returns claims associated with this [Credential].

--- a/auth-foundation/src/main/java/com/okta/authfoundation/credential/Credential.kt
+++ b/auth-foundation/src/main/java/com/okta/authfoundation/credential/Credential.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import okhttp3.Interceptor
@@ -73,6 +74,14 @@ class Credential internal constructor(
     val token: Token?
         get() {
             return _token.value
+        }
+
+    /**
+     * A [StateFlow] that contains the current [Token] that's stored and associated with this [Credential].
+     */
+    val tokenStateFlow: StateFlow<Token?>
+        get() {
+            return _token
         }
 
     /**

--- a/auth-foundation/src/main/java/com/okta/authfoundation/credential/Credential.kt
+++ b/auth-foundation/src/main/java/com/okta/authfoundation/credential/Credential.kt
@@ -61,7 +61,10 @@ class Credential internal constructor(
 
     private val state = MutableStateFlow<CredentialState>(CredentialState.Data(token))
 
-    @Volatile private var isDeleted: Boolean = false
+    private val isDeleted: Boolean
+        get() {
+            return state.value == CredentialState.Deleted
+        }
 
     /**
      * The [OidcClient] associated with this [Credential].
@@ -173,7 +176,6 @@ class Credential internal constructor(
         credentialDataSource.remove(this)
         storage.remove(storageIdentifier)
         state.value = CredentialState.Deleted
-        isDeleted = true
         oidcClient.configuration.eventCoordinator.sendEvent(CredentialDeletedEvent(this))
     }
 

--- a/auth-foundation/src/test/java/com/okta/authfoundation/credential/CredentialTest.kt
+++ b/auth-foundation/src/test/java/com/okta/authfoundation/credential/CredentialTest.kt
@@ -876,6 +876,6 @@ class CredentialTest {
 
     @Test fun testHashCode() {
         val credential = oktaRule.createCredential()
-        assertThat(credential.hashCode()).isEqualTo(-106031989)
+        assertThat(credential.hashCode()).isEqualTo(-280515051)
     }
 }

--- a/auth-foundation/src/test/java/com/okta/authfoundation/credential/CredentialTest.kt
+++ b/auth-foundation/src/test/java/com/okta/authfoundation/credential/CredentialTest.kt
@@ -56,7 +56,6 @@ import org.mockito.kotlin.verifyNoInteractions
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import kotlin.test.assertFailsWith
-import kotlinx.coroutines.flow.single
 
 class CredentialTest {
     @get:Rule val oktaRule = OktaRule()
@@ -144,13 +143,15 @@ class CredentialTest {
         assertThat(removedEvent.credential).isEqualTo(credential)
     }
 
-    @Test fun testGetTokenFlowEmitsSingleNullAfterRemove(): Unit = runBlocking {
+    @Test fun testGetTokenFlowReturnsEmptyFlowAfterRemove(): Unit = runBlocking {
         val storage = mock<TokenStorage>()
         val credentialDataSource = mock<CredentialDataSource>()
         val token = createToken()
         val credential = oktaRule.createCredential(token = token, tokenStorage = storage, credentialDataSource = credentialDataSource)
         credential.delete()
-        assertThat(credential.getTokenFlow().single()).isNull()
+        credential.getTokenFlow().test {
+            awaitComplete()
+        }
     }
 
     @Test fun testRevokeAccessToken(): Unit = runBlocking {

--- a/versions.gradle
+++ b/versions.gradle
@@ -35,6 +35,7 @@ versions.security_crypto = '1.0.0'
 versions.spotless = '6.7.0'
 versions.timber = '5.0.1'
 versions.truth = '1.1.3'
+versions.turbine = '0.9.0'
 ext.versions = versions
 
 def build_versions = [:]
@@ -148,6 +149,7 @@ deps.spotless = "com.diffplug.spotless:spotless-plugin-gradle:$versions.spotless
 
 deps.timber = "com.jakewharton.timber:timber:$versions.timber"
 deps.truth = "com.google.truth:truth:$versions.truth"
+deps.turbine = "app.cash.turbine:turbine:$versions.turbine"
 
 ext.deps = deps
 


### PR DESCRIPTION
This exposes the current token for a `Credential` object as a `StateFlow` that can be observed.

Resolves #210 