### PR TITLE
Fix corrupt encrypted files caused by unwanted backup and restore

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Upload Test Failures
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: test-failures
           path: |
@@ -64,7 +64,7 @@ jobs:
 
       - name: Upload Test Failures
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: test-failures
           path: |

--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ SDKs are split between two primary use cases:
   - Okta supports many OAuth flows, our Android SDKs support the following: Authorization Code, Interaction Code, Refresh Token, Resource Owner Password, Device Authorization, and Token Exchange.
 - Managing the token lifecycle (refresh, storage, validation, etc)
 
+### Auto backup rules
+
+This SDK uses on-device encryption keys to store data. Because of this, the SDK files should not be backed up. This SDK provides backup rules to exclude files automatically.
+But, if your application provides its own backup rules by specifying `android:dataExtractionRules` or `android:fullBackupContent`, please include SDK backup rules as specified in [data_extraction_rules](auth-foundation/src/main/res/xml/data_extraction_rules.xml) and [full_backup_content](auth-foundation/src/main/res/xml/full_backup_content.xml).
+
 ### Kotlin Coroutines
 [Kotlin Coroutines](https://kotlinlang.org/docs/coroutines-overview.html) are used extensively throughout the SDKs. All methods can be used via any thread (including the main thread), and will switch to a background thread internally when performing network IO or expensive computation.
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,7 +3,6 @@
 
     <application
         android:name=".SampleApplication"
-        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/app/src/main/java/sample/okta/android/SampleApplication.kt
+++ b/app/src/main/java/sample/okta/android/SampleApplication.kt
@@ -20,7 +20,7 @@ import android.app.Application
 import android.content.Context
 import com.okta.authfoundation.AuthFoundation
 import com.okta.authfoundation.client.OidcConfiguration
-import com.okta.authfoundation.credential.RecoveryUtil
+import com.okta.authfoundation.credential.TokenDbRecoveryUtil
 import timber.log.Timber
 
 class SampleApplication : Application() {
@@ -43,6 +43,6 @@ class SampleApplication : Application() {
             issuer = BuildConfig.ISSUER
         )
         // Use this in case token database is corrupted due to automatic backup/restore
-        RecoveryUtil.setupDatabaseRecovery()
+        TokenDbRecoveryUtil.setupDatabaseRecovery()
     }
 }

--- a/app/src/main/java/sample/okta/android/SampleApplication.kt
+++ b/app/src/main/java/sample/okta/android/SampleApplication.kt
@@ -20,6 +20,7 @@ import android.app.Application
 import android.content.Context
 import com.okta.authfoundation.AuthFoundation
 import com.okta.authfoundation.client.OidcConfiguration
+import com.okta.authfoundation.credential.RecoveryUtil
 import timber.log.Timber
 
 class SampleApplication : Application() {
@@ -41,5 +42,7 @@ class SampleApplication : Application() {
             defaultScope = SampleHelper.DEFAULT_SCOPE,
             issuer = BuildConfig.ISSUER
         )
+        // Use this in case token database is corrupted due to automatic backup/restore
+        RecoveryUtil.setupDatabaseRecovery()
     }
 }

--- a/auth-foundation/api/auth-foundation.api
+++ b/auth-foundation/api/auth-foundation.api
@@ -546,6 +546,11 @@ public final class com/okta/authfoundation/credential/Token$Metadata {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/okta/authfoundation/credential/TokenDbRecoveryUtil {
+	public static final field INSTANCE Lcom/okta/authfoundation/credential/TokenDbRecoveryUtil;
+	public final fun setupDatabaseRecovery ()V
+}
+
 public abstract interface class com/okta/authfoundation/credential/TokenEncryptionHandler {
 	public static final field Companion Lcom/okta/authfoundation/credential/TokenEncryptionHandler$Companion;
 	public abstract fun decrypt ([BLjava/util/Map;Lcom/okta/authfoundation/credential/Credential$Security;Landroidx/biometric/BiometricPrompt$PromptInfo;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -719,8 +724,9 @@ public final class com/okta/authfoundation/util/AesEncryptionHandler {
 	public fun <init> ()V
 	public fun <init> (Landroid/security/keystore/KeyGenParameterSpec;)V
 	public synthetic fun <init> (Landroid/security/keystore/KeyGenParameterSpec;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun decryptString (Ljava/lang/String;)Ljava/lang/String;
+	public final fun decryptString-IoAF18A (Ljava/lang/String;)Ljava/lang/Object;
 	public final fun encryptString (Ljava/lang/String;)Ljava/lang/String;
+	public final fun resetEncryptionKey ()V
 }
 
 public final class com/okta/authfoundation/util/AesEncryptionHandler$Companion {
@@ -728,6 +734,7 @@ public final class com/okta/authfoundation/util/AesEncryptionHandler$Companion {
 
 public final class com/okta/authfoundation/util/AndroidKeystoreUtil {
 	public static final field INSTANCE Lcom/okta/authfoundation/util/AndroidKeystoreUtil;
+	public final fun deleteKey (Ljava/lang/String;)V
 	public final fun getKeyStore ()Ljava/security/KeyStore;
 	public final fun getOrCreateAesKey (Landroid/security/keystore/KeyGenParameterSpec;)Ljava/security/Key;
 	public final fun getRsaKeyPairGenerator ()Ljava/security/KeyPairGenerator;

--- a/auth-foundation/src/main/AndroidManifest.xml
+++ b/auth-foundation/src/main/AndroidManifest.xml
@@ -6,7 +6,9 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
 
-    <application>
+    <application
+        android:dataExtractionRules="@xml/data_extraction_rules"
+        android:fullBackupContent="@xml/full_backup_content">
         <activity
             android:name=".BiometricDecryptionActivity"
             android:theme="@style/Theme.AppCompat.Transparent"

--- a/auth-foundation/src/main/java/com/okta/authfoundation/credential/DefaultCredentialIdDataStore.kt
+++ b/auth-foundation/src/main/java/com/okta/authfoundation/credential/DefaultCredentialIdDataStore.kt
@@ -40,7 +40,7 @@ internal class DefaultCredentialIdDataStore(
     suspend fun getDefaultCredentialId(): String? {
         val encryptedDefaultCredentialId = context.dataStore.data.firstOrNull()?.get(PREFERENCE_KEY)
         return encryptedDefaultCredentialId?.let {
-            aesEncryptionHandler.decryptString(it)
+            aesEncryptionHandler.decryptString(it).getOrNull()
         }
     }
 

--- a/auth-foundation/src/main/java/com/okta/authfoundation/credential/TokenDbRecoveryUtil.kt
+++ b/auth-foundation/src/main/java/com/okta/authfoundation/credential/TokenDbRecoveryUtil.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.credential
+
+import android.database.sqlite.SQLiteException
+import com.okta.authfoundation.client.ApplicationContextHolder
+import com.okta.authfoundation.credential.storage.TokenDatabase
+
+object TokenDbRecoveryUtil {
+    fun setupDatabaseRecovery() {
+        val context = ApplicationContextHolder.appContext
+        val defaultUncaughtExceptionHandler = Thread.getDefaultUncaughtExceptionHandler()
+        Thread.setDefaultUncaughtExceptionHandler { thread, exception ->
+            if (exception is SQLiteException) {
+                context.deleteDatabase(TokenDatabase.DB_NAME)
+            } else {
+                defaultUncaughtExceptionHandler?.uncaughtException(thread, exception)
+            }
+        }
+    }
+}

--- a/auth-foundation/src/main/java/com/okta/authfoundation/util/AesEncryptionHandler.kt
+++ b/auth-foundation/src/main/java/com/okta/authfoundation/util/AesEncryptionHandler.kt
@@ -48,13 +48,17 @@ class AesEncryptionHandler(
         return Base64.encodeToString(cipher.iv, Base64.NO_WRAP) + SEPARATOR + encryptedString
     }
 
-    fun decryptString(encryptedString: String): String {
+    fun decryptString(encryptedString: String): Result<String> = runCatching {
         val aesKey = AndroidKeystoreUtil.getOrCreateAesKey(encryptionKeySpec)
         val (ivBase64, encryptedAesStringBase64) = encryptedString.split(SEPARATOR, limit = 2)
         val iv = Base64.decode(ivBase64, Base64.NO_WRAP)
         val encryptedAesString = Base64.decode(encryptedAesStringBase64, Base64.NO_WRAP)
         val cipher = getCipher().apply { init(Cipher.DECRYPT_MODE, aesKey, GCMParameterSpec(128, iv)) }
-        return cipher.doFinal(encryptedAesString).decodeToString()
+        cipher.doFinal(encryptedAesString).decodeToString()
+    }
+
+    fun resetEncryptionKey() {
+        AndroidKeystoreUtil.deleteKey(encryptionKeySpec.keystoreAlias)
     }
 
     private fun getCipher(): Cipher = Cipher.getInstance(

--- a/auth-foundation/src/main/java/com/okta/authfoundation/util/AndroidKeystoreUtil.kt
+++ b/auth-foundation/src/main/java/com/okta/authfoundation/util/AndroidKeystoreUtil.kt
@@ -42,6 +42,10 @@ object AndroidKeystoreUtil {
         return KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, "AndroidKeyStore")
     }
 
+    fun deleteKey(alias: String) {
+        keyStore.deleteEntry(alias)
+    }
+
     fun getOrCreateAesKey(keyGenParameterSpec: KeyGenParameterSpec): Key {
         if (keyStore.containsAlias(keyGenParameterSpec.keystoreAlias)) {
             return keyStore.getKey(keyGenParameterSpec.keystoreAlias, null)

--- a/auth-foundation/src/main/res/xml/data_extraction_rules.xml
+++ b/auth-foundation/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="file" path="datastore/com.okta.authfoundation.client.encryptionToken.preferences_pb"/>
+        <exclude domain="file" path="datastore/com.okta.authfoundation.credential.defaultCredentialIdDataStore.preferences_pb"/>
+        <exclude domain="file" path="datastore/com.okta.authfoundation.credential.storage.isStorageMigratedFromV1.preferences_pb"/>
+        <exclude domain="file" path="datastore/com.okta.idx.client.deviceToken.preferences_pb"/>
+        <exclude domain="database" path="token_database"/>
+        <exclude domain="database" path="token_database-wal"/>
+        <exclude domain="database" path="token_database-shm"/>
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="file" path="datastore/com.okta.authfoundation.client.encryptionToken.preferences_pb"/>
+        <exclude domain="file" path="datastore/com.okta.authfoundation.credential.defaultCredentialIdDataStore.preferences_pb"/>
+        <exclude domain="file" path="datastore/com.okta.authfoundation.credential.storage.isStorageMigratedFromV1.preferences_pb"/>
+        <exclude domain="file" path="datastore/com.okta.idx.client.deviceToken.preferences_pb"/>
+        <exclude domain="database" path="token_database"/>
+        <exclude domain="database" path="token_database-wal"/>
+        <exclude domain="database" path="token_database-shm"/>
+    </device-transfer>
+</data-extraction-rules>

--- a/auth-foundation/src/main/res/xml/full_backup_content.xml
+++ b/auth-foundation/src/main/res/xml/full_backup_content.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+    <exclude domain="file" path="datastore/com.okta.authfoundation.client.encryptionToken.preferences_pb"/>
+    <exclude domain="file" path="datastore/com.okta.authfoundation.credential.defaultCredentialIdDataStore.preferences_pb"/>
+    <exclude domain="file" path="datastore/com.okta.authfoundation.credential.storage.isStorageMigratedFromV1.preferences_pb"/>
+    <exclude domain="file" path="datastore/com.okta.idx.client.deviceToken.preferences_pb"/>
+    <exclude domain="database" path="token_database"/>
+    <exclude domain="database" path="token_database-wal"/>
+    <exclude domain="database" path="token_database-shm"/>
+</full-backup-content>

--- a/auth-foundation/src/test/java/com/okta/authfoundation/credential/CredentialDataSourceTest.kt
+++ b/auth-foundation/src/test/java/com/okta/authfoundation/credential/CredentialDataSourceTest.kt
@@ -61,7 +61,7 @@ class CredentialDataSourceTest {
         mockkObject(ApplicationContextHolder)
         every { ApplicationContextHolder.appContext } returns ApplicationProvider.getApplicationContext()
         mockkObject(DefaultCredentialIdDataStore)
-        every { DefaultCredentialIdDataStore.instance } returns DefaultCredentialIdDataStore(MockAesEncryptionHandler.instance)
+        every { DefaultCredentialIdDataStore.instance } returns DefaultCredentialIdDataStore(MockAesEncryptionHandler.getInstance())
     }
 
     @Test fun `test allIds returns all token IDs from token storage`() = runTest {

--- a/auth-foundation/src/test/java/com/okta/authfoundation/credential/CredentialTest.kt
+++ b/auth-foundation/src/test/java/com/okta/authfoundation/credential/CredentialTest.kt
@@ -75,7 +75,7 @@ class CredentialTest {
         mockkObject(ApplicationContextHolder)
         every { ApplicationContextHolder.appContext } returns ApplicationProvider.getApplicationContext()
         mockkObject(DefaultCredentialIdDataStore)
-        defaultCredentialIdDataStore = DefaultCredentialIdDataStore(MockAesEncryptionHandler.instance)
+        defaultCredentialIdDataStore = DefaultCredentialIdDataStore(MockAesEncryptionHandler.getInstance())
         every { DefaultCredentialIdDataStore.instance } returns defaultCredentialIdDataStore
 
         credentialDataSource = mockk(relaxed = true)

--- a/auth-foundation/src/test/java/com/okta/authfoundation/credential/DefaultCredentialIdDataStoreTest.kt
+++ b/auth-foundation/src/test/java/com/okta/authfoundation/credential/DefaultCredentialIdDataStoreTest.kt
@@ -37,7 +37,7 @@ class DefaultCredentialIdDataStoreTest {
     fun setUp() {
         mockkObject(ApplicationContextHolder)
         every { ApplicationContextHolder.appContext } returns ApplicationProvider.getApplicationContext()
-        defaultCredentialIdDataStore = DefaultCredentialIdDataStore(MockAesEncryptionHandler.instance)
+        defaultCredentialIdDataStore = DefaultCredentialIdDataStore(MockAesEncryptionHandler.getInstance())
     }
 
     @After

--- a/auth-foundation/src/test/java/com/okta/authfoundation/credential/storage/V1ToV2StorageMigratorTest.kt
+++ b/auth-foundation/src/test/java/com/okta/authfoundation/credential/storage/V1ToV2StorageMigratorTest.kt
@@ -70,7 +70,7 @@ class V1ToV2StorageMigratorTest {
                 any()
             )
         } answers { legacySharedPreferences }
-        defaultCredentialIdDataStore = DefaultCredentialIdDataStore(MockAesEncryptionHandler.instance)
+        defaultCredentialIdDataStore = DefaultCredentialIdDataStore(MockAesEncryptionHandler.getInstance())
         mockkObject(DefaultCredentialIdDataStore)
         every { DefaultCredentialIdDataStore.instance } returns defaultCredentialIdDataStore
         mockkObject(OidcConfiguration)

--- a/auth-foundation/src/test/java/com/okta/authfoundation/util/AesEncryptionHandlerTest.kt
+++ b/auth-foundation/src/test/java/com/okta/authfoundation/util/AesEncryptionHandlerTest.kt
@@ -26,6 +26,7 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import javax.crypto.AEADBadTagException
 import javax.crypto.KeyGenerator
 
 @RunWith(AndroidJUnit4::class)
@@ -56,6 +57,18 @@ class AesEncryptionHandlerTest {
         assertThat(encryptedString).isNotEqualTo(testString)
 
         val decryptedString = aesEncryptionHandler.decryptString(encryptedString)
-        assertThat(decryptedString).isEqualTo(testString)
+        assertThat(decryptedString).isEqualTo(Result.success(testString))
+    }
+
+    @Test
+    fun `encrypt then decrypt string with exception`() {
+        val testString = "testString"
+        val encryptedString = aesEncryptionHandler.encryptString(testString)
+        assertThat(encryptedString).isNotEqualTo(testString)
+
+        every { AndroidKeystoreUtil.getOrCreateAesKey(any()) } returns keyGenerator.generateKey() // wrong key
+        val decryptedString = aesEncryptionHandler.decryptString(encryptedString)
+        assertThat(decryptedString.isFailure).isTrue()
+        assertThat(decryptedString.exceptionOrNull()).isInstanceOf(AEADBadTagException::class.java)
     }
 }

--- a/test-helpers/src/main/java/com/okta/testhelpers/MockAesEncryptionHandler.kt
+++ b/test-helpers/src/main/java/com/okta/testhelpers/MockAesEncryptionHandler.kt
@@ -18,12 +18,15 @@ package com.okta.testhelpers
 import com.okta.authfoundation.InternalAuthFoundationApi
 import com.okta.authfoundation.util.AesEncryptionHandler
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
 
 @InternalAuthFoundationApi
 object MockAesEncryptionHandler {
-    val instance = mockk<AesEncryptionHandler>().apply {
+    fun getInstance() = mockk<AesEncryptionHandler>().apply {
         every { encryptString(any()) } returnsArgument 0
         every { decryptString(any()) } returnsArgument 0
+        every { resetEncryptionKey() } just runs
     }
 }


### PR DESCRIPTION
This PR adds recovery mechanisms for handling unexpected backup and restore with SDK storage files. Since SDK files in storage are encrypted using device keystore, they shouldn't be copied over to other devices, or even across app installations.

In addition to the recovery mechanisms, this PR also adds rules to exclude SDK files from automatic backup. I tested backup and restore using this to ensure sdk files aren't getting backed up: https://developer.android.com/identity/data/testingbackup