### PR TITLE
Add JVM-specific builder, result wrapper, and event emission

### DIFF
--- a/auth-foundation/api/jvm/auth-foundation.api
+++ b/auth-foundation/api/jvm/auth-foundation.api
@@ -247,6 +247,7 @@ public abstract interface class com/okta/authfoundation/client/Cache {
 public final class com/okta/authfoundation/client/CommonOAuth2Client {
 	public final fun endpointsOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getConfiguration ()Lcom/okta/authfoundation/client/OAuth2ClientConfiguration;
+	public final fun getEvents ()Lkotlinx/coroutines/flow/SharedFlow;
 	public final fun getUserInfo (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun introspectToken (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun jwks (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -264,7 +265,6 @@ public final class com/okta/authfoundation/client/OAuth2ClientBuilder {
 	public final fun getClientSecret ()Ljava/lang/String;
 	public final fun getClock ()Lcom/okta/authfoundation/client/OidcClock;
 	public final fun getComputeDispatcher ()Lkotlin/coroutines/CoroutineContext;
-	public final fun getEventHandlers ()Ljava/util/List;
 	public final fun getIoDispatcher ()Lkotlin/coroutines/CoroutineContext;
 	public final fun getJson ()Lkotlinx/serialization/json/Json;
 	public final fun setAcrValues (Ljava/lang/String;)V
@@ -274,7 +274,6 @@ public final class com/okta/authfoundation/client/OAuth2ClientBuilder {
 	public final fun setClientSecret (Ljava/lang/String;)V
 	public final fun setClock (Lcom/okta/authfoundation/client/OidcClock;)V
 	public final fun setComputeDispatcher (Lkotlin/coroutines/CoroutineContext;)V
-	public final fun setEventHandlers (Ljava/util/List;)V
 	public final fun setIoDispatcher (Lkotlin/coroutines/CoroutineContext;)V
 	public final fun setJson (Lkotlinx/serialization/json/Json;)V
 }
@@ -293,7 +292,6 @@ public final class com/okta/authfoundation/client/OAuth2ClientConfiguration {
 	public final fun getClientSecret ()Ljava/lang/String;
 	public final fun getClock ()Lcom/okta/authfoundation/client/OidcClock;
 	public final fun getDefaultScope ()Ljava/lang/String;
-	public final fun getEventHandlers ()Ljava/util/List;
 	public final fun getIssuerUrl ()Ljava/lang/String;
 	public final fun getJson ()Lkotlinx/serialization/json/Json;
 }
@@ -344,6 +342,16 @@ public final class com/okta/authfoundation/client/dto/OidcUserInfo : com/okta/au
 	public fun deserializeClaims (Lkotlinx/serialization/DeserializationStrategy;)Ljava/lang/Object;
 }
 
+public final class com/okta/authfoundation/client/events/TokenRefreshedEvent : com/okta/authfoundation/events/Event {
+	public fun <init> (Lcom/okta/authfoundation/client/TokenInfo;)V
+	public final fun getTokenInfo ()Lcom/okta/authfoundation/client/TokenInfo;
+}
+
+public final class com/okta/authfoundation/client/events/TokenRevokedEvent : com/okta/authfoundation/events/Event {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun getToken ()Ljava/lang/String;
+}
+
 public final class com/okta/authfoundation/client/internal/OAuth2Endpoints {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public final fun getAuthorizationEndpoint ()Ljava/lang/String;
@@ -355,6 +363,36 @@ public final class com/okta/authfoundation/client/internal/OAuth2Endpoints {
 	public final fun getRevocationEndpoint ()Ljava/lang/String;
 	public final fun getTokenEndpoint ()Ljava/lang/String;
 	public final fun getUserInfoEndpoint ()Ljava/lang/String;
+}
+
+public final class com/okta/authfoundation/client/jvm/AuthFoundationResult {
+	public static final field Companion Lcom/okta/authfoundation/client/jvm/AuthFoundationResult$Companion;
+	public synthetic fun <init> (Ljava/lang/Object;Ljava/lang/Throwable;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun exceptionOrNull ()Ljava/lang/Throwable;
+	public static final fun failure (Ljava/lang/Throwable;)Lcom/okta/authfoundation/client/jvm/AuthFoundationResult;
+	public final fun getOrNull ()Ljava/lang/Object;
+	public final fun getOrThrow ()Ljava/lang/Object;
+	public final fun isFailure ()Z
+	public final fun isSuccess ()Z
+	public static final fun success (Ljava/lang/Object;)Lcom/okta/authfoundation/client/jvm/AuthFoundationResult;
+}
+
+public final class com/okta/authfoundation/client/jvm/AuthFoundationResult$Companion {
+	public final fun failure (Ljava/lang/Throwable;)Lcom/okta/authfoundation/client/jvm/AuthFoundationResult;
+	public final fun success (Ljava/lang/Object;)Lcom/okta/authfoundation/client/jvm/AuthFoundationResult;
+}
+
+public final class com/okta/authfoundation/client/jvm/OAuth2ClientBuilder {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public final fun build ()Lcom/okta/authfoundation/client/jvm/AuthFoundationResult;
+	public final fun setAcrValues (Ljava/lang/String;)Lcom/okta/authfoundation/client/jvm/OAuth2ClientBuilder;
+	public final fun setApiExecutor (Lcom/okta/authfoundation/api/http/ApiExecutor;)Lcom/okta/authfoundation/client/jvm/OAuth2ClientBuilder;
+	public final fun setAuthorizationServerId (Ljava/lang/String;)Lcom/okta/authfoundation/client/jvm/OAuth2ClientBuilder;
+	public final fun setCache (Lcom/okta/authfoundation/client/Cache;)Lcom/okta/authfoundation/client/jvm/OAuth2ClientBuilder;
+	public final fun setClientSecret (Ljava/lang/String;)Lcom/okta/authfoundation/client/jvm/OAuth2ClientBuilder;
+	public final fun setClock (Lcom/okta/authfoundation/client/OidcClock;)Lcom/okta/authfoundation/client/jvm/OAuth2ClientBuilder;
+	public final fun setComputeDispatcher (Lkotlin/coroutines/CoroutineContext;)Lcom/okta/authfoundation/client/jvm/OAuth2ClientBuilder;
+	public final fun setIoDispatcher (Lkotlin/coroutines/CoroutineContext;)Lcom/okta/authfoundation/client/jvm/OAuth2ClientBuilder;
 }
 
 public final class com/okta/authfoundation/credential/RevokeTokenType : java/lang/Enum {

--- a/auth-foundation/build.gradle.kts
+++ b/auth-foundation/build.gradle.kts
@@ -142,6 +142,7 @@ kotlin {
                 implementation(libs.ktor.client.mock)
                 implementation(libs.kotlin.test)
                 implementation(libs.coroutines.test)
+                implementation(libs.junit)
             }
         }
 

--- a/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/jwt/RsaSignatureVerifier.kt
+++ b/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/jwt/RsaSignatureVerifier.kt
@@ -15,10 +15,14 @@
  */
 package com.okta.authfoundation.jwt
 
+import com.okta.authfoundation.api.log.LogLevel
+import com.okta.authfoundation.api.log.getDefaultAuthFoundationLogger
 import java.math.BigInteger
 import java.security.KeyFactory
 import java.security.Signature
 import java.security.spec.RSAPublicKeySpec
+
+private val logger = getDefaultAuthFoundationLogger()
 
 internal actual fun verifyRs256Signature(
     modulus: ByteArray,
@@ -33,6 +37,7 @@ internal actual fun verifyRs256Signature(
         rs256Signature.initVerify(publicKey)
         rs256Signature.update(data)
         rs256Signature.verify(signature)
-    } catch (_: Exception) {
+    } catch (e: Exception) {
+        logger.write("RSA signature verification failed", tr = e, logLevel = LogLevel.WARN)
         false
     }

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/CommonOAuth2Client.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/CommonOAuth2Client.kt
@@ -17,14 +17,21 @@ package com.okta.authfoundation.client
 
 import com.okta.authfoundation.InternalAuthFoundationApi
 import com.okta.authfoundation.client.dto.OidcUserInfo
+import com.okta.authfoundation.client.events.TokenRefreshedEvent
+import com.okta.authfoundation.client.events.TokenRevokedEvent
 import com.okta.authfoundation.client.internal.OAuth2Endpoints
 import com.okta.authfoundation.client.internal.OAuth2TokenResponse
 import com.okta.authfoundation.client.internal.performFormPost
 import com.okta.authfoundation.client.internal.performJsonFormPost
 import com.okta.authfoundation.client.internal.performJsonGetRequest
+import com.okta.authfoundation.events.Event
 import com.okta.authfoundation.jwt.Jwks
 import com.okta.authfoundation.jwt.SerializableJwks
 import com.okta.authfoundation.util.CoalescingOrchestrator
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.serialization.json.JsonObject
 
 /**
@@ -32,7 +39,7 @@ import kotlinx.serialization.json.JsonObject
  *
  * Use [OAuth2ClientBuilder] to create an instance via the builder pattern.
  *
- * On Android, the existing [OAuth2Client] class provides backward-compatible access
+ * On Android, the existing OAuth2Client class provides backward-compatible access
  * with additional platform-specific features.
  */
 @OptIn(InternalAuthFoundationApi::class)
@@ -41,6 +48,23 @@ class CommonOAuth2Client internal constructor(
     val configuration: OAuth2ClientConfiguration,
     internal val endpointsOrchestrator: CoalescingOrchestrator<OAuth2ClientResult<OAuth2Endpoints>>,
 ) {
+    private val _events =
+        MutableSharedFlow<Event>(
+            replay = 0,
+            extraBufferCapacity = 64,
+            onBufferOverflow = BufferOverflow.DROP_OLDEST
+        )
+
+    /**
+     * A read-only flow of OAuth2 lifecycle events emitted by this client.
+     *
+     * Events are multicast — all active collectors receive every event independently.
+     * There is no replay; events emitted before a collector subscribes are not delivered.
+     * When no collectors are active, events are silently dropped (fire-and-forget semantics).
+     * The emitter is never suspended; if the buffer is full, the oldest event is dropped.
+     */
+    val events: SharedFlow<Event> = _events.asSharedFlow()
+
     private val jwksOrchestrator: CoalescingOrchestrator<OAuth2ClientResult<Jwks>> =
         CoalescingOrchestrator(
             factory = ::fetchJwks,
@@ -78,6 +102,8 @@ class CommonOAuth2Client internal constructor(
      *
      * @param refreshToken the refresh token string.
      * @return the new token response as a [TokenInfo].
+     *
+     * TODO change return value from OAuth2ClientResult<TokenInfo> to Result<TokenInfo>
      */
     suspend fun refreshToken(refreshToken: String): OAuth2ClientResult<TokenInfo> {
         val endpoints = endpointsOrNull() ?: return endpointNotAvailableError()
@@ -97,6 +123,11 @@ class CommonOAuth2Client internal constructor(
             deserializer = OAuth2TokenResponse.serializer()
         ).mapSuccess { response ->
             response.toTokenInfo(configuration.clientId, configuration.issuerUrl)
+        }.also { result ->
+            // TODO convert OAuth2ClientResult to Result and emit Result.failures
+            if (result is OAuth2ClientResult.Success) {
+                _events.tryEmit(TokenRefreshedEvent(result.result))
+            }
         }
     }
 
@@ -104,6 +135,7 @@ class CommonOAuth2Client internal constructor(
      * Attempt to revoke the specified token.
      *
      * @param token the token string to revoke.
+     * TODO change return value from OAuth2ClientResult<Unit> to Result<String>
      */
     suspend fun revokeToken(token: String): OAuth2ClientResult<Unit> {
         val endpoint = endpointsOrNull()?.revocationEndpoint ?: return endpointNotAvailableError()
@@ -118,7 +150,12 @@ class CommonOAuth2Client internal constructor(
             apiExecutor = configuration.apiExecutor,
             url = endpoint,
             formParams = formParams
-        )
+        ).also { result ->
+            // TODO convert OAuth2ClientResult to Result and emit Result.failures
+            if (result is OAuth2ClientResult.Success) {
+                _events.tryEmit(TokenRevokedEvent(token))
+            }
+        }
     }
 
     /**

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/OAuth2ClientBuilder.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/OAuth2ClientBuilder.kt
@@ -19,7 +19,6 @@ import com.okta.authfoundation.InternalAuthFoundationApi
 import com.okta.authfoundation.api.http.ApiExecutor
 import com.okta.authfoundation.api.http.KtorHttpExecutor
 import com.okta.authfoundation.client.internal.EndpointDiscovery
-import com.okta.authfoundation.events.EventHandler
 import com.okta.authfoundation.util.CoalescingOrchestrator
 import io.ktor.http.URLProtocol
 import io.ktor.http.Url
@@ -65,9 +64,6 @@ class OAuth2ClientBuilder private constructor(
 
     /** The cache for optimizing network calls. */
     var cache: Cache = NoOpCache()
-
-    /** Event handlers for lifecycle events. */
-    var eventHandlers: List<EventHandler> = emptyList()
 
     /** Optional authorization server ID. */
     var authorizationServerId: String? = null
@@ -130,7 +126,6 @@ class OAuth2ClientBuilder private constructor(
             clock = clock,
             json = json,
             cache = cache,
-            eventHandlers = eventHandlers,
             authorizationServerId = authorizationServerId,
             clientSecret = clientSecret,
             acrValues = acrValues

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/OAuth2ClientConfiguration.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/OAuth2ClientConfiguration.kt
@@ -16,12 +16,10 @@
 package com.okta.authfoundation.client
 
 import com.okta.authfoundation.api.http.ApiExecutor
-import com.okta.authfoundation.events.EventHandler
 import kotlinx.serialization.json.Json
-import kotlin.coroutines.CoroutineContext
 
 /**
- * Immutable configuration for [OAuth2Client].
+ * Immutable configuration for [CommonOAuth2Client].
  *
  * Created via [OAuth2ClientBuilder]. Contains all settings needed to construct and operate an OAuth2 client
  * without requiring global singletons.
@@ -41,8 +39,6 @@ class OAuth2ClientConfiguration internal constructor(
     val json: Json,
     /** The cache used to optimize network calls. */
     val cache: Cache,
-    /** Optional event handlers for lifecycle events. */
-    val eventHandlers: List<EventHandler>,
     /** Optional authorization server ID. */
     val authorizationServerId: String?,
     /** Optional client secret for confidential clients. */

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/events/CommonOAuth2Events.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/events/CommonOAuth2Events.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.client.events
+
+import com.okta.authfoundation.client.CommonOAuth2Client
+import com.okta.authfoundation.client.TokenInfo
+import com.okta.authfoundation.events.Event
+
+/**
+ * Emitted when a token has been refreshed via [CommonOAuth2Client.refreshToken].
+ */
+class TokenRefreshedEvent(
+    /** The new token information returned from the refresh. */
+    val tokenInfo: TokenInfo,
+) : Event
+
+/**
+ * Emitted when a token has been revoked via [CommonOAuth2Client.revokeToken].
+ */
+class TokenRevokedEvent(
+    /** The token string that was revoked. */
+    val token: String,
+) : Event

--- a/auth-foundation/src/commonTest/kotlin/com/okta/authfoundation/client/CommonOAuth2ClientEventsTest.kt
+++ b/auth-foundation/src/commonTest/kotlin/com/okta/authfoundation/client/CommonOAuth2ClientEventsTest.kt
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.client
+
+import com.okta.authfoundation.InternalAuthFoundationApi
+import com.okta.authfoundation.api.http.ApiExecutor
+import com.okta.authfoundation.api.http.ApiRequest
+import com.okta.authfoundation.api.http.ApiResponse
+import com.okta.authfoundation.client.events.TokenRefreshedEvent
+import com.okta.authfoundation.client.events.TokenRevokedEvent
+import com.okta.authfoundation.client.internal.OAuth2Endpoints
+import com.okta.authfoundation.events.Event
+import com.okta.authfoundation.util.CoalescingOrchestrator
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+@OptIn(InternalAuthFoundationApi::class, ExperimentalCoroutinesApi::class)
+class CommonOAuth2ClientEventsTest {
+    private val testEndpoints =
+        OAuth2Endpoints(
+            issuer = "https://example.okta.com/oauth2/default",
+            authorizationEndpoint = "https://example.okta.com/oauth2/default/v1/authorize",
+            tokenEndpoint = "https://example.okta.com/oauth2/default/v1/token",
+            userInfoEndpoint = "https://example.okta.com/oauth2/default/v1/userinfo",
+            jwksUri = "https://example.okta.com/oauth2/default/v1/keys",
+            introspectionEndpoint = "https://example.okta.com/oauth2/default/v1/introspect",
+            revocationEndpoint = "https://example.okta.com/oauth2/default/v1/revoke",
+            endSessionEndpoint = "https://example.okta.com/oauth2/default/v1/logout",
+            deviceAuthorizationEndpoint = null
+        )
+
+    private fun mockApiExecutor(responseBody: String): ApiExecutor =
+        object : ApiExecutor {
+            override suspend fun execute(request: ApiRequest): Result<ApiResponse> =
+                Result.success(
+                    object : ApiResponse {
+                        override val statusCode: Int = 200
+                        override val body: ByteArray = responseBody.toByteArray()
+                        override val headers: Map<String, List<String>> = emptyMap()
+                        override val contentLength: Long = responseBody.length.toLong()
+                        override val contentType: String = "application/json"
+                    }
+                )
+        }
+
+    private fun createClient(apiExecutor: ApiExecutor): CommonOAuth2Client {
+        val config =
+            OAuth2ClientBuilder
+                .create(
+                    issuerUrl = "https://example.okta.com/oauth2/default",
+                    clientId = "test-client-id",
+                    scope = listOf("openid", "profile")
+                ) {
+                    this.apiExecutor = apiExecutor
+                }.getOrThrow()
+                .configuration
+
+        return CommonOAuth2Client(
+            configuration = config,
+            endpointsOrchestrator =
+                CoalescingOrchestrator(
+                    factory = { OAuth2ClientResult.Success(testEndpoints) },
+                    keepDataInMemory = { true }
+                )
+        )
+    }
+
+    @Test
+    fun refreshToken_EmitsTokenRefreshedEvent() =
+        runTest {
+            val recordedEvents = mutableListOf<Event>()
+            val tokenJson =
+                """
+                {
+                    "token_type": "Bearer",
+                    "expires_in": 3600,
+                    "access_token": "new-access-token",
+                    "scope": "openid profile",
+                    "refresh_token": null,
+                    "id_token": null
+                }
+                """.trimIndent()
+
+            val client = createClient(mockApiExecutor(tokenJson))
+            val collectJob =
+                backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+                    client.events.collect { recordedEvents.add(it) }
+                }
+
+            val result = client.refreshToken("old-refresh-token")
+
+            assertTrue(result is OAuth2ClientResult.Success)
+            assertEquals(1, recordedEvents.size)
+            val event = assertIs<TokenRefreshedEvent>(recordedEvents[0])
+            assertEquals("new-access-token", event.tokenInfo.accessToken)
+            collectJob.cancel()
+        }
+
+    @Test
+    fun revokeToken_EmitsTokenRevokedEvent() =
+        runTest {
+            val recordedEvents = mutableListOf<Event>()
+            val client = createClient(mockApiExecutor(""))
+            val collectJob =
+                backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+                    client.events.collect { recordedEvents.add(it) }
+                }
+
+            val result = client.revokeToken("some-token")
+
+            assertTrue(result is OAuth2ClientResult.Success)
+            assertEquals(1, recordedEvents.size)
+            val event = assertIs<TokenRevokedEvent>(recordedEvents[0])
+            assertEquals("some-token", event.token)
+            collectJob.cancel()
+        }
+
+    @Test
+    fun refreshToken_OnFailure_DoesNotEmitEvent() =
+        runTest {
+            val recordedEvents = mutableListOf<Event>()
+            val failingExecutor =
+                object : ApiExecutor {
+                    override suspend fun execute(request: ApiRequest): Result<ApiResponse> = Result.failure(RuntimeException("Network error"))
+                }
+
+            val client = createClient(failingExecutor)
+            val collectJob =
+                backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+                    client.events.collect { recordedEvents.add(it) }
+                }
+
+            val result = client.refreshToken("old-refresh-token")
+
+            assertTrue(result is OAuth2ClientResult.Error)
+            assertEquals(0, recordedEvents.size)
+            collectJob.cancel()
+        }
+}

--- a/auth-foundation/src/commonTest/kotlin/com/okta/authfoundation/client/OAuth2ClientSharedConfigTest.kt
+++ b/auth-foundation/src/commonTest/kotlin/com/okta/authfoundation/client/OAuth2ClientSharedConfigTest.kt
@@ -15,6 +15,7 @@
  */
 package com.okta.authfoundation.client
 
+import com.okta.authfoundation.InternalAuthFoundationApi
 import com.okta.authfoundation.api.http.ApiExecutor
 import com.okta.authfoundation.api.http.ApiRequest
 import com.okta.authfoundation.api.http.ApiResponse
@@ -26,6 +27,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotSame
 import kotlin.test.assertTrue
 
+@OptIn(InternalAuthFoundationApi::class)
 class OAuth2ClientSharedConfigTest {
     private val testEndpoints =
         OAuth2Endpoints(

--- a/auth-foundation/src/jvmMain/kotlin/com/okta/authfoundation/client/jvm/AuthFoundationResult.kt
+++ b/auth-foundation/src/jvmMain/kotlin/com/okta/authfoundation/client/jvm/AuthFoundationResult.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.client.jvm
+
+/**
+ * A Java-friendly result type that wraps a successful value or a failure exception.
+ *
+ * Unlike Kotlin's [kotlin.Result] (which is a value class with JVM limitations),
+ * this class is a standard class that Java callers can use directly.
+ *
+ * @param T The type of the successful value.
+ */
+class AuthFoundationResult<T> private constructor(
+    private val value: T?,
+    private val exception: Throwable?,
+) {
+    /**
+     * Returns `true` if the result is a success.
+     */
+    fun isSuccess(): Boolean = exception == null
+
+    /**
+     * Returns `true` if the result is a failure.
+     */
+    fun isFailure(): Boolean = exception != null
+
+    /**
+     * Returns the successful value, or throws the failure exception.
+     *
+     * @return The successful value.
+     * @throws Throwable if this result is a failure.
+     */
+    fun getOrThrow(): T {
+        if (exception != null) throw exception
+        return value!!
+    }
+
+    /**
+     * Returns the successful value, or `null` if this result is a failure.
+     */
+    fun getOrNull(): T? = if (exception == null) value else null
+
+    /**
+     * Returns the failure exception, or `null` if this result is a success.
+     */
+    fun exceptionOrNull(): Throwable? = exception
+
+    companion object {
+        /**
+         * Creates a successful result.
+         */
+        @JvmStatic
+        fun <T> success(value: T): AuthFoundationResult<T> = AuthFoundationResult(value, null)
+
+        /**
+         * Creates a failed result.
+         */
+        @JvmStatic
+        fun <T> failure(exception: Throwable): AuthFoundationResult<T> = AuthFoundationResult(null, exception)
+
+        /**
+         * Converts a Kotlin [kotlin.Result] to a Java-friendly [AuthFoundationResult].
+         */
+        internal fun <T> fromKotlinResult(result: Result<T>): AuthFoundationResult<T> =
+            result.fold(
+                onSuccess = { success(it) },
+                onFailure = { failure(it) }
+            )
+    }
+}

--- a/auth-foundation/src/jvmMain/kotlin/com/okta/authfoundation/client/jvm/OAuth2ClientBuilder.kt
+++ b/auth-foundation/src/jvmMain/kotlin/com/okta/authfoundation/client/jvm/OAuth2ClientBuilder.kt
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.client.jvm
+
+import com.okta.authfoundation.api.http.ApiExecutor
+import com.okta.authfoundation.client.Cache
+import com.okta.authfoundation.client.CommonOAuth2Client
+import com.okta.authfoundation.client.OAuth2ClientBuilder
+import com.okta.authfoundation.client.OidcClock
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * A Java-idiomatic builder for creating instances of [CommonOAuth2Client].
+ *
+ * This builder provides method-chaining setters for optional parameters and delegates
+ * to the Kotlin [OAuth2ClientBuilder] for the actual construction.
+ *
+ * @param issuerUrl The base URL of the Authorization Server.
+ * @param clientId The client ID of the application.
+ * @param scope The OAuth 2.0 scopes the application is requesting.
+ */
+class OAuth2ClientBuilder(
+    private val issuerUrl: String,
+    private val clientId: String,
+    private val scope: List<String>,
+) {
+    private var apiExecutor: ApiExecutor? = null
+    private var clock: OidcClock? = null
+    private var ioDispatcher: CoroutineContext? = null
+    private var computeDispatcher: CoroutineContext? = null
+    private var cache: Cache? = null
+    private var authorizationServerId: String? = null
+    private var clientSecret: String? = null
+    private var acrValues: String? = null
+
+    /**
+     * Sets the HTTP executor used for all network requests.
+     *
+     * @param apiExecutor The [ApiExecutor] to use.
+     * @return This builder for chaining.
+     */
+    fun setApiExecutor(apiExecutor: ApiExecutor): com.okta.authfoundation.client.jvm.OAuth2ClientBuilder =
+        apply {
+            this.apiExecutor = apiExecutor
+        }
+
+    /**
+     * Sets the clock used for time-sensitive operations.
+     *
+     * @param clock The [OidcClock] to use.
+     * @return This builder for chaining.
+     */
+    fun setClock(clock: OidcClock): com.okta.authfoundation.client.jvm.OAuth2ClientBuilder =
+        apply {
+            this.clock = clock
+        }
+
+    /**
+     * Sets the dispatcher for IO-bound operations.
+     *
+     * @param dispatcher The [CoroutineContext] for IO.
+     * @return This builder for chaining.
+     */
+    fun setIoDispatcher(dispatcher: CoroutineContext): com.okta.authfoundation.client.jvm.OAuth2ClientBuilder =
+        apply {
+            this.ioDispatcher = dispatcher
+        }
+
+    /**
+     * Sets the dispatcher for compute-bound operations.
+     *
+     * @param dispatcher The [CoroutineContext] for computation.
+     * @return This builder for chaining.
+     */
+    fun setComputeDispatcher(dispatcher: CoroutineContext): com.okta.authfoundation.client.jvm.OAuth2ClientBuilder =
+        apply {
+            this.computeDispatcher = dispatcher
+        }
+
+    /**
+     * Sets the cache for optimizing network calls.
+     *
+     * @param cache The [Cache] to use.
+     * @return This builder for chaining.
+     */
+    fun setCache(cache: Cache): com.okta.authfoundation.client.jvm.OAuth2ClientBuilder =
+        apply {
+            this.cache = cache
+        }
+
+    /**
+     * Sets the authorization server ID.
+     *
+     * @param authorizationServerId The ID of the authorization server.
+     * @return This builder for chaining.
+     */
+    fun setAuthorizationServerId(authorizationServerId: String): com.okta.authfoundation.client.jvm.OAuth2ClientBuilder =
+        apply {
+            this.authorizationServerId = authorizationServerId
+        }
+
+    /**
+     * Sets the client secret for confidential clients.
+     *
+     * @param clientSecret The client secret.
+     * @return This builder for chaining.
+     */
+    fun setClientSecret(clientSecret: String): com.okta.authfoundation.client.jvm.OAuth2ClientBuilder =
+        apply {
+            this.clientSecret = clientSecret
+        }
+
+    /**
+     * Sets the ACR values.
+     *
+     * @param acrValues The ACR values string.
+     * @return This builder for chaining.
+     */
+    fun setAcrValues(acrValues: String): com.okta.authfoundation.client.jvm.OAuth2ClientBuilder =
+        apply {
+            this.acrValues = acrValues
+        }
+
+    /**
+     * Creates a [CommonOAuth2Client] instance with the configured parameters.
+     *
+     * @return A [AuthFoundationResult] containing the [CommonOAuth2Client] on success, or an exception on failure.
+     */
+    fun build(): AuthFoundationResult<CommonOAuth2Client> {
+        val kotlinResult =
+            OAuth2ClientBuilder.create(issuerUrl, clientId, scope) {
+                this@OAuth2ClientBuilder.apiExecutor?.let { apiExecutor = it }
+                this@OAuth2ClientBuilder.clock?.let { clock = it }
+                this@OAuth2ClientBuilder.ioDispatcher?.let { ioDispatcher = it }
+                this@OAuth2ClientBuilder.computeDispatcher?.let { computeDispatcher = it }
+                this@OAuth2ClientBuilder.cache?.let { cache = it }
+                this@OAuth2ClientBuilder.authorizationServerId?.let { authorizationServerId = it }
+                this@OAuth2ClientBuilder.clientSecret?.let { clientSecret = it }
+                this@OAuth2ClientBuilder.acrValues?.let { acrValues = it }
+            }
+        return AuthFoundationResult.fromKotlinResult(kotlinResult)
+    }
+}

--- a/auth-foundation/src/jvmMain/kotlin/com/okta/authfoundation/jwt/RsaSignatureVerifier.kt
+++ b/auth-foundation/src/jvmMain/kotlin/com/okta/authfoundation/jwt/RsaSignatureVerifier.kt
@@ -15,10 +15,14 @@
  */
 package com.okta.authfoundation.jwt
 
+import com.okta.authfoundation.api.log.LogLevel
+import com.okta.authfoundation.api.log.getDefaultAuthFoundationLogger
 import java.math.BigInteger
 import java.security.KeyFactory
 import java.security.Signature
 import java.security.spec.RSAPublicKeySpec
+
+private val logger = getDefaultAuthFoundationLogger()
 
 internal actual fun verifyRs256Signature(
     modulus: ByteArray,
@@ -33,6 +37,7 @@ internal actual fun verifyRs256Signature(
         rs256Signature.initVerify(publicKey)
         rs256Signature.update(data)
         rs256Signature.verify(signature)
-    } catch (_: Exception) {
+    } catch (e: Exception) {
+        logger.write("RSA signature verification failed", tr = e, logLevel = LogLevel.WARN)
         false
     }

--- a/auth-foundation/src/jvmTest/java/com/okta/authfoundation/client/jvm/OAuth2ClientBuilderJavaTest.java
+++ b/auth-foundation/src/jvmTest/java/com/okta/authfoundation/client/jvm/OAuth2ClientBuilderJavaTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.client.jvm;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.okta.authfoundation.client.CommonOAuth2Client;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.Test;
+
+/** Pure Java tests verifying that the JvmOAuth2ClientBuilder API is usable from Java. */
+public class OAuth2ClientBuilderJavaTest {
+
+  private static final String ISSUER_URL = "https://example.okta.com/oauth2/default";
+  private static final String CLIENT_ID = "test-client-id";
+  private static final String SCOPE = "openid profile";
+
+  @Test
+  public void build_WithRequiredParamsOnly_Succeeds() {
+    OAuth2ClientBuilder builder =
+        new OAuth2ClientBuilder(ISSUER_URL, CLIENT_ID, Arrays.asList(SCOPE.split(" ")));
+
+    AuthFoundationResult<CommonOAuth2Client> result = builder.build();
+
+    assertTrue("Build with required params should succeed", result.isSuccess());
+    assertNotNull("Client should not be null", result.getOrThrow());
+  }
+
+  @Test
+  public void build_WithChainingSetters_Succeeds() {
+    CommonOAuth2Client client =
+        new OAuth2ClientBuilder(ISSUER_URL, CLIENT_ID, Arrays.asList(SCOPE.split(" ")))
+            .setAuthorizationServerId("default")
+            .setClientSecret("secret")
+            .setAcrValues("urn:okta:loa:2fa:any")
+            .build()
+            .getOrThrow();
+
+    assertNotNull("Client should not be null after chaining", client);
+  }
+
+  @Test
+  public void build_WithInvalidIssuerUrl_Fails() {
+    OAuth2ClientBuilder builder =
+        new OAuth2ClientBuilder(
+            "http://insecure.example.com", CLIENT_ID, Arrays.asList(SCOPE.split(" ")));
+
+    AuthFoundationResult<CommonOAuth2Client> result = builder.build();
+
+    assertTrue("Build with HTTP URL should fail", result.isFailure());
+  }
+
+  @Test
+  public void build_WithEmptyClientId_Fails() {
+    OAuth2ClientBuilder builder =
+        new OAuth2ClientBuilder(ISSUER_URL, "", Arrays.asList(SCOPE.split(" ")));
+
+    AuthFoundationResult<CommonOAuth2Client> result = builder.build();
+
+    assertTrue("Build with empty clientId should fail", result.isFailure());
+  }
+
+  @Test
+  public void build_WithEmptyScope_Fails() {
+    OAuth2ClientBuilder builder =
+        new OAuth2ClientBuilder(ISSUER_URL, CLIENT_ID, Collections.emptyList());
+
+    AuthFoundationResult<CommonOAuth2Client> result = builder.build();
+
+    assertTrue("Build with empty scope should fail", result.isFailure());
+  }
+}


### PR DESCRIPTION
Add jvm OAuth2ClientBuilder (Java-idiomatic builder) and AuthFoundationResult (Java-friendly Result wrapper) for JVM consumers. 

Emit TokenRefreshedEvent and TokenRevokedEvent via SharedFlow after successful token operations.

Update API dump for all new public API surfaces.
    
Emit events via eventHandlers is replaced with a SharedFlow in CommonOAuth2Client.
    
CommonOAuth2Client now emit events from a SharedFlow after:
    - refreshToken success -> TokenRefreshedEvent
    - revokeToken success -> TokenRevokedEvent
No events emitted on failure yet. Includes JVM tests for event emission.