### PR TITLE
Preferences datastore device secrets

### DIFF
--- a/auth-foundation/api/auth-foundation.api
+++ b/auth-foundation/api/auth-foundation.api
@@ -117,6 +117,20 @@ public final class com/okta/authfoundation/client/DeviceTokenCookieJar : okhttp3
 	public fun saveFromResponse (Lokhttp3/HttpUrl;Ljava/util/List;)V
 }
 
+public final class com/okta/authfoundation/client/DeviceTokenProvider {
+	public static final field Companion Lcom/okta/authfoundation/client/DeviceTokenProvider$Companion;
+	public static final field PREFERENCE_NAME Ljava/lang/String;
+	public fun <init> ()V
+	public fun <init> (Lcom/okta/authfoundation/util/AesEncryptionHandler;)V
+	public synthetic fun <init> (Lcom/okta/authfoundation/util/AesEncryptionHandler;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getDeviceToken (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/okta/authfoundation/client/DeviceTokenProvider$Companion {
+	public final fun getInstance ()Lcom/okta/authfoundation/client/DeviceTokenProvider;
+	public final fun getPREFERENCE_KEY ()Landroidx/datastore/preferences/core/Preferences$Key;
+}
+
 public abstract interface class com/okta/authfoundation/client/IdTokenValidator {
 	public abstract fun validate (Lcom/okta/authfoundation/client/OidcClient;Lcom/okta/authfoundation/jwt/Jwt;Lcom/okta/authfoundation/client/IdTokenValidator$Parameters;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
@@ -145,6 +159,10 @@ public final class com/okta/authfoundation/client/IdTokenValidator$Error$Compani
 public final class com/okta/authfoundation/client/IdTokenValidator$Parameters {
 	public final fun getMaxAge ()Ljava/lang/Integer;
 	public final fun getNonce ()Ljava/lang/String;
+}
+
+public final class com/okta/authfoundation/client/LegacyDeviceTokenProvider {
+	public fun <init> (Landroid/content/Context;)V
 }
 
 public final class com/okta/authfoundation/client/NoOpCache : com/okta/authfoundation/client/Cache {
@@ -627,6 +645,25 @@ public final class com/okta/authfoundation/jwt/JwtParser {
 
 public final class com/okta/authfoundation/jwt/JwtParser$Companion {
 	public final fun create ()Lcom/okta/authfoundation/jwt/JwtParser;
+}
+
+public final class com/okta/authfoundation/util/AesEncryptionHandler {
+	public static final field Companion Lcom/okta/authfoundation/util/AesEncryptionHandler$Companion;
+	public fun <init> ()V
+	public fun <init> (Landroid/security/keystore/KeyGenParameterSpec;)V
+	public synthetic fun <init> (Landroid/security/keystore/KeyGenParameterSpec;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun decryptString (Ljava/lang/String;)Ljava/lang/String;
+	public final fun encryptString (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class com/okta/authfoundation/util/AesEncryptionHandler$Companion {
+}
+
+public final class com/okta/authfoundation/util/AndroidKeystoreUtil {
+	public static final field INSTANCE Lcom/okta/authfoundation/util/AndroidKeystoreUtil;
+	public final fun getKeyStore ()Ljava/security/KeyStore;
+	public final fun getOrCreateAesKey (Landroid/security/keystore/KeyGenParameterSpec;)Ljava/security/Key;
+	public final fun getRsaKeyPairGenerator ()Ljava/security/KeyPairGenerator;
 }
 
 public final class com/okta/authfoundation/util/CoalescingOrchestrator {

--- a/auth-foundation/build.gradle
+++ b/auth-foundation/build.gradle
@@ -73,6 +73,7 @@ dependencies {
     implementation deps.lifecycle.viewmodel_ktx
     implementation deps.androidx_activity_ktx
     implementation deps.androidx_constraintlayout
+    implementation deps.androidx_datastore_preferences
     implementation deps.androidx_sqlite
     implementation deps.app_compat
     implementation deps.okio.jvm

--- a/auth-foundation/src/androidTest/java/com/okta/authfoundation/credential/LegacyDeviceTokenProviderTest.kt
+++ b/auth-foundation/src/androidTest/java/com/okta/authfoundation/credential/LegacyDeviceTokenProviderTest.kt
@@ -19,39 +19,39 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
-import com.okta.authfoundation.client.DeviceTokenProvider
+import com.okta.authfoundation.client.LegacyDeviceTokenProvider
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-class DeviceTokenProviderTest {
+class LegacyDeviceTokenProviderTest {
     private lateinit var context: Context
-    private lateinit var deviceTokenProvider: DeviceTokenProvider
+    private lateinit var legacyDeviceTokenProvider: LegacyDeviceTokenProvider
 
     @Before
     fun setup() {
         context = ApplicationProvider.getApplicationContext()
-        deviceTokenProvider = DeviceTokenProvider(context)
+        legacyDeviceTokenProvider = LegacyDeviceTokenProvider(context)
         clearSharedPreferences()
     }
 
     private fun clearSharedPreferences() {
-        context.getSharedPreferences(DeviceTokenProvider.FILE_NAME, Context.MODE_PRIVATE).edit().clear().commit()
+        context.getSharedPreferences(LegacyDeviceTokenProvider.FILE_NAME, Context.MODE_PRIVATE).edit().clear().commit()
     }
 
     @Test
     fun testDeviceTokenProviderInitializesCorrectly() {
-        val actualDeviceToken = deviceTokenProvider.deviceToken
-        val expectedDeviceToken = deviceTokenProvider.sharedPrefs.getString(
-            DeviceTokenProvider.PREFERENCE_KEY, null
+        val actualDeviceToken = legacyDeviceTokenProvider.deviceToken
+        val expectedDeviceToken = legacyDeviceTokenProvider.sharedPrefs.getString(
+            LegacyDeviceTokenProvider.PREFERENCE_KEY, null
         )!!.filter { it.isLetterOrDigit() }
         assertThat(actualDeviceToken).isEqualTo(expectedDeviceToken)
     }
 
     @Test
     fun testDeviceTokenIsAtMost32Characters() {
-        val actualDeviceToken = deviceTokenProvider.deviceToken
+        val actualDeviceToken = legacyDeviceTokenProvider.deviceToken
         assertThat(actualDeviceToken.length).isAtMost(32)
     }
 }

--- a/auth-foundation/src/main/java/com/okta/authfoundation/client/LegacyDeviceTokenProvider.kt
+++ b/auth-foundation/src/main/java/com/okta/authfoundation/client/LegacyDeviceTokenProvider.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2023-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.client
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.annotation.VisibleForTesting
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKeys
+import com.okta.authfoundation.InternalAuthFoundationApi
+import java.util.UUID
+
+@InternalAuthFoundationApi
+class LegacyDeviceTokenProvider(private val appContext: Context) {
+    internal companion object {
+        @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+        internal const val FILE_NAME = "com.okta.authfoundation.device_token_storage"
+        @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+        internal const val PREFERENCE_KEY = "com.okta.authfoundation.device_token_key"
+    }
+
+    private val masterKeyAlias by lazy { MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC) }
+
+    private fun createSharedPreferences(): SharedPreferences {
+        return EncryptedSharedPreferences.create(
+            FILE_NAME,
+            masterKeyAlias,
+            appContext,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal val sharedPrefs: SharedPreferences by lazy {
+        try {
+            createSharedPreferences()
+        } catch (e: Exception) {
+            val sharedPreferences = appContext.getSharedPreferences(FILE_NAME, Context.MODE_PRIVATE)
+            sharedPreferences.edit().clear().commit()
+            createSharedPreferences()
+        }
+    }
+
+    private val sharedPrefsEditor by lazy { sharedPrefs.edit() }
+
+    internal val deviceTokenUUID: String
+        get() {
+            return sharedPrefs.getString(PREFERENCE_KEY, null) ?: run {
+                val newDeviceToken = UUID.randomUUID().toString()
+                sharedPrefsEditor.putString(PREFERENCE_KEY, newDeviceToken)
+                sharedPrefsEditor.commit()
+                newDeviceToken
+            }
+        }
+
+    internal fun containsDeviceToken(): Boolean = sharedPrefs.contains(PREFERENCE_KEY)
+
+    internal val deviceToken: String
+        get() = deviceTokenUUID.filter { it.isLetterOrDigit() }
+}

--- a/auth-foundation/src/main/java/com/okta/authfoundation/credential/CredentialDataSource.kt
+++ b/auth-foundation/src/main/java/com/okta/authfoundation/credential/CredentialDataSource.kt
@@ -25,6 +25,7 @@ import com.okta.authfoundation.client.OidcClient
 import com.okta.authfoundation.credential.events.CredentialCreatedEvent
 import com.okta.authfoundation.credential.storage.TokenDatabase
 import com.okta.authfoundation.jwt.JwtParser
+import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.JsonObject
 import net.zetetic.database.sqlcipher.SupportOpenHelperFactory
 import java.util.Collections
@@ -64,12 +65,7 @@ class CredentialDataSource internal constructor(
             tokenEncryptionHandler: TokenEncryptionHandler = DefaultTokenEncryptionHandler()
         ): CredentialDataSource {
             ApplicationContextHolder.setApplicationContext(context.applicationContext)
-            val deviceTokenProvider = DeviceTokenProvider.shared ?: run {
-                val _deviceTokenProvider = DeviceTokenProvider(context)
-                DeviceTokenProvider.shared = _deviceTokenProvider
-                _deviceTokenProvider
-            }
-            val sqlCipherPassword = deviceTokenProvider.deviceToken
+            val sqlCipherPassword = runBlocking { DeviceTokenProvider.instance.getDeviceToken() }
             System.loadLibrary("sqlcipher")
             val tokenDatabase =
                 Room.databaseBuilder(context, TokenDatabase::class.java, TokenDatabase.DB_NAME)

--- a/auth-foundation/src/main/java/com/okta/authfoundation/credential/DefaultTokenIdDataStore.kt
+++ b/auth-foundation/src/main/java/com/okta/authfoundation/credential/DefaultTokenIdDataStore.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.credential
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.okta.authfoundation.client.ApplicationContextHolder
+import com.okta.authfoundation.util.AesEncryptionHandler
+import kotlinx.coroutines.flow.firstOrNull
+
+internal class DefaultTokenIdDataStore(
+    private val aesEncryptionHandler: AesEncryptionHandler = AesEncryptionHandler()
+) {
+    companion object {
+        const val PREFERENCE_NAME = "com.okta.authfoundation.credential.defaultTokenIdDataStore"
+        val PREFERENCE_KEY = stringPreferencesKey("encryptedDefaultTokenId")
+    }
+
+    private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(PREFERENCE_NAME)
+    private val context by lazy { ApplicationContextHolder.appContext }
+
+    suspend fun getDefaultTokenId(): String? {
+        val encryptedDefaultTokenId = context.dataStore.data.firstOrNull()?.get(PREFERENCE_KEY)
+        return encryptedDefaultTokenId?.let {
+            aesEncryptionHandler.decryptString(it)
+        }
+    }
+
+    suspend fun setDefaultTokenId(id: String) = context.dataStore.edit { preferences ->
+        preferences[PREFERENCE_KEY] = aesEncryptionHandler.encryptString(id)
+    }
+}

--- a/auth-foundation/src/main/java/com/okta/authfoundation/credential/TokenEncryptionHandler.kt
+++ b/auth-foundation/src/main/java/com/okta/authfoundation/credential/TokenEncryptionHandler.kt
@@ -24,7 +24,7 @@ import com.okta.authfoundation.InternalAuthFoundationApi
 import com.okta.authfoundation.TransparentBiometricActivity
 import com.okta.authfoundation.client.ApplicationContextHolder
 import com.okta.authfoundation.client.OidcConfiguration
-import com.okta.authfoundation.credential.CredentialDataSource.Companion.createCredentialDataSource
+import com.okta.authfoundation.util.AndroidKeystoreUtil
 import kotlinx.coroutines.suspendCancellableCoroutine
 import java.security.KeyFactory
 import java.security.KeyPairGenerator
@@ -99,10 +99,8 @@ interface TokenEncryptionHandler {
 
 @InternalAuthFoundationApi
 class DefaultTokenEncryptionHandler(
-    internal val keyStore: KeyStore = KeyStore.getInstance("AndroidKeyStore"),
-    private val keyPairGenerator: KeyPairGenerator = KeyPairGenerator.getInstance(
-        KeyProperties.KEY_ALGORITHM_RSA, "AndroidKeyStore"
-    )
+    internal val keyStore: KeyStore = AndroidKeystoreUtil.keyStore,
+    private val keyPairGenerator: KeyPairGenerator = AndroidKeystoreUtil.getRsaKeyPairGenerator()
 ) : TokenEncryptionHandler {
     private val aesKeyGenerator = KeyGenerator.getInstance("AES").apply {
         // Generate 256-bit AES keys for encryption

--- a/auth-foundation/src/main/java/com/okta/authfoundation/util/AesEncryptionHandler.kt
+++ b/auth-foundation/src/main/java/com/okta/authfoundation/util/AesEncryptionHandler.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.util
+
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import android.util.Base64
+import com.okta.authfoundation.InternalAuthFoundationApi
+import javax.crypto.Cipher
+import javax.crypto.spec.GCMParameterSpec
+
+@InternalAuthFoundationApi
+class AesEncryptionHandler(
+    private val encryptionKeySpec: KeyGenParameterSpec = defaultEncryptionKeySpec
+) {
+    companion object {
+        private const val ENCRYPTION_KEY_ALIAS = "com.authfoundation.preferences.datastore.aesKey"
+        private const val SEPARATOR = ","
+        private val defaultEncryptionKeySpec by lazy {
+            KeyGenParameterSpec.Builder(
+                ENCRYPTION_KEY_ALIAS,
+                KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+            )
+                .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                .build()
+        }
+    }
+
+    fun encryptString(string: String): String {
+        val aesKey = AndroidKeystoreUtil.getOrCreateAesKey(encryptionKeySpec)
+        val cipher = getCipher().apply { init(Cipher.ENCRYPT_MODE, aesKey) }
+        val encryptedStringByteArray = cipher.doFinal(string.toByteArray())
+        val encryptedString = Base64.encodeToString(encryptedStringByteArray, Base64.NO_WRAP)
+        return Base64.encodeToString(cipher.iv, Base64.NO_WRAP) + SEPARATOR + encryptedString
+    }
+
+    fun decryptString(encryptedString: String): String {
+        val aesKey = AndroidKeystoreUtil.getOrCreateAesKey(encryptionKeySpec)
+        val (ivBase64, encryptedAesStringBase64) = encryptedString.split(SEPARATOR, limit = 2)
+        val iv = Base64.decode(ivBase64, Base64.NO_WRAP)
+        val encryptedAesString = Base64.decode(encryptedAesStringBase64, Base64.NO_WRAP)
+        val cipher = getCipher().apply { init(Cipher.DECRYPT_MODE, aesKey, GCMParameterSpec(128, iv)) }
+        return cipher.doFinal(encryptedAesString).decodeToString()
+    }
+
+    private fun getCipher(): Cipher = Cipher.getInstance(
+        KeyProperties.KEY_ALGORITHM_AES + "/" +
+            KeyProperties.BLOCK_MODE_GCM + "/" +
+            KeyProperties.ENCRYPTION_PADDING_NONE
+    )
+}

--- a/auth-foundation/src/main/java/com/okta/authfoundation/util/AndroidKeystoreUtil.kt
+++ b/auth-foundation/src/main/java/com/okta/authfoundation/util/AndroidKeystoreUtil.kt
@@ -1,0 +1,39 @@
+package com.okta.authfoundation.util
+
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import com.okta.authfoundation.InternalAuthFoundationApi
+import java.security.Key
+import java.security.KeyPairGenerator
+import java.security.KeyStore
+import javax.crypto.KeyGenerator
+
+@InternalAuthFoundationApi
+object AndroidKeystoreUtil {
+    val keyStore: KeyStore by lazy {
+        val ks = KeyStore.getInstance("AndroidKeyStore")
+        ks.load(null)
+        ks
+    }
+
+    fun getRsaKeyPairGenerator(): KeyPairGenerator {
+        return KeyPairGenerator.getInstance(
+            KeyProperties.KEY_ALGORITHM_RSA,
+            "AndroidKeyStore"
+        )
+    }
+
+    private fun getAesKeyGenerator(): KeyGenerator {
+        return KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, "AndroidKeyStore")
+    }
+
+    fun getOrCreateAesKey(keyGenParameterSpec: KeyGenParameterSpec): Key {
+        if (keyStore.containsAlias(keyGenParameterSpec.keystoreAlias)) {
+            return keyStore.getKey(keyGenParameterSpec.keystoreAlias, null)
+        }
+
+        val aesKeyGenerator = getAesKeyGenerator()
+        aesKeyGenerator.init(keyGenParameterSpec)
+        return aesKeyGenerator.generateKey()
+    }
+}

--- a/auth-foundation/src/main/java/com/okta/authfoundation/util/AndroidKeystoreUtil.kt
+++ b/auth-foundation/src/main/java/com/okta/authfoundation/util/AndroidKeystoreUtil.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.okta.authfoundation.util
 
 import android.security.keystore.KeyGenParameterSpec

--- a/auth-foundation/src/test/java/com/okta/authfoundation/client/DeviceTokenProviderTest.kt
+++ b/auth-foundation/src/test/java/com/okta/authfoundation/client/DeviceTokenProviderTest.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2024-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.client
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import com.okta.testhelpers.MockAesEncryptionHandler
+import io.mockk.every
+import io.mockk.mockkConstructor
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class DeviceTokenProviderTest {
+    private lateinit var deviceTokenProvider: DeviceTokenProvider
+
+    @Before
+    fun setUp() {
+        mockkObject(ApplicationContextHolder)
+        every { ApplicationContextHolder.appContext } returns ApplicationProvider.getApplicationContext()
+
+        mockkConstructor(LegacyDeviceTokenProvider::class)
+        every { anyConstructed<LegacyDeviceTokenProvider>().containsDeviceToken() } returns false
+        deviceTokenProvider = DeviceTokenProvider(MockAesEncryptionHandler.instance)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `getDeviceToken success`() = runTest {
+        val deviceToken = deviceTokenProvider.getDeviceToken()
+        assertThat(deviceToken).isNotEmpty()
+    }
+
+    @Test
+    fun `getDeviceToken is at most 32 characters`() = runTest {
+        val deviceToken = deviceTokenProvider.getDeviceToken()
+        assertThat(deviceToken.length).isAtMost(32)
+    }
+
+    @Test
+    fun `getDeviceToken imports device token from LegacyDeviceTokenProvider`() = runTest {
+        every { anyConstructed<LegacyDeviceTokenProvider>().containsDeviceToken() } returns true
+        every { anyConstructed<LegacyDeviceTokenProvider>().deviceToken } returns "legacyDeviceToken"
+
+        val deviceToken = deviceTokenProvider.getDeviceToken()
+        assertThat(deviceToken).isEqualTo("legacyDeviceToken")
+    }
+
+    @Test
+    fun `getDeviceToken does not replace existing device token with one from LegacyDeviceTokenProvider`() = runTest {
+        val deviceToken = deviceTokenProvider.getDeviceToken()
+
+        every { anyConstructed<LegacyDeviceTokenProvider>().containsDeviceToken() } returns true
+        every { anyConstructed<LegacyDeviceTokenProvider>().deviceToken } returns "legacyDeviceToken"
+
+        assertThat(deviceToken).isNotEqualTo("legacyDeviceToken")
+    }
+}

--- a/auth-foundation/src/test/java/com/okta/authfoundation/credential/DefaultTokenIdDataStoreTest.kt
+++ b/auth-foundation/src/test/java/com/okta/authfoundation/credential/DefaultTokenIdDataStoreTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2024-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.credential
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import com.okta.authfoundation.client.ApplicationContextHolder
+import com.okta.testhelpers.MockAesEncryptionHandler
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class DefaultTokenIdDataStoreTest {
+    private lateinit var defaultTokenIdDataStore: DefaultTokenIdDataStore
+
+    @Before
+    fun setUp() {
+        mockkObject(ApplicationContextHolder)
+        every { ApplicationContextHolder.appContext } returns ApplicationProvider.getApplicationContext()
+        defaultTokenIdDataStore = DefaultTokenIdDataStore(MockAesEncryptionHandler.instance)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `getDefaultTokenId returns null if no default token is set`() = runTest {
+        assertThat(defaultTokenIdDataStore.getDefaultTokenId()).isNull()
+    }
+
+    @Test
+    fun `getDefaultTokenId returns the token id provided in setDefaultTokenId`() = runTest {
+        val tokenId = "tokenId"
+        defaultTokenIdDataStore.setDefaultTokenId(tokenId)
+        assertThat(defaultTokenIdDataStore.getDefaultTokenId()).isEqualTo(tokenId)
+    }
+
+    @Test
+    fun `getDefaultTokenId returns the token id provided by the latest call to setDefaultTokenId`() = runTest {
+        val oldTokenId = "oldTokenId"
+        val newTokenId = "newTokenId"
+        defaultTokenIdDataStore.setDefaultTokenId(oldTokenId)
+        defaultTokenIdDataStore.setDefaultTokenId(newTokenId)
+
+        assertThat(defaultTokenIdDataStore.getDefaultTokenId()).isEqualTo(newTokenId)
+    }
+}

--- a/auth-foundation/src/test/java/com/okta/authfoundation/util/AesEncryptionHandlerTest.kt
+++ b/auth-foundation/src/test/java/com/okta/authfoundation/util/AesEncryptionHandlerTest.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2024-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.util
+
+import android.security.keystore.KeyGenParameterSpec
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import javax.crypto.KeyGenerator
+
+@RunWith(AndroidJUnit4::class)
+class AesEncryptionHandlerTest {
+    private lateinit var aesEncryptionHandler: AesEncryptionHandler
+    private lateinit var mockEncryptionKeySpec: KeyGenParameterSpec
+    private lateinit var keyGenerator: KeyGenerator
+
+    @Before
+    fun setUp() {
+        mockkObject(AndroidKeystoreUtil)
+        keyGenerator = KeyGenerator.getInstance("AES")
+        every { AndroidKeystoreUtil.getOrCreateAesKey(any()) } returns keyGenerator.generateKey()
+        mockEncryptionKeySpec = mockk(relaxed = true)
+
+        aesEncryptionHandler = AesEncryptionHandler(mockEncryptionKeySpec)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `encrypt then decrypt string successfully`() {
+        val testString = "testString"
+        val encryptedString = aesEncryptionHandler.encryptString(testString)
+        assertThat(encryptedString).isNotEqualTo(testString)
+
+        val decryptedString = aesEncryptionHandler.decryptString(encryptedString)
+        assertThat(decryptedString).isEqualTo(testString)
+    }
+}

--- a/test-helpers/src/main/java/com/okta/testhelpers/MockAesEncryptionHandler.kt
+++ b/test-helpers/src/main/java/com/okta/testhelpers/MockAesEncryptionHandler.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.testhelpers
+
+import com.okta.authfoundation.InternalAuthFoundationApi
+import com.okta.authfoundation.util.AesEncryptionHandler
+import io.mockk.every
+import io.mockk.mockk
+
+@InternalAuthFoundationApi
+object MockAesEncryptionHandler {
+    val instance = mockk<AesEncryptionHandler>().apply {
+        every { encryptString(any()) } returnsArgument 0
+        every { decryptString(any()) } returnsArgument 0
+    }
+}

--- a/versions.gradle
+++ b/versions.gradle
@@ -4,6 +4,7 @@ versions.androidx_annotation = '1.4.0'
 versions.androidx_biometric = '1.1.0'
 versions.androidx_browser = '1.5.0'
 versions.androidx_constraintlayout = '2.1.4'
+versions.androidx_datastore_preferences = '1.0.0'
 versions.androidx_sqlite = '2.2.0'
 versions.androidx_test = '1.5.0'
 versions.androidx_test_runner = '1.5.2'
@@ -65,6 +66,8 @@ deps.androidx_biometric = "androidx.biometric:biometric:$versions.androidx_biome
 deps.androidx_browser = "androidx.browser:browser:$versions.androidx_browser"
 
 deps.androidx_constraintlayout = "androidx.constraintlayout:constraintlayout:$versions.androidx_constraintlayout"
+
+deps.androidx_datastore_preferences = "androidx.datastore:datastore-preferences:$versions.androidx_datastore_preferences"
 
 deps.androidx_sqlite = "androidx.sqlite:sqlite:$versions.androidx_sqlite"
 


### PR DESCRIPTION
This PR adds datastores for holding default token id, and device token. DeviceTokenProvider is reimplemented here to get rid of dependency on Google tink.