### PR TITLE
Add device token cookie to okHttpClient

### DIFF
--- a/auth-foundation/api/auth-foundation.api
+++ b/auth-foundation/api/auth-foundation.api
@@ -4,6 +4,7 @@ public final class com/okta/authfoundation/AuthFoundationDefaults {
 	public final fun getCache ()Lcom/okta/authfoundation/client/Cache;
 	public final fun getClock ()Lcom/okta/authfoundation/client/OidcClock;
 	public final fun getComputeDispatcher ()Lkotlin/coroutines/CoroutineContext;
+	public final fun getCookieJar ()Lokhttp3/CookieJar;
 	public final fun getDeviceSecretValidator ()Lcom/okta/authfoundation/client/DeviceSecretValidator;
 	public final fun getEventCoordinator ()Lcom/okta/authfoundation/events/EventCoordinator;
 	public final fun getIdTokenValidator ()Lcom/okta/authfoundation/client/IdTokenValidator;
@@ -13,6 +14,7 @@ public final class com/okta/authfoundation/AuthFoundationDefaults {
 	public final fun setCache (Lcom/okta/authfoundation/client/Cache;)V
 	public final fun setClock (Lcom/okta/authfoundation/client/OidcClock;)V
 	public final fun setComputeDispatcher (Lkotlin/coroutines/CoroutineContext;)V
+	public final fun setCookieJar (Lokhttp3/CookieJar;)V
 	public final fun setDeviceSecretValidator (Lcom/okta/authfoundation/client/DeviceSecretValidator;)V
 	public final fun setEventCoordinator (Lcom/okta/authfoundation/events/EventCoordinator;)V
 	public final fun setIdTokenValidator (Lcom/okta/authfoundation/client/IdTokenValidator;)V
@@ -76,6 +78,23 @@ public abstract interface class com/okta/authfoundation/client/DeviceSecretValid
 
 public final class com/okta/authfoundation/client/DeviceSecretValidator$Error : java/lang/IllegalStateException {
 	public fun <init> (Ljava/lang/String;)V
+}
+
+public final class com/okta/authfoundation/client/DeviceTokenCookieJar : okhttp3/CookieJar {
+	public fun <init> ()V
+	public fun loadForRequest (Lokhttp3/HttpUrl;)Ljava/util/List;
+	public fun saveFromResponse (Lokhttp3/HttpUrl;Ljava/util/List;)V
+}
+
+public final class com/okta/authfoundation/client/DeviceTokenInitializer : androidx/startup/Initializer {
+	public fun <init> ()V
+	public fun create (Landroid/content/Context;)Lcom/okta/authfoundation/client/DeviceTokenProvider;
+	public synthetic fun create (Landroid/content/Context;)Ljava/lang/Object;
+	public fun dependencies ()Ljava/util/List;
+}
+
+public final class com/okta/authfoundation/client/DeviceTokenProvider {
+	public synthetic fun <init> (Landroid/content/Context;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public abstract interface class com/okta/authfoundation/client/IdTokenValidator {
@@ -156,12 +175,13 @@ public abstract interface class com/okta/authfoundation/client/OidcClock {
 
 public final class com/okta/authfoundation/client/OidcConfiguration {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Lcom/okta/authfoundation/client/OidcClock;Lcom/okta/authfoundation/events/EventCoordinator;Lcom/okta/authfoundation/client/IdTokenValidator;Lcom/okta/authfoundation/client/AccessTokenValidator;Lcom/okta/authfoundation/client/DeviceSecretValidator;Lcom/okta/authfoundation/client/Cache;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Lcom/okta/authfoundation/client/OidcClock;Lcom/okta/authfoundation/events/EventCoordinator;Lcom/okta/authfoundation/client/IdTokenValidator;Lcom/okta/authfoundation/client/AccessTokenValidator;Lcom/okta/authfoundation/client/DeviceSecretValidator;Lcom/okta/authfoundation/client/Cache;Lokhttp3/CookieJar;)V
 	public final fun getAccessTokenValidator ()Lcom/okta/authfoundation/client/AccessTokenValidator;
 	public final fun getCache ()Lcom/okta/authfoundation/client/Cache;
 	public final fun getClientId ()Ljava/lang/String;
 	public final fun getClock ()Lcom/okta/authfoundation/client/OidcClock;
 	public final fun getComputeDispatcher ()Lkotlin/coroutines/CoroutineContext;
+	public final fun getCookieJar ()Lokhttp3/CookieJar;
 	public final fun getDefaultScope ()Ljava/lang/String;
 	public final fun getDeviceSecretValidator ()Lcom/okta/authfoundation/client/DeviceSecretValidator;
 	public final fun getEventCoordinator ()Lcom/okta/authfoundation/events/EventCoordinator;

--- a/auth-foundation/api/auth-foundation.api
+++ b/auth-foundation/api/auth-foundation.api
@@ -81,7 +81,7 @@ public final class com/okta/authfoundation/client/DeviceSecretValidator$Error : 
 }
 
 public final class com/okta/authfoundation/client/DeviceTokenCookieJar : okhttp3/CookieJar {
-	public fun <init> ()V
+	public fun <init> (Lcom/okta/authfoundation/client/OidcClock;)V
 	public fun loadForRequest (Lokhttp3/HttpUrl;)Ljava/util/List;
 	public fun saveFromResponse (Lokhttp3/HttpUrl;Ljava/util/List;)V
 }
@@ -170,7 +170,7 @@ public final class com/okta/authfoundation/client/OidcClientResult$Success : com
 }
 
 public abstract interface class com/okta/authfoundation/client/OidcClock {
-	public abstract fun currentTimeEpochSecond (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun currentTimeEpochSecond ()J
 }
 
 public final class com/okta/authfoundation/client/OidcConfiguration {

--- a/auth-foundation/build.gradle
+++ b/auth-foundation/build.gradle
@@ -53,6 +53,7 @@ dependencies {
 
     implementation deps.kotlin.serialization_okio
     implementation deps.security_crypto
+    implementation deps.startup_runtime
 
     testImplementation deps.coroutines.test
     testImplementation deps.androidx_test.core

--- a/auth-foundation/src/androidTest/java/com/okta/authfoundation/credential/DeviceTokenProviderTest.kt
+++ b/auth-foundation/src/androidTest/java/com/okta/authfoundation/credential/DeviceTokenProviderTest.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.credential
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import com.okta.authfoundation.client.DeviceTokenProvider
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.UUID
+
+@RunWith(AndroidJUnit4::class)
+class DeviceTokenProviderTest {
+    lateinit var context: Context
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+    }
+
+    @Test
+    fun testDeviceTokenProviderInitializesCorrectly() {
+        val deviceTokenProvider = DeviceTokenProvider.initialize(context)
+        val expectedUUID = UUID.fromString(deviceTokenProvider.sharedPrefs.getString(DeviceTokenProvider.PREFERENCE_KEY, null))
+        val actualUUID = UUID.fromString(DeviceTokenProvider.deviceToken)
+        assertThat(actualUUID).isEqualTo(expectedUUID)
+    }
+
+    @Test
+    fun testDeviceTokenProviderOnlyInitializesOnce() {
+        val deviceTokenProvider = DeviceTokenProvider.initialize(context)
+        val expectedUUID = UUID.fromString(deviceTokenProvider.sharedPrefs.getString(DeviceTokenProvider.PREFERENCE_KEY, null))
+        DeviceTokenProvider.initialize(context)
+        val actualUUID = UUID.fromString(DeviceTokenProvider.deviceToken)
+        assertThat(actualUUID).isEqualTo(expectedUUID)
+    }
+}

--- a/auth-foundation/src/main/AndroidManifest.xml
+++ b/auth-foundation/src/main/AndroidManifest.xml
@@ -5,4 +5,15 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-sdk tools:overrideLibrary="androidx.security" />
+
+    <application>
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false"
+            tools:node="merge">
+            <meta-data android:name="com.okta.authfoundation.client.DeviceTokenInitializer"
+                android:value="androidx.startup" />
+        </provider>
+    </application>
 </manifest>

--- a/auth-foundation/src/main/java/com/okta/authfoundation/AuthFoundationDefaults.kt
+++ b/auth-foundation/src/main/java/com/okta/authfoundation/AuthFoundationDefaults.kt
@@ -70,5 +70,5 @@ object AuthFoundationDefaults {
 
     /** The default [CookieJar]. By default, it adds a DT cookie for identifying the device.
      * To use the default [CookieJar] in OkHttp, set this to [CookieJar.NO_COOKIES] */
-    var cookieJar: CookieJar by NoSetAfterGetWithLazyDefaultFactory { DeviceTokenCookieJar() }
+    var cookieJar: CookieJar by NoSetAfterGetWithLazyDefaultFactory { DeviceTokenCookieJar(clock) }
 }

--- a/auth-foundation/src/main/java/com/okta/authfoundation/AuthFoundationDefaults.kt
+++ b/auth-foundation/src/main/java/com/okta/authfoundation/AuthFoundationDefaults.kt
@@ -21,12 +21,14 @@ import com.okta.authfoundation.client.DefaultAccessTokenValidator
 import com.okta.authfoundation.client.DefaultDeviceSecretValidator
 import com.okta.authfoundation.client.DefaultIdTokenValidator
 import com.okta.authfoundation.client.DeviceSecretValidator
+import com.okta.authfoundation.client.DeviceTokenCookieJar
 import com.okta.authfoundation.client.IdTokenValidator
 import com.okta.authfoundation.client.NoOpCache
 import com.okta.authfoundation.client.OidcClock
 import com.okta.authfoundation.events.EventCoordinator
 import kotlinx.coroutines.Dispatchers
 import okhttp3.Call
+import okhttp3.CookieJar
 import okhttp3.OkHttpClient
 import java.time.Instant
 import kotlin.coroutines.CoroutineContext
@@ -65,4 +67,8 @@ object AuthFoundationDefaults {
 
     /** The default [Cache]. No caching is enabled by default. */
     var cache: Cache by NoSetAfterGetWithLazyDefaultFactory { NoOpCache() }
+
+    /** The default [CookieJar]. By default, it adds a DT cookie for identifying the device.
+     * To use the default [CookieJar] in OkHttp, set this to [CookieJar.NO_COOKIES] */
+    var cookieJar: CookieJar by NoSetAfterGetWithLazyDefaultFactory { DeviceTokenCookieJar() }
 }

--- a/auth-foundation/src/main/java/com/okta/authfoundation/client/DeviceTokenCookieJar.kt
+++ b/auth-foundation/src/main/java/com/okta/authfoundation/client/DeviceTokenCookieJar.kt
@@ -18,8 +18,9 @@ package com.okta.authfoundation.client
 import okhttp3.Cookie
 import okhttp3.CookieJar
 import okhttp3.HttpUrl
+import kotlin.time.Duration.Companion.seconds
 
-class DeviceTokenCookieJar : CookieJar {
+class DeviceTokenCookieJar(private val oidcClock: OidcClock) : CookieJar {
     private val savedCookiesCache = mutableMapOf<String, List<Cookie>>()
 
     private val deviceTokenCookieBuilder = Cookie.Builder()
@@ -30,7 +31,7 @@ class DeviceTokenCookieJar : CookieJar {
     override fun loadForRequest(url: HttpUrl): List<Cookie> {
         val deviceTokenCookie = deviceTokenCookieBuilder.domain(url.host).build()
         val savedCookiesForDomain = savedCookiesCache[url.host]?.filter {
-            it.expiresAt > System.currentTimeMillis()
+            it.expiresAt > oidcClock.currentTimeEpochSecond().seconds.inWholeMilliseconds
         } ?: emptyList()
         return savedCookiesForDomain + listOf(deviceTokenCookie)
     }

--- a/auth-foundation/src/main/java/com/okta/authfoundation/client/DeviceTokenCookieJar.kt
+++ b/auth-foundation/src/main/java/com/okta/authfoundation/client/DeviceTokenCookieJar.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.client
+
+import okhttp3.Cookie
+import okhttp3.CookieJar
+import okhttp3.HttpUrl
+
+class DeviceTokenCookieJar : CookieJar {
+    private val savedCookiesCache = mutableMapOf<String, List<Cookie>>()
+
+    private val deviceTokenCookieBuilder = Cookie.Builder()
+        .name("DT")
+        .value(DeviceTokenProvider.deviceToken)
+        .secure()
+
+    override fun loadForRequest(url: HttpUrl): List<Cookie> {
+        val deviceTokenCookie = deviceTokenCookieBuilder.domain(url.host).build()
+        val savedCookiesForDomain = savedCookiesCache[url.host]?.filter {
+            it.expiresAt > System.currentTimeMillis()
+        } ?: emptyList()
+        return savedCookiesForDomain + listOf(deviceTokenCookie)
+    }
+
+    override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) {
+        savedCookiesCache[url.host] = cookies
+    }
+}

--- a/auth-foundation/src/main/java/com/okta/authfoundation/client/DeviceTokenInitializer.kt
+++ b/auth-foundation/src/main/java/com/okta/authfoundation/client/DeviceTokenInitializer.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.client
+
+import android.content.Context
+import androidx.startup.Initializer
+
+class DeviceTokenInitializer : Initializer<DeviceTokenProvider> {
+    override fun create(context: Context): DeviceTokenProvider {
+        return DeviceTokenProvider.initialize(context)
+    }
+
+    override fun dependencies(): List<Class<out Initializer<*>>> = emptyList()
+}

--- a/auth-foundation/src/main/java/com/okta/authfoundation/client/DeviceTokenProvider.kt
+++ b/auth-foundation/src/main/java/com/okta/authfoundation/client/DeviceTokenProvider.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.client
+
+import android.content.Context
+import androidx.annotation.VisibleForTesting
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKeys
+import java.util.UUID
+
+class DeviceTokenProvider private constructor(appContext: Context) {
+    internal companion object {
+        private const val FILE_NAME = "com.okta.authfoundation.device_token_storage"
+        @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+        internal const val PREFERENCE_KEY = "com.okta.authfoundation.device_token_key"
+
+        private val lock = Any()
+        private lateinit var instance: DeviceTokenProvider
+        internal val deviceToken: String
+            get() = instance.deviceToken
+
+        internal fun initialize(context: Context): DeviceTokenProvider {
+            synchronized(lock) {
+                if (::instance.isInitialized) return instance
+                instance = DeviceTokenProvider(context.applicationContext)
+                return instance
+            }
+        }
+    }
+
+    private val masterKeyAlias = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal val sharedPrefs = EncryptedSharedPreferences.create(
+        FILE_NAME,
+        masterKeyAlias,
+        appContext,
+        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+    )
+
+    private val sharedPrefsEditor = sharedPrefs.edit()
+
+    private val deviceToken = sharedPrefs.getString(PREFERENCE_KEY, null) ?: run {
+        val newDeviceToken = UUID.randomUUID().toString()
+        sharedPrefsEditor.putString(PREFERENCE_KEY, newDeviceToken)
+        sharedPrefsEditor.commit()
+        newDeviceToken
+    }
+}

--- a/auth-foundation/src/main/java/com/okta/authfoundation/client/OidcClock.kt
+++ b/auth-foundation/src/main/java/com/okta/authfoundation/client/OidcClock.kt
@@ -29,5 +29,5 @@ fun interface OidcClock {
     /**
      *  Returns the current time in seconds since January 1, 1970 UTC, adjusting the system clock to correct for clock skew.
      */
-    suspend fun currentTimeEpochSecond(): Long
+    fun currentTimeEpochSecond(): Long
 }

--- a/test-helpers/src/main/java/com/okta/testhelpers/OktaRule.kt
+++ b/test-helpers/src/main/java/com/okta/testhelpers/OktaRule.kt
@@ -25,6 +25,7 @@ import com.okta.authfoundation.client.OidcClient
 import com.okta.authfoundation.client.OidcConfiguration
 import com.okta.authfoundation.client.OidcEndpoints
 import com.okta.authfoundation.events.EventCoordinator
+import okhttp3.CookieJar
 import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
@@ -66,6 +67,7 @@ class OktaRule(
         ioDispatcher = EmptyCoroutineContext,
         computeDispatcher = EmptyCoroutineContext,
         cache = cache,
+        cookieJar = CookieJar.NO_COOKIES,
     )
 
     fun createEndpoints(

--- a/test-helpers/src/main/java/com/okta/testhelpers/TestClock.kt
+++ b/test-helpers/src/main/java/com/okta/testhelpers/TestClock.kt
@@ -20,7 +20,7 @@ import com.okta.authfoundation.client.OidcClock
 class TestClock : OidcClock {
     @Volatile var currentTime: Long = 1644347069L
 
-    override suspend fun currentTimeEpochSecond(): Long {
+    override fun currentTimeEpochSecond(): Long {
         return currentTime
     }
 }

--- a/versions.gradle
+++ b/versions.gradle
@@ -34,6 +34,7 @@ versions.okta_management = '8.2.2'
 versions.robolectric = '4.8.1'
 versions.security_crypto = '1.0.0'
 versions.spotless = '6.7.0'
+versions.startup_runtime = '1.1.1'
 versions.timber = '5.0.1'
 versions.truth = '1.1.3'
 versions.turbine = '0.9.0'
@@ -150,6 +151,8 @@ deps.robolectric = "org.robolectric:robolectric:$versions.robolectric"
 
 deps.security_crypto = "androidx.security:security-crypto:$versions.security_crypto"
 deps.spotless = "com.diffplug.spotless:spotless-plugin-gradle:$versions.spotless"
+
+deps.startup_runtime = "androidx.startup:startup-runtime:$versions.startup_runtime"
 
 deps.timber = "com.jakewharton.timber:timber:$versions.timber"
 deps.truth = "com.google.truth:truth:$versions.truth"


### PR DESCRIPTION
Add DT cookie to http requests. This is mainly useful for okta-idx-android, but there didn't seem to be a clean way to do this by changing okta-idx-android since okHttpClient is already initialized in this SDK before code in idx sdk can be reached.