### PR TITLE
OIDC client refactor

### DIFF
--- a/app/src/main/java/sample/okta/android/SampleApplication.kt
+++ b/app/src/main/java/sample/okta/android/SampleApplication.kt
@@ -39,12 +39,11 @@ class SampleApplication : Application() {
         Timber.plant(Timber.DebugTree())
 
         AuthFoundation.initializeAndroidContext(this)
-        val oidcConfiguration = OidcConfiguration(
+        OidcConfiguration.default = OidcConfiguration(
             clientId = BuildConfig.CLIENT_ID,
             defaultScope = SampleHelper.DEFAULT_SCOPE,
             issuer = BuildConfig.ISSUER
         )
-        val oidcClient = OidcClient.createFromConfiguration(oidcConfiguration)
-        CredentialBootstrap.initialize(oidcClient.createCredentialDataSource(this))
+        CredentialBootstrap.initialize(OidcClient.default.createCredentialDataSource(this))
     }
 }

--- a/app/src/main/java/sample/okta/android/browser/BrowserViewModel.kt
+++ b/app/src/main/java/sample/okta/android/browser/BrowserViewModel.kt
@@ -22,7 +22,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.okta.authfoundation.client.OidcClientResult
 import com.okta.authfoundationbootstrap.CredentialBootstrap
-import com.okta.webauthenticationui.WebAuthenticationClient
+import com.okta.webauthenticationui.WebAuthentication
 import kotlinx.coroutines.launch
 import sample.okta.android.BuildConfig
 import sample.okta.android.SampleHelper
@@ -36,14 +36,14 @@ class BrowserViewModel : ViewModel() {
         viewModelScope.launch {
             _state.value = BrowserState.Loading
 
-            val webAuthenticationClient = WebAuthenticationClient()
+            val webAuthentication = WebAuthentication()
             var scope = SampleHelper.DEFAULT_SCOPE
             if (addDeviceSsoScope) {
                 scope += " device_sso"
             }
 
             when (
-                val result = webAuthenticationClient.login(
+                val result = webAuthentication.login(
                     context = context,
                     redirectUrl = BuildConfig.SIGN_IN_REDIRECT_URI,
                     extraRequestParameters = emptyMap(),

--- a/app/src/main/java/sample/okta/android/browser/BrowserViewModel.kt
+++ b/app/src/main/java/sample/okta/android/browser/BrowserViewModel.kt
@@ -22,7 +22,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.okta.authfoundation.client.OidcClientResult
 import com.okta.authfoundationbootstrap.CredentialBootstrap
-import com.okta.webauthenticationui.WebAuthenticationClient.Companion.createWebAuthenticationClient
+import com.okta.webauthenticationui.WebAuthenticationClient
 import kotlinx.coroutines.launch
 import sample.okta.android.BuildConfig
 import sample.okta.android.SampleHelper
@@ -36,7 +36,7 @@ class BrowserViewModel : ViewModel() {
         viewModelScope.launch {
             _state.value = BrowserState.Loading
 
-            val webAuthenticationClient = CredentialBootstrap.oidcClient.createWebAuthenticationClient()
+            val webAuthenticationClient = WebAuthenticationClient()
             var scope = SampleHelper.DEFAULT_SCOPE
             if (addDeviceSsoScope) {
                 scope += " device_sso"

--- a/app/src/main/java/sample/okta/android/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/sample/okta/android/dashboard/DashboardViewModel.kt
@@ -26,7 +26,7 @@ import com.okta.authfoundation.credential.Credential
 import com.okta.authfoundation.credential.RevokeTokenType
 import com.okta.authfoundation.credential.TokenType
 import com.okta.authfoundationbootstrap.CredentialBootstrap
-import com.okta.webauthenticationui.WebAuthenticationClient.Companion.createWebAuthenticationClient
+import com.okta.webauthenticationui.WebAuthenticationClient
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.JsonObject
@@ -119,7 +119,7 @@ internal class DashboardViewModel(private val credentialTagNameValue: String?) :
         viewModelScope.launch {
             val idToken = credential.token?.idToken ?: return@launch
             when (
-                val result = CredentialBootstrap.oidcClient.createWebAuthenticationClient().logoutOfBrowser(
+                val result = WebAuthenticationClient().logoutOfBrowser(
                     context = context,
                     redirectUrl = BuildConfig.SIGN_OUT_REDIRECT_URI,
                     idToken = idToken,

--- a/app/src/main/java/sample/okta/android/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/sample/okta/android/dashboard/DashboardViewModel.kt
@@ -26,7 +26,7 @@ import com.okta.authfoundation.credential.Credential
 import com.okta.authfoundation.credential.RevokeTokenType
 import com.okta.authfoundation.credential.TokenType
 import com.okta.authfoundationbootstrap.CredentialBootstrap
-import com.okta.webauthenticationui.WebAuthenticationClient
+import com.okta.webauthenticationui.WebAuthentication
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.JsonObject
@@ -119,7 +119,7 @@ internal class DashboardViewModel(private val credentialTagNameValue: String?) :
         viewModelScope.launch {
             val idToken = credential.token?.idToken ?: return@launch
             when (
-                val result = WebAuthenticationClient().logoutOfBrowser(
+                val result = WebAuthentication().logoutOfBrowser(
                     context = context,
                     redirectUrl = BuildConfig.SIGN_OUT_REDIRECT_URI,
                     idToken = idToken,

--- a/app/src/main/java/sample/okta/android/deviceauthorization/DeviceAuthorizationViewModel.kt
+++ b/app/src/main/java/sample/okta/android/deviceauthorization/DeviceAuthorizationViewModel.kt
@@ -22,7 +22,6 @@ import androidx.lifecycle.viewModelScope
 import com.okta.authfoundation.client.OidcClientResult
 import com.okta.authfoundationbootstrap.CredentialBootstrap
 import com.okta.oauth2.DeviceAuthorizationFlow
-import com.okta.oauth2.DeviceAuthorizationFlow.Companion.createDeviceAuthorizationFlow
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -38,7 +37,7 @@ internal class DeviceAuthorizationViewModel : ViewModel() {
         _state.value = DeviceAuthorizationState.Loading
 
         viewModelScope.launch {
-            val deviceAuthorizationFlow = CredentialBootstrap.oidcClient.createDeviceAuthorizationFlow()
+            val deviceAuthorizationFlow = DeviceAuthorizationFlow()
             when (val result = deviceAuthorizationFlow.start()) {
                 is OidcClientResult.Error -> {
                     Timber.e(result.exception, "Failed to start device authorization flow.")

--- a/app/src/main/java/sample/okta/android/resourceowner/ResourceOwnerViewModel.kt
+++ b/app/src/main/java/sample/okta/android/resourceowner/ResourceOwnerViewModel.kt
@@ -21,7 +21,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.okta.authfoundation.client.OidcClientResult
 import com.okta.authfoundationbootstrap.CredentialBootstrap
-import com.okta.oauth2.ResourceOwnerFlow.Companion.createResourceOwnerFlow
+import com.okta.oauth2.ResourceOwnerFlow
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -33,7 +33,7 @@ internal class ResourceOwnerViewModel : ViewModel() {
         _state.value = ResourceOwnerState.Loading
 
         viewModelScope.launch {
-            val resourceOwnerFlow = CredentialBootstrap.oidcClient.createResourceOwnerFlow()
+            val resourceOwnerFlow = ResourceOwnerFlow()
             when (val result = resourceOwnerFlow.start(username, password)) {
                 is OidcClientResult.Error -> {
                     Timber.e(result.exception, "Failed to start resource owner flow.")

--- a/app/src/main/java/sample/okta/android/tokenexchange/TokenExchangeViewModel.kt
+++ b/app/src/main/java/sample/okta/android/tokenexchange/TokenExchangeViewModel.kt
@@ -21,7 +21,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.okta.authfoundation.client.OidcClientResult
 import com.okta.authfoundationbootstrap.CredentialBootstrap
-import com.okta.oauth2.TokenExchangeFlow.Companion.createTokenExchangeFlow
+import com.okta.oauth2.TokenExchangeFlow
 import kotlinx.coroutines.launch
 import sample.okta.android.SampleHelper
 import timber.log.Timber
@@ -47,7 +47,7 @@ class TokenExchangeViewModel : ViewModel() {
             val tokenExchangeCredential =
                 credentialDataSource.findCredential { it.tags[SampleHelper.CREDENTIAL_NAME_TAG_KEY] == NAME_TAG_VALUE }
                     .firstOrNull()
-            val tokenExchangeFlow = CredentialBootstrap.oidcClient.createTokenExchangeFlow()
+            val tokenExchangeFlow = TokenExchangeFlow()
             val idToken = credential?.token?.idToken
             if (idToken == null) {
                 _state.value = TokenExchangeState.Error("Missing Id Token")

--- a/auth-foundation/api/auth-foundation.api
+++ b/auth-foundation/api/auth-foundation.api
@@ -170,6 +170,7 @@ public final class com/okta/authfoundation/client/OidcClient {
 public final class com/okta/authfoundation/client/OidcClient$Companion {
 	public final fun create (Lcom/okta/authfoundation/client/OidcConfiguration;Lcom/okta/authfoundation/client/OidcEndpoints;)Lcom/okta/authfoundation/client/OidcClient;
 	public final fun createFromConfiguration (Lcom/okta/authfoundation/client/OidcConfiguration;)Lcom/okta/authfoundation/client/OidcClient;
+	public final fun getDefault ()Lcom/okta/authfoundation/client/OidcClient;
 }
 
 public abstract class com/okta/authfoundation/client/OidcClientResult {
@@ -201,7 +202,6 @@ public abstract interface class com/okta/authfoundation/client/OidcClock {
 
 public final class com/okta/authfoundation/client/OidcConfiguration {
 	public static final field Companion Lcom/okta/authfoundation/client/OidcConfiguration$Companion;
-	public static field default Lcom/okta/authfoundation/client/OidcConfiguration;
 	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Lcom/okta/authfoundation/client/OidcClock;Lcom/okta/authfoundation/client/IdTokenValidator;Lcom/okta/authfoundation/client/AccessTokenValidator;Lcom/okta/authfoundation/client/DeviceSecretValidator;Lkotlin/jvm/functions/Function1;Lokhttp3/CookieJar;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public final fun getAccessTokenValidator ()Lcom/okta/authfoundation/client/AccessTokenValidator;

--- a/auth-foundation/build.gradle
+++ b/auth-foundation/build.gradle
@@ -108,9 +108,6 @@ dependencies {
     androidTestImplementation deps.androidx_test.runner
     androidTestImplementation deps.androidx_test.rules
     androidTestImplementation deps.coroutines.test
-    androidTestImplementation(project(':test-helpers')) {
-        exclude group: "io.mockk"
-    }
 }
 
 preBuild.dependsOn(copyKotlinTemplates)

--- a/auth-foundation/src/androidTest/java/com/okta/testhelpers/RecordingEventHandler.kt
+++ b/auth-foundation/src/androidTest/java/com/okta/testhelpers/RecordingEventHandler.kt
@@ -1,0 +1,20 @@
+package com.okta.testhelpers
+
+import com.okta.authfoundation.events.EventHandler
+import java.util.Collections
+
+class RecordingEventHandler(
+    private val list: MutableList<Any> = Collections.synchronizedList(mutableListOf<Any>()),
+    private val nestedEventHandlers: MutableList<EventHandler> = Collections.synchronizedList(mutableListOf()),
+) : EventHandler, List<Any> by list {
+    override fun onEvent(event: Any) {
+        for (eventHandler in nestedEventHandlers) {
+            eventHandler.onEvent(event)
+        }
+        list += event
+    }
+
+    fun registerEventHandler(eventHandler: EventHandler) {
+        nestedEventHandlers += eventHandler
+    }
+}

--- a/auth-foundation/src/androidTest/java/com/okta/testhelpers/RecordingEventHandler.kt
+++ b/auth-foundation/src/androidTest/java/com/okta/testhelpers/RecordingEventHandler.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.okta.testhelpers
 
 import com.okta.authfoundation.events.EventHandler

--- a/auth-foundation/src/main/java/com/okta/authfoundation/client/OidcClient.kt
+++ b/auth-foundation/src/main/java/com/okta/authfoundation/client/OidcClient.kt
@@ -73,6 +73,7 @@ class OidcClient private constructor(
             )
         }
 
+        @InternalAuthFoundationApi
         fun create(configuration: OidcConfiguration, endpoints: OidcEndpoints): OidcClient {
             return OidcClient(
                 configuration = configuration,
@@ -82,6 +83,8 @@ class OidcClient private constructor(
                 ),
             )
         }
+
+        val default: OidcClient by lazy { createFromConfiguration(OidcConfiguration.default) }
     }
 
     private val jwks: CoalescingOrchestrator<OidcClientResult<Jwks>> = jwks ?: jwksCoalescingOrchestrator()

--- a/auth-foundation/src/main/java/com/okta/authfoundation/client/OidcConfiguration.kt
+++ b/auth-foundation/src/main/java/com/okta/authfoundation/client/OidcConfiguration.kt
@@ -131,8 +131,18 @@ class OidcConfiguration private constructor(
 
     companion object {
         internal fun defaultJson(): Json = Json { ignoreUnknownKeys = true }
+        private var _default: OidcConfiguration? = null
 
-        lateinit var default: OidcConfiguration
+        /**
+         * The default OidcConfiguration. This must be set before calling any OAuth flows. Note that this variable
+         * can only be set once in the lifetime of the app.
+         */
+        var default: OidcConfiguration
+            get() = _default ?: throw IllegalStateException("Attempted to use OidcConfiguration.default without setting it")
+            set(value) {
+                if (_default == null) _default = value
+                else throw IllegalStateException("Attempted setting OidcConfiguration.default after initialization")
+            }
     }
 }
 

--- a/legacy-token-migration-sample/src/main/java/sample/okta/android/legacy/SampleCredentialHelper.kt
+++ b/legacy-token-migration-sample/src/main/java/sample/okta/android/legacy/SampleCredentialHelper.kt
@@ -25,12 +25,11 @@ import com.okta.authfoundationbootstrap.CredentialBootstrap
 internal object SampleCredentialHelper {
     fun initialize(context: Context) {
         AuthFoundation.initializeAndroidContext(context)
-        val oidcConfiguration = OidcConfiguration(
+        OidcConfiguration.default = OidcConfiguration(
             clientId = BuildConfig.CLIENT_ID,
             defaultScope = "openid email profile offline_access",
             issuer = BuildConfig.ISSUER
         )
-        val oidcClient = OidcClient.createFromConfiguration(oidcConfiguration)
-        CredentialBootstrap.initialize(oidcClient.createCredentialDataSource(context))
+        CredentialBootstrap.initialize(OidcClient.default.createCredentialDataSource(context))
     }
 }

--- a/legacy-token-migration-sample/src/main/java/sample/okta/android/legacy/browser/BrowserViewModel.kt
+++ b/legacy-token-migration-sample/src/main/java/sample/okta/android/legacy/browser/BrowserViewModel.kt
@@ -22,7 +22,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.okta.authfoundation.client.OidcClientResult
 import com.okta.authfoundationbootstrap.CredentialBootstrap
-import com.okta.webauthenticationui.WebAuthenticationClient.Companion.createWebAuthenticationClient
+import com.okta.webauthenticationui.WebAuthenticationClient
 import kotlinx.coroutines.launch
 import sample.okta.android.legacy.BuildConfig
 import timber.log.Timber
@@ -35,7 +35,7 @@ class BrowserViewModel : ViewModel() {
         viewModelScope.launch {
             _state.value = BrowserState.Loading
 
-            val webAuthenticationClient = CredentialBootstrap.oidcClient.createWebAuthenticationClient()
+            val webAuthenticationClient = WebAuthenticationClient()
             when (val result = webAuthenticationClient.login(context, BuildConfig.SIGN_IN_REDIRECT_URI)) {
                 is OidcClientResult.Error -> {
                     Timber.e(result.exception, "Failed to login.")

--- a/legacy-token-migration-sample/src/main/java/sample/okta/android/legacy/browser/BrowserViewModel.kt
+++ b/legacy-token-migration-sample/src/main/java/sample/okta/android/legacy/browser/BrowserViewModel.kt
@@ -22,7 +22,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.okta.authfoundation.client.OidcClientResult
 import com.okta.authfoundationbootstrap.CredentialBootstrap
-import com.okta.webauthenticationui.WebAuthenticationClient
+import com.okta.webauthenticationui.WebAuthentication
 import kotlinx.coroutines.launch
 import sample.okta.android.legacy.BuildConfig
 import timber.log.Timber
@@ -35,8 +35,8 @@ class BrowserViewModel : ViewModel() {
         viewModelScope.launch {
             _state.value = BrowserState.Loading
 
-            val webAuthenticationClient = WebAuthenticationClient()
-            when (val result = webAuthenticationClient.login(context, BuildConfig.SIGN_IN_REDIRECT_URI)) {
+            val webAuthentication = WebAuthentication()
+            when (val result = webAuthentication.login(context, BuildConfig.SIGN_IN_REDIRECT_URI)) {
                 is OidcClientResult.Error -> {
                     Timber.e(result.exception, "Failed to login.")
                     _state.value = BrowserState.Error("Failed to login.")

--- a/legacy-token-migration-sample/src/main/java/sample/okta/android/legacy/dashboard/DashboardViewModel.kt
+++ b/legacy-token-migration-sample/src/main/java/sample/okta/android/legacy/dashboard/DashboardViewModel.kt
@@ -24,7 +24,7 @@ import com.okta.authfoundation.client.OidcClientResult
 import com.okta.authfoundation.credential.Credential
 import com.okta.authfoundation.credential.RevokeTokenType
 import com.okta.authfoundationbootstrap.CredentialBootstrap
-import com.okta.webauthenticationui.WebAuthenticationClient
+import com.okta.webauthenticationui.WebAuthentication
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.JsonObject
@@ -86,7 +86,7 @@ internal class DashboardViewModel : ViewModel() {
         viewModelScope.launch {
             val idToken = credential.token?.idToken ?: return@launch
             when (
-                val result = WebAuthenticationClient().logoutOfBrowser(
+                val result = WebAuthentication().logoutOfBrowser(
                     context = context,
                     redirectUrl = BuildConfig.SIGN_OUT_REDIRECT_URI,
                     idToken = idToken,

--- a/legacy-token-migration-sample/src/main/java/sample/okta/android/legacy/dashboard/DashboardViewModel.kt
+++ b/legacy-token-migration-sample/src/main/java/sample/okta/android/legacy/dashboard/DashboardViewModel.kt
@@ -24,7 +24,7 @@ import com.okta.authfoundation.client.OidcClientResult
 import com.okta.authfoundation.credential.Credential
 import com.okta.authfoundation.credential.RevokeTokenType
 import com.okta.authfoundationbootstrap.CredentialBootstrap
-import com.okta.webauthenticationui.WebAuthenticationClient.Companion.createWebAuthenticationClient
+import com.okta.webauthenticationui.WebAuthenticationClient
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.JsonObject
@@ -86,7 +86,7 @@ internal class DashboardViewModel : ViewModel() {
         viewModelScope.launch {
             val idToken = credential.token?.idToken ?: return@launch
             when (
-                val result = CredentialBootstrap.oidcClient.createWebAuthenticationClient().logoutOfBrowser(
+                val result = WebAuthenticationClient().logoutOfBrowser(
                     context = context,
                     redirectUrl = BuildConfig.SIGN_OUT_REDIRECT_URI,
                     idToken = idToken,

--- a/oauth2/api/oauth2.api
+++ b/oauth2/api/oauth2.api
@@ -1,13 +1,14 @@
 public final class com/okta/oauth2/AuthorizationCodeFlow {
 	public static final field Companion Lcom/okta/oauth2/AuthorizationCodeFlow$Companion;
-	public synthetic fun <init> (Lcom/okta/authfoundation/client/OidcClient;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> ()V
+	public fun <init> (Lcom/okta/authfoundation/client/OidcClient;)V
+	public fun <init> (Lcom/okta/authfoundation/client/OidcConfiguration;)V
 	public final fun resume (Landroid/net/Uri;Lcom/okta/oauth2/AuthorizationCodeFlow$Context;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun start (Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun start$default (Lcom/okta/oauth2/AuthorizationCodeFlow;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class com/okta/oauth2/AuthorizationCodeFlow$Companion {
-	public final fun createAuthorizationCodeFlow (Lcom/okta/authfoundation/client/OidcClient;)Lcom/okta/oauth2/AuthorizationCodeFlow;
 }
 
 public final class com/okta/oauth2/AuthorizationCodeFlow$Context {
@@ -26,14 +27,15 @@ public final class com/okta/oauth2/AuthorizationCodeFlow$ResumeException : java/
 
 public final class com/okta/oauth2/DeviceAuthorizationFlow {
 	public static final field Companion Lcom/okta/oauth2/DeviceAuthorizationFlow$Companion;
-	public synthetic fun <init> (Lcom/okta/authfoundation/client/OidcClient;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> ()V
+	public fun <init> (Lcom/okta/authfoundation/client/OidcClient;)V
+	public fun <init> (Lcom/okta/authfoundation/client/OidcConfiguration;)V
 	public final fun resume (Lcom/okta/oauth2/DeviceAuthorizationFlow$Context;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun start (Ljava/util/Map;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun start$default (Lcom/okta/oauth2/DeviceAuthorizationFlow;Ljava/util/Map;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class com/okta/oauth2/DeviceAuthorizationFlow$Companion {
-	public final fun createDeviceAuthorizationFlow (Lcom/okta/authfoundation/client/OidcClient;)Lcom/okta/oauth2/DeviceAuthorizationFlow;
 }
 
 public final class com/okta/oauth2/DeviceAuthorizationFlow$Context {
@@ -49,13 +51,14 @@ public final class com/okta/oauth2/DeviceAuthorizationFlow$TimeoutException : ja
 
 public final class com/okta/oauth2/RedirectEndSessionFlow {
 	public static final field Companion Lcom/okta/oauth2/RedirectEndSessionFlow$Companion;
-	public synthetic fun <init> (Lcom/okta/authfoundation/client/OidcClient;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> ()V
+	public fun <init> (Lcom/okta/authfoundation/client/OidcClient;)V
+	public fun <init> (Lcom/okta/authfoundation/client/OidcConfiguration;)V
 	public final fun resume (Landroid/net/Uri;Lcom/okta/oauth2/RedirectEndSessionFlow$Context;)Lcom/okta/authfoundation/client/OidcClientResult;
 	public final fun start (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class com/okta/oauth2/RedirectEndSessionFlow$Companion {
-	public final fun createRedirectEndSessionFlow (Lcom/okta/authfoundation/client/OidcClient;)Lcom/okta/oauth2/RedirectEndSessionFlow;
 }
 
 public final class com/okta/oauth2/RedirectEndSessionFlow$Context {
@@ -70,34 +73,33 @@ public final class com/okta/oauth2/RedirectEndSessionFlow$ResumeException : java
 
 public final class com/okta/oauth2/ResourceOwnerFlow {
 	public static final field Companion Lcom/okta/oauth2/ResourceOwnerFlow$Companion;
-	public synthetic fun <init> (Lcom/okta/authfoundation/client/OidcClient;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> ()V
+	public fun <init> (Lcom/okta/authfoundation/client/OidcClient;)V
+	public fun <init> (Lcom/okta/authfoundation/client/OidcConfiguration;)V
 	public final fun start (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun start$default (Lcom/okta/oauth2/ResourceOwnerFlow;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class com/okta/oauth2/ResourceOwnerFlow$Companion {
-	public final fun createResourceOwnerFlow (Lcom/okta/authfoundation/client/OidcClient;)Lcom/okta/oauth2/ResourceOwnerFlow;
 }
 
 public final class com/okta/oauth2/SessionTokenFlow {
-	public static final field Companion Lcom/okta/oauth2/SessionTokenFlow$Companion;
-	public synthetic fun <init> (Lcom/okta/authfoundation/client/OidcClient;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> ()V
+	public fun <init> (Lcom/okta/authfoundation/client/OidcClient;)V
+	public fun <init> (Lcom/okta/authfoundation/client/OidcConfiguration;)V
 	public final fun start (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun start$default (Lcom/okta/oauth2/SessionTokenFlow;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
-public final class com/okta/oauth2/SessionTokenFlow$Companion {
-	public final fun createSessionTokenFlow (Lcom/okta/authfoundation/client/OidcClient;)Lcom/okta/oauth2/SessionTokenFlow;
-}
-
 public final class com/okta/oauth2/TokenExchangeFlow {
 	public static final field Companion Lcom/okta/oauth2/TokenExchangeFlow$Companion;
-	public synthetic fun <init> (Lcom/okta/authfoundation/client/OidcClient;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> ()V
+	public fun <init> (Lcom/okta/authfoundation/client/OidcClient;)V
+	public fun <init> (Lcom/okta/authfoundation/client/OidcConfiguration;)V
 	public final fun start (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun start$default (Lcom/okta/oauth2/TokenExchangeFlow;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class com/okta/oauth2/TokenExchangeFlow$Companion {
-	public final fun createTokenExchangeFlow (Lcom/okta/authfoundation/client/OidcClient;)Lcom/okta/oauth2/TokenExchangeFlow;
 }
 

--- a/oauth2/src/main/java/com/okta/oauth2/AuthorizationCodeFlow.kt
+++ b/oauth2/src/main/java/com/okta/oauth2/AuthorizationCodeFlow.kt
@@ -38,15 +38,6 @@ class AuthorizationCodeFlow(
         init {
             SdkVersionsRegistry.register(SDK_VERSION)
         }
-
-        /**
-         * Initializes an authorization code flow using the [OidcClient].
-         *
-         * @receiver the [OidcClient] used to perform the low level OIDC requests, as well as with which to use the configuration from.
-         */
-        fun OidcClient.createAuthorizationCodeFlow(): AuthorizationCodeFlow {
-            return AuthorizationCodeFlow(this)
-        }
     }
 
     /**

--- a/oauth2/src/main/java/com/okta/oauth2/AuthorizationCodeFlow.kt
+++ b/oauth2/src/main/java/com/okta/oauth2/AuthorizationCodeFlow.kt
@@ -31,7 +31,7 @@ import java.util.UUID
  *
  * See [Authorization Code Flow documentation](https://developer.okta.com/docs/guides/implement-grant-type/authcodepkce/main/#about-the-authorization-code-grant-with-pkce)
  */
-class AuthorizationCodeFlow private constructor(
+class AuthorizationCodeFlow(
     private val oidcClient: OidcClient,
 ) {
     companion object {
@@ -48,6 +48,18 @@ class AuthorizationCodeFlow private constructor(
             return AuthorizationCodeFlow(this)
         }
     }
+
+    /**
+     * Initializes an authorization code flow.
+     */
+    constructor() : this(OidcClient.default)
+
+    /**
+     * Initializes an authorization code flow using the [OidcConfiguration].
+     *
+     * @param oidcConfiguration the [OidcConfiguration] specifying the authorization servers.
+     */
+    constructor(oidcConfiguration: OidcConfiguration) : this(OidcClient.createFromConfiguration(oidcConfiguration))
 
     /**
      * A model representing the context and current state for an authorization session.

--- a/oauth2/src/main/java/com/okta/oauth2/DeviceAuthorizationFlow.kt
+++ b/oauth2/src/main/java/com/okta/oauth2/DeviceAuthorizationFlow.kt
@@ -43,15 +43,6 @@ class DeviceAuthorizationFlow(
         init {
             SdkVersionsRegistry.register(SDK_VERSION)
         }
-
-        /**
-         * Initializes a device authorization grant flow using the [OidcClient].
-         *
-         * @receiver the [OidcClient] used to perform the low level OIDC requests, as well as with which to use the configuration from.
-         */
-        fun OidcClient.createDeviceAuthorizationFlow(): DeviceAuthorizationFlow {
-            return DeviceAuthorizationFlow(this)
-        }
     }
 
     /**

--- a/oauth2/src/main/java/com/okta/oauth2/DeviceAuthorizationFlow.kt
+++ b/oauth2/src/main/java/com/okta/oauth2/DeviceAuthorizationFlow.kt
@@ -36,7 +36,7 @@ import okhttp3.Request
  *
  * Upon visiting that URL and entering in the code, the user is prompted to sign in using their standard credentials. Upon completing authentication, the device automatically signs the user in, without any direct interaction on the user's part.
  */
-class DeviceAuthorizationFlow private constructor(
+class DeviceAuthorizationFlow(
     private val oidcClient: OidcClient,
 ) {
     companion object {
@@ -53,6 +53,18 @@ class DeviceAuthorizationFlow private constructor(
             return DeviceAuthorizationFlow(this)
         }
     }
+
+    /**
+     * Initializes a device authorization grant flow.
+     */
+    constructor() : this(OidcClient.default)
+
+    /**
+     * Initializes a device authorization grant flow using the [OidcConfiguration].
+     *
+     * @param oidcConfiguration the [OidcConfiguration] specifying the authorization servers.
+     */
+    constructor(oidcConfiguration: OidcConfiguration) : this(OidcClient.createFromConfiguration(oidcConfiguration))
 
     /**
      * A model representing the context and current state for an authorization session.

--- a/oauth2/src/main/java/com/okta/oauth2/RedirectEndSessionFlow.kt
+++ b/oauth2/src/main/java/com/okta/oauth2/RedirectEndSessionFlow.kt
@@ -35,15 +35,6 @@ class RedirectEndSessionFlow(
         init {
             SdkVersionsRegistry.register(SDK_VERSION)
         }
-
-        /**
-         * Initializes an end session redirect flow using the [OidcClient].
-         *
-         * @receiver the [OidcClient] used to perform the low level OIDC requests, as well as with which to use the configuration from.
-         */
-        fun OidcClient.createRedirectEndSessionFlow(): RedirectEndSessionFlow {
-            return RedirectEndSessionFlow(this)
-        }
     }
 
     /**

--- a/oauth2/src/main/java/com/okta/oauth2/RedirectEndSessionFlow.kt
+++ b/oauth2/src/main/java/com/okta/oauth2/RedirectEndSessionFlow.kt
@@ -18,6 +18,7 @@ package com.okta.oauth2
 import android.net.Uri
 import com.okta.authfoundation.client.OidcClient
 import com.okta.authfoundation.client.OidcClientResult
+import com.okta.authfoundation.client.OidcConfiguration
 import com.okta.authfoundation.client.internal.SdkVersionsRegistry
 import okhttp3.HttpUrl
 import java.util.UUID
@@ -27,7 +28,7 @@ import java.util.UUID
  *
  * > Note: OIDC Logout terminology is nuanced, see [Logout Documentation](https://github.com/okta/okta-mobile-kotlin#logout) for additional details.
  */
-class RedirectEndSessionFlow private constructor(
+class RedirectEndSessionFlow(
     private val oidcClient: OidcClient,
 ) {
     companion object {
@@ -44,6 +45,18 @@ class RedirectEndSessionFlow private constructor(
             return RedirectEndSessionFlow(this)
         }
     }
+
+    /**
+     * Initializes an end session redirect flow.
+     */
+    constructor() : this(OidcClient.default)
+
+    /**
+     * Initializes an end session redirect flow using [OidcConfiguration].
+     *
+     * @param oidcConfiguration the [OidcConfiguration] specifying the authorization servers.
+     */
+    constructor(oidcConfiguration: OidcConfiguration) : this(OidcClient.createFromConfiguration(oidcConfiguration))
 
     /**
      * A model representing the context and current state for a logout flow.

--- a/oauth2/src/main/java/com/okta/oauth2/ResourceOwnerFlow.kt
+++ b/oauth2/src/main/java/com/okta/oauth2/ResourceOwnerFlow.kt
@@ -30,7 +30,7 @@ import okhttp3.Request
  *
  * > Important: Resource Owner authentication does not support MFA or other more secure authentication models, and is not recommended for production applications.
  */
-class ResourceOwnerFlow private constructor(
+class ResourceOwnerFlow(
     private val oidcClient: OidcClient,
 ) {
     companion object {
@@ -47,6 +47,18 @@ class ResourceOwnerFlow private constructor(
             return ResourceOwnerFlow(this)
         }
     }
+
+    /**
+     * Initializes a resource owner flow.
+     */
+    constructor() : this(OidcClient.default)
+
+    /**
+     * Initializes a resource owner flow using the [OidcConfiguration].
+     *
+     * @param oidcConfiguration the [OidcConfiguration] specifying the authorization servers.
+     */
+    constructor(oidcConfiguration: OidcConfiguration) : this(OidcClient.createFromConfiguration(oidcConfiguration))
 
     /**
      * Initiates the Resource Owner flow.

--- a/oauth2/src/main/java/com/okta/oauth2/ResourceOwnerFlow.kt
+++ b/oauth2/src/main/java/com/okta/oauth2/ResourceOwnerFlow.kt
@@ -37,15 +37,6 @@ class ResourceOwnerFlow(
         init {
             SdkVersionsRegistry.register(SDK_VERSION)
         }
-
-        /**
-         * Initializes a resource owner flow using the [OidcClient].
-         *
-         * @receiver the [OidcClient] used to perform the low level OIDC requests, as well as with which to use the configuration from.
-         */
-        fun OidcClient.createResourceOwnerFlow(): ResourceOwnerFlow {
-            return ResourceOwnerFlow(this)
-        }
     }
 
     /**

--- a/oauth2/src/main/java/com/okta/oauth2/SessionTokenFlow.kt
+++ b/oauth2/src/main/java/com/okta/oauth2/SessionTokenFlow.kt
@@ -21,7 +21,6 @@ import com.okta.authfoundation.client.OidcClientResult
 import com.okta.authfoundation.client.OidcConfiguration
 import com.okta.authfoundation.client.internal.performRequest
 import com.okta.authfoundation.credential.Token
-import com.okta.oauth2.AuthorizationCodeFlow.Companion.createAuthorizationCodeFlow
 import okhttp3.Request
 
 /**
@@ -31,16 +30,6 @@ import okhttp3.Request
 class SessionTokenFlow(
     private val oidcClient: OidcClient,
 ) {
-    companion object {
-        /**
-         * Initializes a session token flow using the [OidcClient].
-         *
-         * @receiver the [OidcClient] used to perform the low level OIDC requests, as well as with which to use the configuration from.
-         */
-        fun OidcClient.createSessionTokenFlow(): SessionTokenFlow {
-            return SessionTokenFlow(this)
-        }
-    }
 
     /**
      * Initializes a session token flow.
@@ -69,7 +58,7 @@ class SessionTokenFlow(
         extraRequestParameters: Map<String, String> = emptyMap(),
         scope: String = oidcClient.configuration.defaultScope,
     ): OidcClientResult<Token> {
-        val authorizationCodeFlow = oidcClient.createAuthorizationCodeFlow()
+        val authorizationCodeFlow = AuthorizationCodeFlow(oidcClient)
         val mutableParameters = extraRequestParameters.toMutableMap()
         mutableParameters["sessionToken"] = sessionToken
         val flowContext = when (val startResult = authorizationCodeFlow.start(redirectUrl, mutableParameters, scope)) {

--- a/oauth2/src/main/java/com/okta/oauth2/SessionTokenFlow.kt
+++ b/oauth2/src/main/java/com/okta/oauth2/SessionTokenFlow.kt
@@ -28,7 +28,7 @@ import okhttp3.Request
  * [SessionTokenFlow] encapsulates the behavior required to authentication using a session token obtained from the Okta Legacy Authn
  * APIs.
  */
-class SessionTokenFlow private constructor(
+class SessionTokenFlow(
     private val oidcClient: OidcClient,
 ) {
     companion object {
@@ -41,6 +41,18 @@ class SessionTokenFlow private constructor(
             return SessionTokenFlow(this)
         }
     }
+
+    /**
+     * Initializes a session token flow.
+     */
+    constructor() : this(OidcClient.default)
+
+    /**
+     * Initializes a session token flow using the [OidcConfiguration].
+     *
+     * @param oidcConfiguration the [OidcConfiguration] specifying the authorization servers.
+     */
+    constructor(oidcConfiguration: OidcConfiguration) : this(OidcClient.createFromConfiguration(oidcConfiguration))
 
     /**
      * Initiates the Session Token Flow.

--- a/oauth2/src/main/java/com/okta/oauth2/TokenExchangeFlow.kt
+++ b/oauth2/src/main/java/com/okta/oauth2/TokenExchangeFlow.kt
@@ -30,23 +30,26 @@ import okhttp3.Request
  *
  * See the [specification](https://openid.net/specs/openid-connect-native-sso-1_0.html)
  */
-class TokenExchangeFlow private constructor(
+class TokenExchangeFlow(
     private val oidcClient: OidcClient,
 ) {
     companion object {
         init {
             SdkVersionsRegistry.register(SDK_VERSION)
         }
-
-        /**
-         * Initializes a token exchange flow using the [OidcClient].
-         *
-         * @receiver the [OidcClient] used to perform the low level OIDC requests, as well as with which to use the configuration from.
-         */
-        fun OidcClient.createTokenExchangeFlow(): TokenExchangeFlow {
-            return TokenExchangeFlow(this)
-        }
     }
+
+    /**
+     * Initializes a token exchange flow.
+     */
+    constructor() : this(OidcClient.default)
+
+    /**
+     * Initializes a token exchange flow using the [OidcConfiguration].
+     *
+     * @param oidcConfiguration the [OidcConfiguration] specifying the authorization servers.
+     */
+    constructor(oidcConfiguration: OidcConfiguration) : this(OidcClient.createFromConfiguration(oidcConfiguration))
 
     /**
      * Initiates the Token Exchange flow.

--- a/oauth2/src/test/java/com/okta/oauth2/DeviceAuthorizationFlowTest.kt
+++ b/oauth2/src/test/java/com/okta/oauth2/DeviceAuthorizationFlowTest.kt
@@ -16,11 +16,9 @@
 package com.okta.oauth2
 
 import com.google.common.truth.Truth.assertThat
-import com.okta.authfoundation.client.OidcClient
 import com.okta.authfoundation.client.OidcClientResult
 import com.okta.authfoundation.client.OidcEndpoints
 import com.okta.authfoundation.credential.Token
-import com.okta.oauth2.DeviceAuthorizationFlow.Companion.createDeviceAuthorizationFlow
 import com.okta.testhelpers.OktaRule
 import com.okta.testhelpers.RequestMatchers.body
 import com.okta.testhelpers.RequestMatchers.bodyPart
@@ -67,7 +65,7 @@ class DeviceAuthorizationFlowTest {
             response.setBody(minimalBody)
         }
 
-        val flow = oktaRule.createOidcClient().createDeviceAuthorizationFlow()
+        val flow = DeviceAuthorizationFlow()
         val startResult = (flow.start() as OidcClientResult.Success<DeviceAuthorizationFlow.Context>).result
 
         assertThat(startResult.deviceCode).isEqualTo("1a521d9f-0922-4e6d-8db9-8b654297435a")
@@ -82,9 +80,8 @@ class DeviceAuthorizationFlowTest {
         oktaRule.enqueue(path("/.well-known/openid-configuration")) { response ->
             response.setResponseCode(503)
         }
-        val client = OidcClient.createFromConfiguration(oktaRule.configuration)
 
-        val flow = client.createDeviceAuthorizationFlow()
+        val flow = DeviceAuthorizationFlow(oktaRule.configuration)
         val startResult = flow.start() as OidcClientResult.Error<DeviceAuthorizationFlow.Context>
         assertThat(startResult.exception).isInstanceOf(OidcClientResult.Error.OidcEndpointsNotAvailableException::class.java)
         assertThat(startResult.exception).hasMessageThat().isEqualTo("OIDC Endpoints not available.")
@@ -93,7 +90,7 @@ class DeviceAuthorizationFlowTest {
     @Test fun testStartWithNoDeviceAuthorizationEndpoints(): Unit = runBlocking {
         val client = oktaRule.createOidcClient(oktaRule.createEndpoints().copy(deviceAuthorizationEndpoint = null))
 
-        val flow = client.createDeviceAuthorizationFlow()
+        val flow = DeviceAuthorizationFlow(client)
         val startResult = flow.start() as OidcClientResult.Error<DeviceAuthorizationFlow.Context>
         assertThat(startResult.exception).isInstanceOf(OidcClientResult.Error.OidcEndpointsNotAvailableException::class.java)
     }
@@ -108,7 +105,7 @@ class DeviceAuthorizationFlowTest {
             response.setBody(successBody)
         }
 
-        val flow = oktaRule.createOidcClient().createDeviceAuthorizationFlow()
+        val flow = DeviceAuthorizationFlow()
         val startResult = (flow.start() as OidcClientResult.Success<DeviceAuthorizationFlow.Context>).result
 
         assertThat(startResult.deviceCode).isEqualTo("1a521d9f-0922-4e6d-8db9-8b654297435a")
@@ -130,7 +127,7 @@ class DeviceAuthorizationFlowTest {
             response.setBody(successBody)
         }
 
-        val flow = oktaRule.createOidcClient().createDeviceAuthorizationFlow()
+        val flow = DeviceAuthorizationFlow()
         val startResult = (
             flow.start(
                 extraRequestParameters = mapOf(Pair("foo", "bar")),
@@ -150,7 +147,7 @@ class DeviceAuthorizationFlowTest {
             response.setResponseCode(500)
         }
 
-        val flow = oktaRule.createOidcClient().createDeviceAuthorizationFlow()
+        val flow = DeviceAuthorizationFlow()
         val startResult = flow.start() as OidcClientResult.Error<DeviceAuthorizationFlow.Context>
 
         assertThat(startResult.exception).isInstanceOf(OidcClientResult.Error.HttpResponseException::class.java)
@@ -161,9 +158,8 @@ class DeviceAuthorizationFlowTest {
         oktaRule.enqueue(path("/.well-known/openid-configuration")) { response ->
             response.setResponseCode(503)
         }
-        val client = OidcClient.createFromConfiguration(oktaRule.configuration)
 
-        val flow = client.createDeviceAuthorizationFlow()
+        val flow = DeviceAuthorizationFlow(oktaRule.configuration)
         val context = mock<DeviceAuthorizationFlow.Context>()
         val resumeResult = flow.resume(context) as OidcClientResult.Error<Token>
 
@@ -180,7 +176,7 @@ class DeviceAuthorizationFlowTest {
             response.testBodyFromFile("$mockPrefix/token.json")
         }
 
-        val flow = oktaRule.createOidcClient().createDeviceAuthorizationFlow()
+        val flow = DeviceAuthorizationFlow()
         val context = DeviceAuthorizationFlow.Context(
             deviceCode = "1a521d9f-0922-4e6d-8db9-8b654297435a",
             interval = 5,
@@ -219,7 +215,7 @@ class DeviceAuthorizationFlowTest {
             response.testBodyFromFile("$mockPrefix/token.json")
         }
 
-        val flow = oktaRule.createOidcClient().createDeviceAuthorizationFlow()
+        val flow = DeviceAuthorizationFlow()
         val context = DeviceAuthorizationFlow.Context(
             deviceCode = "1a521d9f-0922-4e6d-8db9-8b654297435a",
             interval = 5,
@@ -258,7 +254,7 @@ class DeviceAuthorizationFlowTest {
             response.testBodyFromFile("$mockPrefix/token.json")
         }
 
-        val flow = oktaRule.createOidcClient().createDeviceAuthorizationFlow()
+        val flow = DeviceAuthorizationFlow()
         val context = DeviceAuthorizationFlow.Context(
             deviceCode = "1a521d9f-0922-4e6d-8db9-8b654297435a",
             interval = 5,
@@ -291,7 +287,7 @@ class DeviceAuthorizationFlowTest {
             }
         }
 
-        val flow = oktaRule.createOidcClient().createDeviceAuthorizationFlow()
+        val flow = DeviceAuthorizationFlow()
         val context = DeviceAuthorizationFlow.Context(
             deviceCode = "1a521d9f-0922-4e6d-8db9-8b654297435a",
             interval = 5,
@@ -319,7 +315,7 @@ class DeviceAuthorizationFlowTest {
             response.setResponseCode(400)
         }
 
-        val flow = oktaRule.createOidcClient().createDeviceAuthorizationFlow()
+        val flow = DeviceAuthorizationFlow()
         val context = DeviceAuthorizationFlow.Context(
             deviceCode = "1a521d9f-0922-4e6d-8db9-8b654297435a",
             interval = 5,

--- a/oauth2/src/test/java/com/okta/oauth2/ResourceOwnerFlowTest.kt
+++ b/oauth2/src/test/java/com/okta/oauth2/ResourceOwnerFlowTest.kt
@@ -16,10 +16,8 @@
 package com.okta.oauth2
 
 import com.google.common.truth.Truth.assertThat
-import com.okta.authfoundation.client.OidcClient
 import com.okta.authfoundation.client.OidcClientResult
 import com.okta.authfoundation.credential.Token
-import com.okta.oauth2.ResourceOwnerFlow.Companion.createResourceOwnerFlow
 import com.okta.testhelpers.OktaRule
 import com.okta.testhelpers.RequestMatchers.body
 import com.okta.testhelpers.RequestMatchers.method
@@ -42,7 +40,7 @@ class ResourceOwnerFlowTest {
         ) { response ->
             response.testBodyFromFile("$mockPrefix/token.json")
         }
-        val resourceOwnerFlow = oktaRule.createOidcClient().createResourceOwnerFlow()
+        val resourceOwnerFlow = ResourceOwnerFlow()
         val result = resourceOwnerFlow.start("foo", "bar")
         val token = (result as OidcClientResult.Success<Token>).result
         assertThat(token.tokenType).isEqualTo("Bearer")
@@ -61,7 +59,7 @@ class ResourceOwnerFlowTest {
         ) { response ->
             response.testBodyFromFile("$mockPrefix/token.json")
         }
-        val resourceOwnerFlow = oktaRule.createOidcClient().createResourceOwnerFlow()
+        val resourceOwnerFlow = ResourceOwnerFlow()
         val result = resourceOwnerFlow.start("foo", "bar", "openid custom")
         val token = (result as OidcClientResult.Success<Token>).result
         assertThat(token.tokenType).isEqualTo("Bearer")
@@ -71,8 +69,7 @@ class ResourceOwnerFlowTest {
         oktaRule.enqueue(path("/.well-known/openid-configuration")) { response ->
             response.setResponseCode(503)
         }
-        val client = OidcClient.createFromConfiguration(oktaRule.configuration)
-        val resourceOwnerFlow = client.createResourceOwnerFlow()
+        val resourceOwnerFlow = ResourceOwnerFlow(oktaRule.configuration)
         val result = resourceOwnerFlow.start("foo", "bar")
         assertThat(result).isInstanceOf(OidcClientResult.Error::class.java)
         val errorResult = result as OidcClientResult.Error<Token>
@@ -86,7 +83,7 @@ class ResourceOwnerFlowTest {
         ) { response ->
             response.setResponseCode(503)
         }
-        val resourceOwnerFlow = oktaRule.createOidcClient().createResourceOwnerFlow()
+        val resourceOwnerFlow = ResourceOwnerFlow()
         val result = resourceOwnerFlow.start("foo", "bar")
         assertThat(result).isInstanceOf(OidcClientResult.Error::class.java)
         val errorResult = result as OidcClientResult.Error<Token>

--- a/oauth2/src/test/java/com/okta/oauth2/SessionTokenFlowTest.kt
+++ b/oauth2/src/test/java/com/okta/oauth2/SessionTokenFlowTest.kt
@@ -16,10 +16,8 @@
 package com.okta.oauth2
 
 import com.google.common.truth.Truth.assertThat
-import com.okta.authfoundation.client.OidcClient
 import com.okta.authfoundation.client.OidcClientResult
 import com.okta.authfoundation.credential.Token
-import com.okta.oauth2.SessionTokenFlow.Companion.createSessionTokenFlow
 import com.okta.testhelpers.OktaRule
 import com.okta.testhelpers.RequestMatchers.bodyPart
 import com.okta.testhelpers.RequestMatchers.method
@@ -66,7 +64,7 @@ internal class SessionTokenFlowTest {
         ) { response ->
             response.testBodyFromFile("$mockPrefix/token.json")
         }
-        val sessionTokenFlow = oktaRule.createOidcClient().createSessionTokenFlow()
+        val sessionTokenFlow = SessionTokenFlow()
         val result = sessionTokenFlow.start("exampleSessionToken", "exampleRedirect:/callback")
         val token = (result as OidcClientResult.Success<Token>).result
         assertThat(token.tokenType).isEqualTo("Bearer")
@@ -83,8 +81,7 @@ internal class SessionTokenFlowTest {
         oktaRule.enqueue(path("/.well-known/openid-configuration")) { response ->
             response.setResponseCode(503)
         }
-        val client = OidcClient.createFromConfiguration(oktaRule.configuration)
-        val sessionTokenFlow = client.createSessionTokenFlow()
+        val sessionTokenFlow = SessionTokenFlow(oktaRule.configuration)
         val result = sessionTokenFlow.start("exampleSessionToken", "exampleRedirect:/callback")
         assertThat(result).isInstanceOf(OidcClientResult.Error::class.java)
         val errorResult = result as OidcClientResult.Error<Token>
@@ -99,7 +96,7 @@ internal class SessionTokenFlowTest {
         ) { response ->
             response.socketPolicy = SocketPolicy.DISCONNECT_AFTER_REQUEST
         }
-        val sessionTokenFlow = oktaRule.createOidcClient().createSessionTokenFlow()
+        val sessionTokenFlow = SessionTokenFlow()
         val result = sessionTokenFlow.start("exampleSessionToken", "exampleRedirect:/callback")
         val exception = (result as OidcClientResult.Error<Token>).exception
         assertThat(exception).isInstanceOf(ConnectException::class.java)
@@ -123,7 +120,7 @@ internal class SessionTokenFlowTest {
         ) { response ->
             response.setResponseCode(403)
         }
-        val sessionTokenFlow = oktaRule.createOidcClient().createSessionTokenFlow()
+        val sessionTokenFlow = SessionTokenFlow()
         val result = sessionTokenFlow.start("exampleSessionToken", "exampleRedirect:/callback")
         val exception = (result as OidcClientResult.Error<Token>).exception
         assertThat(exception).isInstanceOf(OidcClientResult.Error.HttpResponseException::class.java)
@@ -152,7 +149,7 @@ internal class SessionTokenFlowTest {
         ) { response ->
             response.testBodyFromFile("$mockPrefix/token.json")
         }
-        val sessionTokenFlow = oktaRule.createOidcClient().createSessionTokenFlow()
+        val sessionTokenFlow = SessionTokenFlow()
         val result = sessionTokenFlow.start(
             sessionToken = "exampleSessionToken",
             redirectUrl = "exampleRedirect:/callback",

--- a/oauth2/src/test/java/com/okta/oauth2/TokenExchangeFlowTest.kt
+++ b/oauth2/src/test/java/com/okta/oauth2/TokenExchangeFlowTest.kt
@@ -19,7 +19,6 @@ import com.google.common.truth.Truth.assertThat
 import com.okta.authfoundation.client.OidcClient
 import com.okta.authfoundation.client.OidcClientResult
 import com.okta.authfoundation.credential.Token
-import com.okta.oauth2.TokenExchangeFlow.Companion.createTokenExchangeFlow
 import com.okta.testhelpers.OktaRule
 import com.okta.testhelpers.RequestMatchers.body
 import com.okta.testhelpers.RequestMatchers.method
@@ -35,8 +34,8 @@ class TokenExchangeFlowTest {
         oktaRule.enqueue(path("/.well-known/openid-configuration")) { response ->
             response.setResponseCode(503)
         }
-        val client = OidcClient.createFromConfiguration(oktaRule.configuration)
-        val flow = client.createTokenExchangeFlow()
+        oktaRule.oidcClient = OidcClient.createFromConfiguration(oktaRule.configuration)
+        val flow = TokenExchangeFlow()
         val result = flow.start("foo", "bar")
         assertThat(result).isInstanceOf(OidcClientResult.Error::class.java)
         val errorResult = result as OidcClientResult.Error<Token>
@@ -53,7 +52,7 @@ class TokenExchangeFlowTest {
             response.setResponseCode(503)
         }
 
-        val flow = oktaRule.createOidcClient().createTokenExchangeFlow()
+        val flow = TokenExchangeFlow()
         val result = flow.start("foo", "bar") as OidcClientResult.Error<Token>
         assertThat(result.exception).isInstanceOf(OidcClientResult.Error.HttpResponseException::class.java)
         assertThat(result.exception).hasMessageThat().isEqualTo("HTTP Error: status code - 503")
@@ -79,7 +78,7 @@ class TokenExchangeFlowTest {
             response.setBody(body)
         }
 
-        val flow = oktaRule.createOidcClient().createTokenExchangeFlow()
+        val flow = TokenExchangeFlow()
         val result = flow.start("foo", "bar") as OidcClientResult.Success<Token>
         assertThat(result.result.accessToken).isEqualTo("exampleAccessToken")
         assertThat(result.result.issuedTokenType).isEqualTo("urn:ietf:params:oauth:token-type:access_token")
@@ -105,7 +104,7 @@ class TokenExchangeFlowTest {
             response.setBody(body)
         }
 
-        val flow = oktaRule.createOidcClient().createTokenExchangeFlow()
+        val flow = TokenExchangeFlow()
         val result = flow.start("foo", "bar", "non_default_audience", scope = "openid profile custom_for_test") as OidcClientResult.Success<Token>
         assertThat(result.result.accessToken).isEqualTo("exampleAccessToken")
         assertThat(result.result.issuedTokenType).isEqualTo("urn:ietf:params:oauth:token-type:access_token")

--- a/oauth2/src/test/java/com/okta/oauth2/TokenExchangeFlowTest.kt
+++ b/oauth2/src/test/java/com/okta/oauth2/TokenExchangeFlowTest.kt
@@ -16,7 +16,6 @@
 package com.okta.oauth2
 
 import com.google.common.truth.Truth.assertThat
-import com.okta.authfoundation.client.OidcClient
 import com.okta.authfoundation.client.OidcClientResult
 import com.okta.authfoundation.credential.Token
 import com.okta.testhelpers.OktaRule
@@ -34,8 +33,7 @@ class TokenExchangeFlowTest {
         oktaRule.enqueue(path("/.well-known/openid-configuration")) { response ->
             response.setResponseCode(503)
         }
-        oktaRule.oidcClient = OidcClient.createFromConfiguration(oktaRule.configuration)
-        val flow = TokenExchangeFlow()
+        val flow = TokenExchangeFlow(oktaRule.configuration)
         val result = flow.start("foo", "bar")
         assertThat(result).isInstanceOf(OidcClientResult.Error::class.java)
         val errorResult = result as OidcClientResult.Error<Token>

--- a/session-token-sample/src/main/java/sample/okta/android/sessiontoken/SampleCredentialHelper.kt
+++ b/session-token-sample/src/main/java/sample/okta/android/sessiontoken/SampleCredentialHelper.kt
@@ -25,12 +25,11 @@ import com.okta.authfoundationbootstrap.CredentialBootstrap
 internal object SampleCredentialHelper {
     fun initialize(context: Context) {
         AuthFoundation.initializeAndroidContext(context)
-        val oidcConfiguration = OidcConfiguration(
+        OidcConfiguration.default = OidcConfiguration(
             clientId = BuildConfig.CLIENT_ID,
             defaultScope = "openid email profile offline_access",
             issuer = BuildConfig.ISSUER
         )
-        val oidcClient = OidcClient.createFromConfiguration(oidcConfiguration)
-        CredentialBootstrap.initialize(oidcClient.createCredentialDataSource(context))
+        CredentialBootstrap.initialize(OidcClient.default.createCredentialDataSource(context))
     }
 }

--- a/session-token-sample/src/main/java/sample/okta/android/sessiontoken/sessiontoken/SessionTokenViewModel.kt
+++ b/session-token-sample/src/main/java/sample/okta/android/sessiontoken/sessiontoken/SessionTokenViewModel.kt
@@ -24,7 +24,7 @@ import com.okta.authfoundationbootstrap.CredentialBootstrap
 import com.okta.authn.sdk.AuthenticationStateHandlerAdapter
 import com.okta.authn.sdk.client.AuthenticationClients
 import com.okta.authn.sdk.resource.AuthenticationResponse
-import com.okta.oauth2.SessionTokenFlow.Companion.createSessionTokenFlow
+import com.okta.oauth2.SessionTokenFlow
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -67,7 +67,7 @@ class SessionTokenViewModel : ViewModel() {
 
     private fun completeLoginWithSessionToken(sessionToken: String) {
         viewModelScope.launch(Dispatchers.Main) {
-            val sessionTokenFlow = CredentialBootstrap.oidcClient.createSessionTokenFlow()
+            val sessionTokenFlow = SessionTokenFlow()
             when (val result = sessionTokenFlow.start(sessionToken, BuildConfig.SIGN_IN_REDIRECT_URI)) {
                 is OidcClientResult.Error -> {
                     Timber.e(result.exception, "Failed to login.")

--- a/test-helpers/src/main/java/com/okta/testhelpers/OktaRule.kt
+++ b/test-helpers/src/main/java/com/okta/testhelpers/OktaRule.kt
@@ -53,7 +53,26 @@ class OktaRule(
     val eventHandler: RecordingEventHandler = RecordingEventHandler()
     val clock: TestClock = TestClock()
 
-    val configuration: OidcConfiguration = createConfiguration()
+    var configuration: OidcConfiguration = createConfiguration()
+        set(value) {
+            mockkObject(OidcConfiguration)
+            every { OidcConfiguration.default } returns value
+            field = value
+        }
+
+    var oidcClient: OidcClient = createOidcClient()
+        set(value) {
+            mockkObject(OidcClient)
+            every { OidcClient.default } returns value
+            field = value
+        }
+
+    init {
+        mockkObject(OidcConfiguration)
+        mockkObject(OidcClient)
+        every { OidcConfiguration.default } returns configuration
+        every { OidcClient.default } returns oidcClient
+    }
 
     fun createConfiguration(
         okHttpClient: OkHttpClient = this.okHttpClient,

--- a/web-authentication-ui/api/web-authentication-ui.api
+++ b/web-authentication-ui/api/web-authentication-ui.api
@@ -30,20 +30,27 @@ public final class com/okta/webauthenticationui/ForegroundViewModel$State$Launch
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
-public final class com/okta/webauthenticationui/WebAuthenticationClient {
-	public static final field Companion Lcom/okta/webauthenticationui/WebAuthenticationClient$Companion;
-	public synthetic fun <init> (Lcom/okta/authfoundation/client/OidcClient;Lcom/okta/webauthenticationui/WebAuthenticationProvider;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class com/okta/webauthenticationui/WebAuthentication {
+	public static final field Companion Lcom/okta/webauthenticationui/WebAuthentication$Companion;
+	public fun <init> (Lcom/okta/authfoundation/client/OidcClient;Lcom/okta/webauthenticationui/WebAuthenticationProvider;)V
+	public synthetic fun <init> (Lcom/okta/authfoundation/client/OidcClient;Lcom/okta/webauthenticationui/WebAuthenticationProvider;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/okta/authfoundation/client/OidcConfiguration;Lcom/okta/webauthenticationui/WebAuthenticationProvider;)V
+	public synthetic fun <init> (Lcom/okta/authfoundation/client/OidcConfiguration;Lcom/okta/webauthenticationui/WebAuthenticationProvider;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/okta/webauthenticationui/WebAuthenticationProvider;)V
+	public synthetic fun <init> (Lcom/okta/webauthenticationui/WebAuthenticationProvider;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAuthorizationCodeFlow ()Lcom/okta/oauth2/AuthorizationCodeFlow;
+	public final fun getRedirectEndSessionFlow ()Lcom/okta/oauth2/RedirectEndSessionFlow;
 	public final fun login (Landroid/content/Context;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun login$default (Lcom/okta/webauthenticationui/WebAuthenticationClient;Landroid/content/Context;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun login$default (Lcom/okta/webauthenticationui/WebAuthentication;Landroid/content/Context;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun logoutOfBrowser (Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun setAuthorizationCodeFlow (Lcom/okta/oauth2/AuthorizationCodeFlow;)V
+	public final fun setRedirectEndSessionFlow (Lcom/okta/oauth2/RedirectEndSessionFlow;)V
 }
 
-public final class com/okta/webauthenticationui/WebAuthenticationClient$Companion {
-	public final fun createWebAuthenticationClient (Lcom/okta/authfoundation/client/OidcClient;Lcom/okta/webauthenticationui/WebAuthenticationProvider;)Lcom/okta/webauthenticationui/WebAuthenticationClient;
-	public static synthetic fun createWebAuthenticationClient$default (Lcom/okta/webauthenticationui/WebAuthenticationClient$Companion;Lcom/okta/authfoundation/client/OidcClient;Lcom/okta/webauthenticationui/WebAuthenticationProvider;ILjava/lang/Object;)Lcom/okta/webauthenticationui/WebAuthenticationClient;
+public final class com/okta/webauthenticationui/WebAuthentication$Companion {
 }
 
-public final class com/okta/webauthenticationui/WebAuthenticationClient$FlowCancelledException : java/lang/Exception {
+public final class com/okta/webauthenticationui/WebAuthentication$FlowCancelledException : java/lang/Exception {
 }
 
 public abstract interface class com/okta/webauthenticationui/WebAuthenticationProvider {

--- a/web-authentication-ui/src/main/java/com/okta/webauthenticationui/RedirectCoordinator.kt
+++ b/web-authentication-ui/src/main/java/com/okta/webauthenticationui/RedirectCoordinator.kt
@@ -139,7 +139,7 @@ internal class DefaultRedirectCoordinator(
             // accepting the error.
             emitErrorJob = coroutineScope.launch {
                 delay(AuthFoundationDefaults.loginCancellationDebounceTime)
-                val exception = WebAuthenticationClient.FlowCancelledException()
+                val exception = WebAuthentication.FlowCancelledException()
                 initializationContinuation?.resume(RedirectInitializationResult.Error<Any>(exception))
                 val localContinuation = redirectContinuation
                 reset()

--- a/web-authentication-ui/src/main/java/com/okta/webauthenticationui/WebAuthentication.kt
+++ b/web-authentication-ui/src/main/java/com/okta/webauthenticationui/WebAuthentication.kt
@@ -38,7 +38,7 @@ import com.okta.webauthenticationui.events.CustomizeCustomTabsEvent
  * To further customize the authentication flow, please read more about the underlying flows: [AuthorizationCodeFlow],
  * [RedirectEndSessionFlow].
  */
-class WebAuthenticationClient(
+class WebAuthentication(
     private val oidcClient: OidcClient,
     private val webAuthenticationProvider: WebAuthenticationProvider = DefaultWebAuthenticationProvider(oidcClient.configuration.eventCoordinator),
 ) {
@@ -70,8 +70,8 @@ class WebAuthenticationClient(
         webAuthenticationProvider: WebAuthenticationProvider = DefaultWebAuthenticationProvider(oidcConfiguration.eventCoordinator)
     ) : this(OidcClient.createFromConfiguration(oidcConfiguration), webAuthenticationProvider)
 
-    private val authorizationCodeFlow: AuthorizationCodeFlow = AuthorizationCodeFlow(oidcClient)
-    private val redirectEndSessionFlow: RedirectEndSessionFlow = RedirectEndSessionFlow(oidcClient)
+    var authorizationCodeFlow: AuthorizationCodeFlow = AuthorizationCodeFlow(oidcClient)
+    var redirectEndSessionFlow: RedirectEndSessionFlow = RedirectEndSessionFlow(oidcClient)
 
     @VisibleForTesting internal var redirectCoordinator: RedirectCoordinator = SingletonRedirectCoordinator
 

--- a/web-authentication-ui/src/main/java/com/okta/webauthenticationui/WebAuthenticationClient.kt
+++ b/web-authentication-ui/src/main/java/com/okta/webauthenticationui/WebAuthenticationClient.kt
@@ -24,9 +24,7 @@ import com.okta.authfoundation.client.OidcConfiguration
 import com.okta.authfoundation.client.internal.SdkVersionsRegistry
 import com.okta.authfoundation.credential.Token
 import com.okta.oauth2.AuthorizationCodeFlow
-import com.okta.oauth2.AuthorizationCodeFlow.Companion.createAuthorizationCodeFlow
 import com.okta.oauth2.RedirectEndSessionFlow
-import com.okta.oauth2.RedirectEndSessionFlow.Companion.createRedirectEndSessionFlow
 import com.okta.webauthenticationui.events.CustomizeBrowserEvent
 import com.okta.webauthenticationui.events.CustomizeCustomTabsEvent
 
@@ -47,19 +45,6 @@ class WebAuthenticationClient(
     companion object {
         init {
             SdkVersionsRegistry.register(SDK_VERSION)
-        }
-
-        /**
-         * Initializes a web authentication client using the [OidcClient].
-         *
-         * @receiver the [OidcClient] used to perform the low level OIDC requests, as well as with which to use the configuration from.
-         * @param webAuthenticationProvider the [WebAuthenticationProvider] which will be used to show the UI when performing the
-         * redirect flows.
-         */
-        fun OidcClient.createWebAuthenticationClient(
-            webAuthenticationProvider: WebAuthenticationProvider = DefaultWebAuthenticationProvider(configuration.eventCoordinator)
-        ): WebAuthenticationClient {
-            return WebAuthenticationClient(this, webAuthenticationProvider)
         }
     }
 
@@ -85,8 +70,8 @@ class WebAuthenticationClient(
         webAuthenticationProvider: WebAuthenticationProvider = DefaultWebAuthenticationProvider(oidcConfiguration.eventCoordinator)
     ) : this(OidcClient.createFromConfiguration(oidcConfiguration), webAuthenticationProvider)
 
-    private val authorizationCodeFlow: AuthorizationCodeFlow = oidcClient.createAuthorizationCodeFlow()
-    private val redirectEndSessionFlow: RedirectEndSessionFlow = oidcClient.createRedirectEndSessionFlow()
+    private val authorizationCodeFlow: AuthorizationCodeFlow = AuthorizationCodeFlow(oidcClient)
+    private val redirectEndSessionFlow: RedirectEndSessionFlow = RedirectEndSessionFlow(oidcClient)
 
     @VisibleForTesting internal var redirectCoordinator: RedirectCoordinator = SingletonRedirectCoordinator
 

--- a/web-authentication-ui/src/main/java/com/okta/webauthenticationui/WebAuthenticationClient.kt
+++ b/web-authentication-ui/src/main/java/com/okta/webauthenticationui/WebAuthenticationClient.kt
@@ -40,9 +40,9 @@ import com.okta.webauthenticationui.events.CustomizeCustomTabsEvent
  * To further customize the authentication flow, please read more about the underlying flows: [AuthorizationCodeFlow],
  * [RedirectEndSessionFlow].
  */
-class WebAuthenticationClient private constructor(
+class WebAuthenticationClient(
     private val oidcClient: OidcClient,
-    private val webAuthenticationProvider: WebAuthenticationProvider,
+    private val webAuthenticationProvider: WebAuthenticationProvider = DefaultWebAuthenticationProvider(oidcClient.configuration.eventCoordinator),
 ) {
     companion object {
         init {
@@ -62,6 +62,28 @@ class WebAuthenticationClient private constructor(
             return WebAuthenticationClient(this, webAuthenticationProvider)
         }
     }
+
+    /**
+     * Initializes a web authentication client.
+     *
+     * @param webAuthenticationProvider the [WebAuthenticationProvider] which will be used to show the UI when performing the
+     * redirect flows.
+     */
+    constructor(
+        webAuthenticationProvider: WebAuthenticationProvider = DefaultWebAuthenticationProvider(OidcConfiguration.default.eventCoordinator)
+    ) : this(OidcClient.default, webAuthenticationProvider)
+
+    /**
+     * Initializes a web authentication client.
+     *
+     * @param oidcConfiguration the [OidcConfiguration] specifying the authorization servers.
+     * @param webAuthenticationProvider the [WebAuthenticationProvider] which will be used to show the UI when performing the
+     * redirect flows.
+     */
+    constructor(
+        oidcConfiguration: OidcConfiguration,
+        webAuthenticationProvider: WebAuthenticationProvider = DefaultWebAuthenticationProvider(oidcConfiguration.eventCoordinator)
+    ) : this(OidcClient.createFromConfiguration(oidcConfiguration), webAuthenticationProvider)
 
     private val authorizationCodeFlow: AuthorizationCodeFlow = oidcClient.createAuthorizationCodeFlow()
     private val redirectEndSessionFlow: RedirectEndSessionFlow = oidcClient.createRedirectEndSessionFlow()

--- a/web-authentication-ui/src/main/java/com/okta/webauthenticationui/WebAuthenticationProvider.kt
+++ b/web-authentication-ui/src/main/java/com/okta/webauthenticationui/WebAuthenticationProvider.kt
@@ -32,11 +32,11 @@ import com.okta.webauthenticationui.events.CustomizeCustomTabsEvent
 import okhttp3.HttpUrl
 
 /**
- * Used to launch the OIDC redirect flow associated with a [WebAuthenticationClient].
+ * Used to launch the OIDC redirect flow associated with a [WebAuthentication].
  */
 interface WebAuthenticationProvider {
     /**
-     * Launches the OIDC redirect flow associated with a [WebAuthenticationClient].
+     * Launches the OIDC redirect flow associated with a [WebAuthentication].
      *
      * @param context the Android [Activity] [Context] which is used to display the flow.
      * @param url the url the instance should display.

--- a/web-authentication-ui/src/main/java/com/okta/webauthenticationui/events/CustomizeBrowserEvent.kt
+++ b/web-authentication-ui/src/main/java/com/okta/webauthenticationui/events/CustomizeBrowserEvent.kt
@@ -17,10 +17,10 @@ package com.okta.webauthenticationui.events
 
 import android.content.pm.PackageManager
 import com.okta.authfoundation.events.EventHandler
-import com.okta.webauthenticationui.WebAuthenticationClient
+import com.okta.webauthenticationui.WebAuthentication
 
 /**
- * Emitted via [EventHandler.onEvent] when [WebAuthenticationClient.login] or [WebAuthenticationClient.logoutOfBrowser] is invoked.
+ * Emitted via [EventHandler.onEvent] when [WebAuthentication.login] or [WebAuthentication.logoutOfBrowser] is invoked.
  *
  * This can be used to customize the browsers used for displaying the Chrome Custom Tabs to the user.
  */

--- a/web-authentication-ui/src/main/java/com/okta/webauthenticationui/events/CustomizeCustomTabsEvent.kt
+++ b/web-authentication-ui/src/main/java/com/okta/webauthenticationui/events/CustomizeCustomTabsEvent.kt
@@ -18,10 +18,10 @@ package com.okta.webauthenticationui.events
 import android.content.Context
 import androidx.browser.customtabs.CustomTabsIntent
 import com.okta.authfoundation.events.EventHandler
-import com.okta.webauthenticationui.WebAuthenticationClient
+import com.okta.webauthenticationui.WebAuthentication
 
 /**
- * Emitted via [EventHandler.onEvent] when [WebAuthenticationClient.login] or [WebAuthenticationClient.logoutOfBrowser] is invoked.
+ * Emitted via [EventHandler.onEvent] when [WebAuthentication.login] or [WebAuthentication.logoutOfBrowser] is invoked.
  *
  * This can be used to customize the [CustomTabsIntent.Builder] before being displayed to the user.
  */

--- a/web-authentication-ui/src/test/java/com/okta/webauthenticationui/RedirectCoordinatorTest.kt
+++ b/web-authentication-ui/src/test/java/com/okta/webauthenticationui/RedirectCoordinatorTest.kt
@@ -116,7 +116,7 @@ class RedirectCoordinatorTest {
         val elapsedTime = currentTime - startTime
         assertThat(result).isInstanceOf(RedirectResult.Error::class.java)
         val error = result as RedirectResult.Error
-        assertThat(error.exception).isInstanceOf(WebAuthenticationClient.FlowCancelledException::class.java)
+        assertThat(error.exception).isInstanceOf(WebAuthentication.FlowCancelledException::class.java)
         assertThat(elapsedTime).isEqualTo(testDebounceTime.inWholeMilliseconds)
     }
 
@@ -146,7 +146,7 @@ class RedirectCoordinatorTest {
         val elapsedTime = currentTime - startTime
         assertThat(result).isInstanceOf(RedirectResult.Error::class.java)
         val error = result as RedirectResult.Error
-        assertThat(error.exception).isInstanceOf(WebAuthenticationClient.FlowCancelledException::class.java)
+        assertThat(error.exception).isInstanceOf(WebAuthentication.FlowCancelledException::class.java)
         assertThat(elapsedTime).isEqualTo(testDebounceTime.inWholeMilliseconds)
     }
 
@@ -165,7 +165,7 @@ class RedirectCoordinatorTest {
         val result = resultDeferred.await()
         assertThat(result).isInstanceOf(RedirectInitializationResult.Error::class.java)
         val error = result as RedirectInitializationResult.Error
-        assertThat(error.exception).isInstanceOf(WebAuthenticationClient.FlowCancelledException::class.java)
+        assertThat(error.exception).isInstanceOf(WebAuthentication.FlowCancelledException::class.java)
     }
 
     @Test fun testEmitWithoutListening(): Unit = testScope.runTest {

--- a/web-authentication-ui/src/test/java/com/okta/webauthenticationui/WebAuthenticationClientTest.kt
+++ b/web-authentication-ui/src/test/java/com/okta/webauthenticationui/WebAuthenticationClientTest.kt
@@ -18,14 +18,12 @@ package com.okta.webauthenticationui
 import android.content.Context
 import android.net.Uri
 import com.google.common.truth.Truth.assertThat
-import com.okta.authfoundation.client.OidcClient
 import com.okta.authfoundation.client.OidcClientResult
 import com.okta.authfoundation.credential.Token
 import com.okta.testhelpers.OktaRule
 import com.okta.testhelpers.RequestMatchers.method
 import com.okta.testhelpers.RequestMatchers.path
 import com.okta.testhelpers.testBodyFromFile
-import com.okta.webauthenticationui.WebAuthenticationClient.Companion.createWebAuthenticationClient
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.test.runTest
@@ -52,7 +50,7 @@ class WebAuthenticationClientTest {
         }
 
         val webAuthenticationProvider = mock<WebAuthenticationProvider>()
-        val webAuthenticationClient = oktaRule.createOidcClient().createWebAuthenticationClient(webAuthenticationProvider)
+        val webAuthenticationClient = WebAuthenticationClient(webAuthenticationProvider)
         val context = mock<Context>()
 
         val redirectCoordinator = DefaultRedirectCoordinator(this)
@@ -90,7 +88,7 @@ class WebAuthenticationClientTest {
 
     @Test fun testLoginInitializationCancellation(): Unit = runTest {
         val webAuthenticationProvider = mock<WebAuthenticationProvider>()
-        val webAuthenticationClient = oktaRule.createOidcClient().createWebAuthenticationClient(webAuthenticationProvider)
+        val webAuthenticationClient = WebAuthenticationClient(webAuthenticationProvider)
         val context = mock<Context>()
 
         val redirectCoordinator = DefaultRedirectCoordinator(this)
@@ -112,7 +110,7 @@ class WebAuthenticationClientTest {
 
     @Test fun testLoginRedirectCancellation(): Unit = runTest {
         val webAuthenticationProvider = mock<WebAuthenticationProvider>()
-        val webAuthenticationClient = oktaRule.createOidcClient().createWebAuthenticationClient(webAuthenticationProvider)
+        val webAuthenticationClient = WebAuthenticationClient(webAuthenticationProvider)
         val context = mock<Context>()
 
         val redirectCoordinator = DefaultRedirectCoordinator(this)
@@ -143,9 +141,8 @@ class WebAuthenticationClientTest {
         oktaRule.enqueue(path("/.well-known/openid-configuration")) { response ->
             response.setResponseCode(503)
         }
-        val client = OidcClient.createFromConfiguration(oktaRule.configuration)
         val webAuthenticationProvider = mock<WebAuthenticationProvider>()
-        val webAuthenticationClient = client.createWebAuthenticationClient(webAuthenticationProvider)
+        val webAuthenticationClient = WebAuthenticationClient(oktaRule.configuration, webAuthenticationProvider)
         val context = mock<Context>()
 
         val redirectCoordinator = DefaultRedirectCoordinator(this)
@@ -167,7 +164,7 @@ class WebAuthenticationClientTest {
 
     @Test fun testLogout(): Unit = runTest {
         val webAuthenticationProvider = mock<WebAuthenticationProvider>()
-        val webAuthenticationClient = oktaRule.createOidcClient().createWebAuthenticationClient(webAuthenticationProvider)
+        val webAuthenticationClient = WebAuthenticationClient(webAuthenticationProvider)
         val context = mock<Context>()
 
         val redirectCoordinator = DefaultRedirectCoordinator(this)
@@ -197,7 +194,7 @@ class WebAuthenticationClientTest {
 
     @Test fun testLogoutInitializerCancellation(): Unit = runTest {
         val webAuthenticationProvider = mock<WebAuthenticationProvider>()
-        val webAuthenticationClient = oktaRule.createOidcClient().createWebAuthenticationClient(webAuthenticationProvider)
+        val webAuthenticationClient = WebAuthenticationClient(webAuthenticationProvider)
         val context = mock<Context>()
 
         val redirectCoordinator = DefaultRedirectCoordinator(this)
@@ -219,7 +216,7 @@ class WebAuthenticationClientTest {
 
     @Test fun testLogoutRedirectCancellation(): Unit = runTest {
         val webAuthenticationProvider = mock<WebAuthenticationProvider>()
-        val webAuthenticationClient = oktaRule.createOidcClient().createWebAuthenticationClient(webAuthenticationProvider)
+        val webAuthenticationClient = WebAuthenticationClient(webAuthenticationProvider)
         val context = mock<Context>()
 
         val redirectCoordinator = DefaultRedirectCoordinator(this)
@@ -250,9 +247,8 @@ class WebAuthenticationClientTest {
         oktaRule.enqueue(path("/.well-known/openid-configuration")) { response ->
             response.setResponseCode(503)
         }
-        val client = OidcClient.createFromConfiguration(oktaRule.configuration)
         val webAuthenticationProvider = mock<WebAuthenticationProvider>()
-        val webAuthenticationClient = client.createWebAuthenticationClient(webAuthenticationProvider)
+        val webAuthenticationClient = WebAuthenticationClient(oktaRule.configuration, webAuthenticationProvider)
         val context = mock<Context>()
 
         val redirectCoordinator = DefaultRedirectCoordinator(this)

--- a/web-authentication-ui/src/test/java/com/okta/webauthenticationui/WebAuthenticationTest.kt
+++ b/web-authentication-ui/src/test/java/com/okta/webauthenticationui/WebAuthenticationTest.kt
@@ -36,7 +36,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
 @RunWith(RobolectricTestRunner::class)
-class WebAuthenticationClientTest {
+class WebAuthenticationTest {
     private val mockPrefix = "test_responses"
 
     @get:Rule val oktaRule = OktaRule()
@@ -50,11 +50,11 @@ class WebAuthenticationClientTest {
         }
 
         val webAuthenticationProvider = mock<WebAuthenticationProvider>()
-        val webAuthenticationClient = WebAuthenticationClient(webAuthenticationProvider)
+        val webAuthentication = WebAuthentication(webAuthenticationProvider)
         val context = mock<Context>()
 
         val redirectCoordinator = DefaultRedirectCoordinator(this)
-        webAuthenticationClient.redirectCoordinator = redirectCoordinator
+        webAuthentication.redirectCoordinator = redirectCoordinator
 
         val initializeCountDownLatch = CountDownLatch(1)
         redirectCoordinator.initializerContinuationListeningCallback = {
@@ -65,7 +65,7 @@ class WebAuthenticationClientTest {
             redirectCountDownLatch.countDown()
         }
         val loginResultDeferred = async(Dispatchers.IO) {
-            webAuthenticationClient.login(context, "unitTest:/login")
+            webAuthentication.login(context, "unitTest:/login")
         }
         assertThat(initializeCountDownLatch.await(1, TimeUnit.SECONDS)).isTrue()
         val initializationResult = redirectCoordinator.runInitializationFunction() as RedirectInitializationResult.Success<*>
@@ -88,33 +88,33 @@ class WebAuthenticationClientTest {
 
     @Test fun testLoginInitializationCancellation(): Unit = runTest {
         val webAuthenticationProvider = mock<WebAuthenticationProvider>()
-        val webAuthenticationClient = WebAuthenticationClient(webAuthenticationProvider)
+        val webAuthentication = WebAuthentication(webAuthenticationProvider)
         val context = mock<Context>()
 
         val redirectCoordinator = DefaultRedirectCoordinator(this)
-        webAuthenticationClient.redirectCoordinator = redirectCoordinator
+        webAuthentication.redirectCoordinator = redirectCoordinator
 
         val initializeCountDownLatch = CountDownLatch(1)
         redirectCoordinator.initializerContinuationListeningCallback = {
             initializeCountDownLatch.countDown()
         }
         val loginResultDeferred = async(Dispatchers.IO) {
-            webAuthenticationClient.login(context, "unitTest:/login")
+            webAuthentication.login(context, "unitTest:/login")
         }
         assertThat(initializeCountDownLatch.await(1, TimeUnit.SECONDS)).isTrue()
         redirectCoordinator.emit(null)
 
         val exception = (loginResultDeferred.await() as OidcClientResult.Error<Token>).exception
-        assertThat(exception).isInstanceOf(WebAuthenticationClient.FlowCancelledException::class.java)
+        assertThat(exception).isInstanceOf(WebAuthentication.FlowCancelledException::class.java)
     }
 
     @Test fun testLoginRedirectCancellation(): Unit = runTest {
         val webAuthenticationProvider = mock<WebAuthenticationProvider>()
-        val webAuthenticationClient = WebAuthenticationClient(webAuthenticationProvider)
+        val webAuthentication = WebAuthentication(webAuthenticationProvider)
         val context = mock<Context>()
 
         val redirectCoordinator = DefaultRedirectCoordinator(this)
-        webAuthenticationClient.redirectCoordinator = redirectCoordinator
+        webAuthentication.redirectCoordinator = redirectCoordinator
 
         val initializeCountDownLatch = CountDownLatch(1)
         redirectCoordinator.initializerContinuationListeningCallback = {
@@ -125,7 +125,7 @@ class WebAuthenticationClientTest {
             redirectCountDownLatch.countDown()
         }
         val loginResultDeferred = async(Dispatchers.IO) {
-            webAuthenticationClient.login(context, "unitTest:/login")
+            webAuthentication.login(context, "unitTest:/login")
         }
         assertThat(initializeCountDownLatch.await(1, TimeUnit.SECONDS)).isTrue()
         redirectCoordinator.runInitializationFunction()
@@ -134,7 +134,7 @@ class WebAuthenticationClientTest {
         redirectCoordinator.emit(null)
 
         val exception = (loginResultDeferred.await() as OidcClientResult.Error<Token>).exception
-        assertThat(exception).isInstanceOf(WebAuthenticationClient.FlowCancelledException::class.java)
+        assertThat(exception).isInstanceOf(WebAuthentication.FlowCancelledException::class.java)
     }
 
     @Test fun testLoginAuthorizationCodeFlowError(): Unit = runTest {
@@ -142,18 +142,18 @@ class WebAuthenticationClientTest {
             response.setResponseCode(503)
         }
         val webAuthenticationProvider = mock<WebAuthenticationProvider>()
-        val webAuthenticationClient = WebAuthenticationClient(oktaRule.configuration, webAuthenticationProvider)
+        val webAuthentication = WebAuthentication(oktaRule.configuration, webAuthenticationProvider)
         val context = mock<Context>()
 
         val redirectCoordinator = DefaultRedirectCoordinator(this)
-        webAuthenticationClient.redirectCoordinator = redirectCoordinator
+        webAuthentication.redirectCoordinator = redirectCoordinator
 
         val initializeCountDownLatch = CountDownLatch(1)
         redirectCoordinator.initializerContinuationListeningCallback = {
             initializeCountDownLatch.countDown()
         }
         val loginResultDeferred = async(Dispatchers.IO) {
-            webAuthenticationClient.login(context, "unitTest:/login")
+            webAuthentication.login(context, "unitTest:/login")
         }
         assertThat(initializeCountDownLatch.await(1, TimeUnit.SECONDS)).isTrue()
         redirectCoordinator.runInitializationFunction()
@@ -164,11 +164,11 @@ class WebAuthenticationClientTest {
 
     @Test fun testLogout(): Unit = runTest {
         val webAuthenticationProvider = mock<WebAuthenticationProvider>()
-        val webAuthenticationClient = WebAuthenticationClient(webAuthenticationProvider)
+        val webAuthentication = WebAuthentication(webAuthenticationProvider)
         val context = mock<Context>()
 
         val redirectCoordinator = DefaultRedirectCoordinator(this)
-        webAuthenticationClient.redirectCoordinator = redirectCoordinator
+        webAuthentication.redirectCoordinator = redirectCoordinator
 
         val initializeCountDownLatch = CountDownLatch(1)
         redirectCoordinator.initializerContinuationListeningCallback = {
@@ -179,7 +179,7 @@ class WebAuthenticationClientTest {
             redirectCountDownLatch.countDown()
         }
         val logoutResultDeferred = async(Dispatchers.IO) {
-            webAuthenticationClient.logoutOfBrowser(context, "unitTest:/logout", "ExampleIdToken")
+            webAuthentication.logoutOfBrowser(context, "unitTest:/logout", "ExampleIdToken")
         }
         assertThat(initializeCountDownLatch.await(1, TimeUnit.SECONDS)).isTrue()
         val initializationResult = redirectCoordinator.runInitializationFunction() as RedirectInitializationResult.Success<*>
@@ -194,33 +194,33 @@ class WebAuthenticationClientTest {
 
     @Test fun testLogoutInitializerCancellation(): Unit = runTest {
         val webAuthenticationProvider = mock<WebAuthenticationProvider>()
-        val webAuthenticationClient = WebAuthenticationClient(webAuthenticationProvider)
+        val webAuthentication = WebAuthentication(webAuthenticationProvider)
         val context = mock<Context>()
 
         val redirectCoordinator = DefaultRedirectCoordinator(this)
-        webAuthenticationClient.redirectCoordinator = redirectCoordinator
+        webAuthentication.redirectCoordinator = redirectCoordinator
 
         val initializeCountDownLatch = CountDownLatch(1)
         redirectCoordinator.initializerContinuationListeningCallback = {
             initializeCountDownLatch.countDown()
         }
         val logoutResultDeferred = async(Dispatchers.IO) {
-            webAuthenticationClient.logoutOfBrowser(context, "unitTest:/logout", "ExampleIdToken")
+            webAuthentication.logoutOfBrowser(context, "unitTest:/logout", "ExampleIdToken")
         }
         assertThat(initializeCountDownLatch.await(1, TimeUnit.SECONDS)).isTrue()
         redirectCoordinator.emit(null)
 
         val exception = (logoutResultDeferred.await() as OidcClientResult.Error<Unit>).exception
-        assertThat(exception).isInstanceOf(WebAuthenticationClient.FlowCancelledException::class.java)
+        assertThat(exception).isInstanceOf(WebAuthentication.FlowCancelledException::class.java)
     }
 
     @Test fun testLogoutRedirectCancellation(): Unit = runTest {
         val webAuthenticationProvider = mock<WebAuthenticationProvider>()
-        val webAuthenticationClient = WebAuthenticationClient(webAuthenticationProvider)
+        val webAuthentication = WebAuthentication(webAuthenticationProvider)
         val context = mock<Context>()
 
         val redirectCoordinator = DefaultRedirectCoordinator(this)
-        webAuthenticationClient.redirectCoordinator = redirectCoordinator
+        webAuthentication.redirectCoordinator = redirectCoordinator
 
         val initializeCountDownLatch = CountDownLatch(1)
         redirectCoordinator.initializerContinuationListeningCallback = {
@@ -231,7 +231,7 @@ class WebAuthenticationClientTest {
             redirectCountDownLatch.countDown()
         }
         val logoutResultDeferred = async(Dispatchers.IO) {
-            webAuthenticationClient.logoutOfBrowser(context, "unitTest:/logout", "ExampleIdToken")
+            webAuthentication.logoutOfBrowser(context, "unitTest:/logout", "ExampleIdToken")
         }
         assertThat(initializeCountDownLatch.await(1, TimeUnit.SECONDS)).isTrue()
         redirectCoordinator.runInitializationFunction()
@@ -240,7 +240,7 @@ class WebAuthenticationClientTest {
         redirectCoordinator.emit(null)
 
         val exception = (logoutResultDeferred.await() as OidcClientResult.Error<Unit>).exception
-        assertThat(exception).isInstanceOf(WebAuthenticationClient.FlowCancelledException::class.java)
+        assertThat(exception).isInstanceOf(WebAuthentication.FlowCancelledException::class.java)
     }
 
     @Test fun testLogoutEndSessionRedirectFlowError(): Unit = runTest {
@@ -248,18 +248,18 @@ class WebAuthenticationClientTest {
             response.setResponseCode(503)
         }
         val webAuthenticationProvider = mock<WebAuthenticationProvider>()
-        val webAuthenticationClient = WebAuthenticationClient(oktaRule.configuration, webAuthenticationProvider)
+        val webAuthentication = WebAuthentication(oktaRule.configuration, webAuthenticationProvider)
         val context = mock<Context>()
 
         val redirectCoordinator = DefaultRedirectCoordinator(this)
-        webAuthenticationClient.redirectCoordinator = redirectCoordinator
+        webAuthentication.redirectCoordinator = redirectCoordinator
 
         val initializeCountDownLatch = CountDownLatch(1)
         redirectCoordinator.initializerContinuationListeningCallback = {
             initializeCountDownLatch.countDown()
         }
         val logoutResultDeferred = async(Dispatchers.IO) {
-            webAuthenticationClient.logoutOfBrowser(context, "unitTest:/logout", "ExampleIdToken")
+            webAuthentication.logoutOfBrowser(context, "unitTest:/logout", "ExampleIdToken")
         }
         assertThat(initializeCountDownLatch.await(1, TimeUnit.SECONDS)).isTrue()
         redirectCoordinator.runInitializationFunction()


### PR DESCRIPTION
This PR removes explicit dependency on users having to interact with oidcClient to create new instances of OAuth flows. Now, the OAuth flows can automatically use OidcClient.default created from OidcConfiguration.default. The followup PR to this will remove CredentialBootstrap altogether, and the only setup step users will need to perform is setting OidcConfiguration.default (and that too will be optional if the user supplies OidcConfiguration to each flow manually).