### PR TITLE
Decouple ForegroundActivity lifecycle from login state

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,9 @@
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply plugin: 'androidx.navigation.safeargs.kotlin'
+plugins {
+    id("com.android.application")
+    id("kotlin-android")
+    id("kotlin-parcelize")
+    id("androidx.navigation.safeargs.kotlin")
+}
 
 def oktaProperties = new Properties()
 rootProject.file("okta.properties").withInputStream { oktaProperties.load(it) }

--- a/auth-foundation-bootstrap/api/auth-foundation-bootstrap.api
+++ b/auth-foundation-bootstrap/api/auth-foundation-bootstrap.api
@@ -4,5 +4,6 @@ public final class com/okta/authfoundationbootstrap/CredentialBootstrap {
 	public final fun getCredentialDataSource ()Lcom/okta/authfoundation/credential/CredentialDataSource;
 	public final fun getOidcClient ()Lcom/okta/authfoundation/client/OidcClient;
 	public final fun initialize (Lcom/okta/authfoundation/credential/CredentialDataSource;)V
+	public final fun reset ()V
 }
 

--- a/auth-foundation-bootstrap/src/main/java/com/okta/authfoundationbootstrap/CredentialBootstrap.kt
+++ b/auth-foundation-bootstrap/src/main/java/com/okta/authfoundationbootstrap/CredentialBootstrap.kt
@@ -15,6 +15,7 @@
  */
 package com.okta.authfoundationbootstrap
 
+import com.okta.authfoundation.InternalAuthFoundationApi
 import com.okta.authfoundation.client.OidcClient
 import com.okta.authfoundation.credential.Credential
 import com.okta.authfoundation.credential.CredentialDataSource
@@ -95,7 +96,8 @@ object CredentialBootstrap {
         return credential
     }
 
-    internal fun reset() {
+    @InternalAuthFoundationApi
+    fun reset() {
         privateCredentialDataSource = null
     }
 }

--- a/web-authentication-ui/api/web-authentication-ui.api
+++ b/web-authentication-ui/api/web-authentication-ui.api
@@ -1,3 +1,35 @@
+public final class com/okta/webauthenticationui/ForegroundViewModel$State$AwaitingBrowserCallback$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/okta/webauthenticationui/ForegroundViewModel$State$AwaitingBrowserCallback;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/okta/webauthenticationui/ForegroundViewModel$State$AwaitingBrowserCallback;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/okta/webauthenticationui/ForegroundViewModel$State$AwaitingInitialization$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/okta/webauthenticationui/ForegroundViewModel$State$AwaitingInitialization;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/okta/webauthenticationui/ForegroundViewModel$State$AwaitingInitialization;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/okta/webauthenticationui/ForegroundViewModel$State$Error$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/okta/webauthenticationui/ForegroundViewModel$State$Error;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/okta/webauthenticationui/ForegroundViewModel$State$Error;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/okta/webauthenticationui/ForegroundViewModel$State$LaunchBrowser$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/okta/webauthenticationui/ForegroundViewModel$State$LaunchBrowser;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/okta/webauthenticationui/ForegroundViewModel$State$LaunchBrowser;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/okta/webauthenticationui/WebAuthenticationClient {
 	public static final field Companion Lcom/okta/webauthenticationui/WebAuthenticationClient$Companion;
 	public synthetic fun <init> (Lcom/okta/authfoundation/client/OidcClient;Lcom/okta/webauthenticationui/WebAuthenticationProvider;Lkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/web-authentication-ui/build.gradle
+++ b/web-authentication-ui/build.gradle
@@ -1,5 +1,9 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+plugins {
+    id("com.android.library")
+    id("kotlin-android")
+    id("kotlin-parcelize")
+}
+
 apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 apply plugin: 'org.jetbrains.dokka'
 apply plugin: 'com.vanniktech.maven.publish.base'

--- a/web-authentication-ui/src/main/java/com/okta/webauthenticationui/ForegroundActivity.kt
+++ b/web-authentication-ui/src/main/java/com/okta/webauthenticationui/ForegroundActivity.kt
@@ -91,7 +91,7 @@ internal class ForegroundActivity : AppCompatActivity() {
                 finish()
             }
             is ForegroundViewModel.State.LaunchBrowser -> {
-                viewModel.launchBrowser(this, state.url)
+                viewModel.launchBrowser(this, state.urlString)
             }
             ForegroundViewModel.State.AwaitingInitialization -> {
                 // Idle, nothing to do.

--- a/web-authentication-ui/src/main/java/com/okta/webauthenticationui/ForegroundViewModel.kt
+++ b/web-authentication-ui/src/main/java/com/okta/webauthenticationui/ForegroundViewModel.kt
@@ -17,48 +17,58 @@ package com.okta.webauthenticationui
 
 import android.app.Activity
 import android.net.Uri
+import android.os.Parcelable
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.launch
-import okhttp3.HttpUrl
+import kotlinx.parcelize.Parcelize
+import okhttp3.HttpUrl.Companion.toHttpUrl
 
-internal class ForegroundViewModel : ViewModel() {
+internal class ForegroundViewModel(private val savedStateHandle: SavedStateHandle) : ViewModel() {
     companion object {
         // Needs to be inside the companion object due to the tests. Since this is accessed in init, we'd either need to pass it in the
         // constructor, or make it static. Since it's for tests only, making it static was the easier solution, which is why I chose
         // it.
         @VisibleForTesting var redirectCoordinator: RedirectCoordinator = SingletonRedirectCoordinator
+        private const val LIVE_DATA_KEY = "FOREGROUND_STATE_LIVE_DATA_KEY"
     }
 
-    sealed class State {
+    @Parcelize
+    sealed class State : Parcelable {
+        @Parcelize
         object AwaitingInitialization : State()
+        @Parcelize
         object Error : State()
-        class LaunchBrowser(val url: HttpUrl) : State()
+        @Parcelize
+        class LaunchBrowser(val urlString: String) : State()
+        @Parcelize
         object AwaitingBrowserCallback : State()
     }
 
-    private val _stateLiveData = MutableLiveData<State>(State.AwaitingInitialization)
-    val stateLiveData: LiveData<State> = _stateLiveData
+    val stateLiveData: LiveData<State> = savedStateHandle.getLiveData(LIVE_DATA_KEY, State.AwaitingInitialization)
 
     init {
         viewModelScope.launch {
-            when (val result = redirectCoordinator.runInitializationFunction()) {
-                is RedirectInitializationResult.Error -> {
-                    _stateLiveData.value = State.Error
-                }
-                is RedirectInitializationResult.Success -> {
-                    _stateLiveData.value = State.LaunchBrowser(result.url)
+            if (stateLiveData.value == State.AwaitingInitialization) {
+                when (val result = redirectCoordinator.runInitializationFunction()) {
+                    is RedirectInitializationResult.Error -> {
+                        savedStateHandle[LIVE_DATA_KEY] = State.Error
+                    }
+
+                    is RedirectInitializationResult.Success -> {
+                        savedStateHandle[LIVE_DATA_KEY] = State.LaunchBrowser(result.url.toString())
+                    }
                 }
             }
         }
     }
 
-    fun launchBrowser(activity: Activity, url: HttpUrl) {
-        _stateLiveData.value = State.AwaitingBrowserCallback
-        if (!redirectCoordinator.launchWebAuthenticationProvider(activity, url)) {
+    fun launchBrowser(activity: Activity, urlString: String) {
+        savedStateHandle[LIVE_DATA_KEY] = State.AwaitingBrowserCallback
+        if (!redirectCoordinator.launchWebAuthenticationProvider(activity, urlString.toHttpUrl())) {
             activity.finish()
         }
     }

--- a/web-authentication-ui/src/test/java/com/okta/webauthenticationui/ForegroundActivityTest.kt
+++ b/web-authentication-ui/src/test/java/com/okta/webauthenticationui/ForegroundActivityTest.kt
@@ -19,6 +19,8 @@ import android.app.Activity
 import android.net.Uri
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.CompletableDeferred
+import okhttp3.HttpUrl
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
@@ -31,10 +33,19 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import java.lang.IllegalStateException
 
 @RunWith(RobolectricTestRunner::class)
 class ForegroundActivityTest {
+    private lateinit var mockUrl: HttpUrl
+    private val testUrlString = "http://testing"
+
+    @Before
+    fun setup() {
+        mockUrl = mock() {
+            on { toString() } doReturn testUrlString
+        }
+    }
+
     @Test fun testResumeLaunchesWebAuthenticationProvider() {
         val launchedFromActivity = Robolectric.buildActivity(Activity::class.java).create().get()
         val intent = ForegroundActivity.createIntent(launchedFromActivity)
@@ -43,7 +54,7 @@ class ForegroundActivityTest {
         val redirectCoordinator = mock<RedirectCoordinator> {
             on { launchWebAuthenticationProvider(any(), any()) } doReturn true
             onBlocking { runInitializationFunction() } doAnswer {
-                RedirectInitializationResult.Success(mock(), Any())
+                RedirectInitializationResult.Success(mockUrl, Any())
             }
         }
         ForegroundViewModel.redirectCoordinator = redirectCoordinator
@@ -70,7 +81,7 @@ class ForegroundActivityTest {
         ForegroundViewModel.redirectCoordinator = redirectCoordinator
         controller.create().resume().pause()
         verify(redirectCoordinator, never()).launchWebAuthenticationProvider(any(), any())
-        deferred.complete(RedirectInitializationResult.Success(mock(), Any()))
+        deferred.complete(RedirectInitializationResult.Success(mockUrl, Any()))
         controller.resume()
 
         verify(redirectCoordinator).launchWebAuthenticationProvider(any(), any())
@@ -87,7 +98,7 @@ class ForegroundActivityTest {
         val redirectCoordinator = mock<RedirectCoordinator> {
             on { launchWebAuthenticationProvider(any(), any()) } doReturn false
             onBlocking { runInitializationFunction() } doAnswer {
-                RedirectInitializationResult.Success(mock(), Any())
+                RedirectInitializationResult.Success(mockUrl, Any())
             }
         }
         ForegroundViewModel.redirectCoordinator = redirectCoordinator
@@ -105,7 +116,7 @@ class ForegroundActivityTest {
         val redirectCoordinator = mock<RedirectCoordinator> {
             on { launchWebAuthenticationProvider(any(), any()) } doReturn true
             onBlocking { runInitializationFunction() } doAnswer {
-                RedirectInitializationResult.Success(mock(), Any())
+                RedirectInitializationResult.Success(mockUrl, Any())
             }
         }
         ForegroundViewModel.redirectCoordinator = redirectCoordinator
@@ -125,7 +136,7 @@ class ForegroundActivityTest {
         val redirectCoordinator = mock<RedirectCoordinator> {
             on { launchWebAuthenticationProvider(any(), any()) } doReturn true
             onBlocking { runInitializationFunction() } doAnswer {
-                RedirectInitializationResult.Success(mock(), Any())
+                RedirectInitializationResult.Success(mockUrl, Any())
             }
         }
         ForegroundViewModel.redirectCoordinator = redirectCoordinator


### PR DESCRIPTION
This PR fixes #248 to the best of the SDKs abilities. Also this fixes #257, which makes an CredentialBootstrap.reset() visible for user's testing purposes and guards it with InternalAuthFoundationApi annotation.

To fully fix #248, users also need to ensure that they are executing and storing results of call to WebAuthenticationClient.login() in a component that survives activity onDestroy(), rather than storing results in a ViewModel's data holder and executing in viewModelScope.