### PR TITLE
Initialize token database before default id store

### DIFF
--- a/auth-foundation/src/main/java/com/okta/authfoundation/AuthFoundation.kt
+++ b/auth-foundation/src/main/java/com/okta/authfoundation/AuthFoundation.kt
@@ -22,4 +22,8 @@ object AuthFoundation {
     fun initializeAndroidContext(context: Context) {
         ApplicationContextHolder.setApplicationContext(context)
     }
+
+    internal suspend fun initializeStorage() {
+        AuthFoundationDefaults.tokenStorageFactory()
+    }
 }

--- a/auth-foundation/src/main/java/com/okta/authfoundation/credential/DefaultCredentialIdDataStore.kt
+++ b/auth-foundation/src/main/java/com/okta/authfoundation/credential/DefaultCredentialIdDataStore.kt
@@ -21,6 +21,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import com.okta.authfoundation.AuthFoundation
 import com.okta.authfoundation.client.ApplicationContextHolder
 import com.okta.authfoundation.util.AesEncryptionHandler
 import kotlinx.coroutines.flow.firstOrNull
@@ -38,6 +39,7 @@ internal class DefaultCredentialIdDataStore(
     private val context by lazy { ApplicationContextHolder.appContext }
 
     suspend fun getDefaultCredentialId(): String? {
+        AuthFoundation.initializeStorage()
         val encryptedDefaultCredentialId = context.dataStore.data.firstOrNull()?.get(PREFERENCE_KEY)
         return encryptedDefaultCredentialId?.let {
             aesEncryptionHandler.decryptString(it).getOrNull()

--- a/auth-foundation/src/test/java/com/okta/authfoundation/credential/CredentialDataSourceTest.kt
+++ b/auth-foundation/src/test/java/com/okta/authfoundation/credential/CredentialDataSourceTest.kt
@@ -19,6 +19,7 @@ import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
+import com.okta.authfoundation.AuthFoundation
 import com.okta.authfoundation.client.ApplicationContextHolder
 import com.okta.authfoundation.credential.events.CredentialCreatedEvent
 import com.okta.authfoundation.credential.storage.TokenDatabase
@@ -28,7 +29,9 @@ import com.okta.testhelpers.TestTokenEncryptionHandler
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockkObject
+import io.mockk.runs
 import io.mockk.spyk
 import io.mockk.unmockkAll
 import kotlinx.coroutines.test.runTest
@@ -62,6 +65,8 @@ class CredentialDataSourceTest {
         every { ApplicationContextHolder.appContext } returns ApplicationProvider.getApplicationContext()
         mockkObject(DefaultCredentialIdDataStore)
         every { DefaultCredentialIdDataStore.instance } returns DefaultCredentialIdDataStore(MockAesEncryptionHandler.getInstance())
+        mockkObject(AuthFoundation)
+        coEvery { AuthFoundation.initializeStorage() } just runs
     }
 
     @Test fun `test allIds returns all token IDs from token storage`() = runTest {

--- a/auth-foundation/src/test/java/com/okta/authfoundation/credential/CredentialTest.kt
+++ b/auth-foundation/src/test/java/com/okta/authfoundation/credential/CredentialTest.kt
@@ -19,6 +19,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
+import com.okta.authfoundation.AuthFoundation
 import com.okta.authfoundation.client.ApplicationContextHolder
 import com.okta.authfoundation.client.OAuth2Client
 import com.okta.authfoundation.client.OAuth2ClientResult
@@ -39,8 +40,10 @@ import com.okta.testhelpers.RequestMatchers.path
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkObject
+import io.mockk.runs
 import io.mockk.unmockkAll
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -83,6 +86,8 @@ class CredentialTest {
             coEvery { revokeToken(any(), any()) } returns OAuth2ClientResult.Success(Unit)
             every { configuration } returns oktaRule.configuration
         }
+        mockkObject(AuthFoundation)
+        coEvery { AuthFoundation.initializeStorage() } just runs
     }
 
     @After

--- a/auth-foundation/src/test/java/com/okta/authfoundation/credential/DefaultCredentialIdDataStoreTest.kt
+++ b/auth-foundation/src/test/java/com/okta/authfoundation/credential/DefaultCredentialIdDataStoreTest.kt
@@ -18,10 +18,15 @@ package com.okta.authfoundation.credential
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
+import com.okta.authfoundation.AuthFoundation
 import com.okta.authfoundation.client.ApplicationContextHolder
 import com.okta.testhelpers.MockAesEncryptionHandler
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockkObject
+import io.mockk.runs
 import io.mockk.unmockkAll
 import kotlinx.coroutines.test.runTest
 import org.junit.After
@@ -38,6 +43,8 @@ class DefaultCredentialIdDataStoreTest {
         mockkObject(ApplicationContextHolder)
         every { ApplicationContextHolder.appContext } returns ApplicationProvider.getApplicationContext()
         defaultCredentialIdDataStore = DefaultCredentialIdDataStore(MockAesEncryptionHandler.getInstance())
+        mockkObject(AuthFoundation)
+        coEvery { AuthFoundation.initializeStorage() } just runs
     }
 
     @After
@@ -48,6 +55,7 @@ class DefaultCredentialIdDataStoreTest {
     @Test
     fun `getDefaultCredentialId returns null if no default token is set`() = runTest {
         assertThat(defaultCredentialIdDataStore.getDefaultCredentialId()).isNull()
+        coVerify { AuthFoundation.initializeStorage() }
     }
 
     @Test
@@ -55,6 +63,7 @@ class DefaultCredentialIdDataStoreTest {
         val tokenId = "tokenId"
         defaultCredentialIdDataStore.setDefaultCredentialId(tokenId)
         assertThat(defaultCredentialIdDataStore.getDefaultCredentialId()).isEqualTo(tokenId)
+        coVerify { AuthFoundation.initializeStorage() }
     }
 
     @Test
@@ -65,5 +74,6 @@ class DefaultCredentialIdDataStoreTest {
         defaultCredentialIdDataStore.setDefaultCredentialId(newTokenId)
 
         assertThat(defaultCredentialIdDataStore.getDefaultCredentialId()).isEqualTo(newTokenId)
+        coVerify { AuthFoundation.initializeStorage() }
     }
 }

--- a/auth-foundation/src/test/java/com/okta/authfoundation/credential/storage/V1ToV2StorageMigratorTest.kt
+++ b/auth-foundation/src/test/java/com/okta/authfoundation/credential/storage/V1ToV2StorageMigratorTest.kt
@@ -21,6 +21,7 @@ import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
+import com.okta.authfoundation.AuthFoundation
 import com.okta.authfoundation.client.ApplicationContextHolder
 import com.okta.authfoundation.client.OidcConfiguration
 import com.okta.authfoundation.credential.DefaultCredentialIdDataStore
@@ -33,9 +34,12 @@ import com.okta.authfoundation.credential.storage.migration.V1ToV2StorageMigrato
 import com.okta.authfoundation.credential.storage.migration.V1ToV2StorageMigrator.Companion.LEGACY_DEFAULT_CREDENTIAL_NAME_TAG_VALUE
 import com.okta.testhelpers.MockAesEncryptionHandler
 import com.okta.testhelpers.TestTokenEncryptionHandler
+import io.mockk.coEvery
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkObject
+import io.mockk.runs
 import io.mockk.unmockkAll
 import kotlinx.coroutines.test.runTest
 import org.junit.After
@@ -77,6 +81,8 @@ class V1ToV2StorageMigratorTest {
         every { OidcConfiguration.default } returns OidcConfiguration("clientId", "defaultScope", "issuer")
         mockkObject(V1ToV2StorageMigrator)
         every { V1ToV2StorageMigrator.legacyKeyGenParameterSpec } returns mockk()
+        mockkObject(AuthFoundation)
+        coEvery { AuthFoundation.initializeStorage() } just runs
     }
 
     @After


### PR DESCRIPTION
This PR adds a fix for the scenario where user migrates from v1 of this SDK to v2. For users migrating from v1 to v2, automigration for storage kicks off after Token storage is initialized. But, DefaultCredentialIdDataStore could be accessed before token storage was migrated. Because of this. Credential.default would always return null on the first call after v1 -> v2 migration.

To fix this, this PR simply calls AuthfoundationDefaults.tokenStorageFactory in DefaultCredentialIdDataStore when getting the default credential. The contract for AuthfoundationDefaults.tokenStorageFactory says that it should return the singleton token storage, so calling it repeatedly for each call to getDefaultCredentialId should have no negative impact.