### PR TITLE
Fix Chrome custom tab race condition in ForegroundActivity

### DIFF
--- a/web-authentication-ui/src/main/java/com/okta/webauthenticationui/ForegroundActivity.kt
+++ b/web-authentication-ui/src/main/java/com/okta/webauthenticationui/ForegroundActivity.kt
@@ -63,6 +63,9 @@ internal class ForegroundActivity : AppCompatActivity() {
         // Removing the observer because we want the result delivered in onResume (where we observer), rather than onStart in the case
         // where the activity was backgrounded.
         viewModel.stateLiveData.removeObserver(stateObserver)
+        if (isFinishing) {
+            viewModel.flowCancelled()
+        }
     }
 
     override fun onNewIntent(intent: Intent) {
@@ -80,13 +83,6 @@ internal class ForegroundActivity : AppCompatActivity() {
     override fun onBackPressed() {
         super.onBackPressed()
         viewModel.flowCancelled()
-    }
-
-    override fun onDestroy() {
-        super.onDestroy()
-        if (isFinishing) {
-            viewModel.flowCancelled()
-        }
     }
 
     private val stateObserver = Observer<ForegroundViewModel.State> { state ->


### PR DESCRIPTION
Fixes #236. onDestroy is incorrectly detecting whether the activity is cancelled by the user or by the system. I've moved the logic for detecting this to onPause, which doesn't seem to have the same issue.

Also, onDestroy can be called _after_ a second instance of ForegroundActivity is created. This can cause the first activity to output garbage data into the new flow. By moving user cancellation detection to onPause, both these issues are fixed.