### PR TITLE
Fix DeviceToken format

### DIFF
--- a/auth-foundation/src/androidTest/java/com/okta/authfoundation/credential/DeviceTokenProviderTest.kt
+++ b/auth-foundation/src/androidTest/java/com/okta/authfoundation/credential/DeviceTokenProviderTest.kt
@@ -23,7 +23,6 @@ import com.okta.authfoundation.client.DeviceTokenProvider
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.util.UUID
 
 @RunWith(AndroidJUnit4::class)
 class DeviceTokenProviderTest {
@@ -37,17 +36,24 @@ class DeviceTokenProviderTest {
     @Test
     fun testDeviceTokenProviderInitializesCorrectly() {
         val deviceTokenProvider = DeviceTokenProvider.initialize(context)
-        val expectedUUID = UUID.fromString(deviceTokenProvider.sharedPrefs.getString(DeviceTokenProvider.PREFERENCE_KEY, null))
-        val actualUUID = UUID.fromString(DeviceTokenProvider.deviceToken)
-        assertThat(actualUUID).isEqualTo(expectedUUID)
+        val expectedDeviceToken = deviceTokenProvider.sharedPrefs.getString(DeviceTokenProvider.PREFERENCE_KEY, null)!!.filter { it.isLetterOrDigit() }
+        val actualDeviceToken = DeviceTokenProvider.deviceToken
+        assertThat(actualDeviceToken).isEqualTo(expectedDeviceToken)
     }
 
     @Test
     fun testDeviceTokenProviderOnlyInitializesOnce() {
         val deviceTokenProvider = DeviceTokenProvider.initialize(context)
-        val expectedUUID = UUID.fromString(deviceTokenProvider.sharedPrefs.getString(DeviceTokenProvider.PREFERENCE_KEY, null))
+        val expectedDeviceToken = deviceTokenProvider.sharedPrefs.getString(DeviceTokenProvider.PREFERENCE_KEY, null)!!.filter { it.isLetterOrDigit() }
         DeviceTokenProvider.initialize(context)
-        val actualUUID = UUID.fromString(DeviceTokenProvider.deviceToken)
-        assertThat(actualUUID).isEqualTo(expectedUUID)
+        val actualDeviceToken = DeviceTokenProvider.deviceToken
+        assertThat(actualDeviceToken).isEqualTo(expectedDeviceToken)
+    }
+
+    @Test
+    fun testDeviceTokenIsAtMost32Characters() {
+        DeviceTokenProvider.initialize(context)
+        val actualDeviceToken = DeviceTokenProvider.deviceToken
+        assertThat(actualDeviceToken.length).isAtMost(32)
     }
 }

--- a/auth-foundation/src/main/java/com/okta/authfoundation/client/DeviceTokenProvider.kt
+++ b/auth-foundation/src/main/java/com/okta/authfoundation/client/DeviceTokenProvider.kt
@@ -30,7 +30,7 @@ class DeviceTokenProvider private constructor(appContext: Context) {
         private val lock = Any()
         private lateinit var instance: DeviceTokenProvider
         internal val deviceToken: String
-            get() = instance.deviceToken
+            get() = instance.deviceToken.filter { it.isLetterOrDigit() }
 
         internal fun initialize(context: Context): DeviceTokenProvider {
             synchronized(lock) {


### PR DESCRIPTION
Previously, a randomly generated UUID was being used as device token. This UUID string contained alphanumeric characters, and dashes. Having dashes in device token seems to cause the backend to not remember the device. Removing dashes fixes the issue.