### PR TITLE
Add cross-platform User-Agent header and ID token validation

### DIFF
--- a/auth-foundation/api/jvm/auth-foundation.api
+++ b/auth-foundation/api/jvm/auth-foundation.api
@@ -255,6 +255,7 @@ public final class com/okta/authfoundation/client/OAuth2ClientBuilder {
 	public final fun getClientSecret ()Ljava/lang/String;
 	public final fun getClock ()Lcom/okta/authfoundation/client/OidcClock;
 	public final fun getComputeDispatcher ()Lkotlin/coroutines/CoroutineContext;
+	public final fun getIdTokenValidator ()Lcom/okta/authfoundation/client/kmp/IdTokenValidator;
 	public final fun getIoDispatcher ()Lkotlin/coroutines/CoroutineContext;
 	public final fun getJson ()Lkotlinx/serialization/json/Json;
 	public final fun setAcrValues (Ljava/lang/String;)V
@@ -264,6 +265,7 @@ public final class com/okta/authfoundation/client/OAuth2ClientBuilder {
 	public final fun setClientSecret (Ljava/lang/String;)V
 	public final fun setClock (Lcom/okta/authfoundation/client/OidcClock;)V
 	public final fun setComputeDispatcher (Lkotlin/coroutines/CoroutineContext;)V
+	public final fun setIdTokenValidator (Lcom/okta/authfoundation/client/kmp/IdTokenValidator;)V
 	public final fun setIoDispatcher (Lkotlin/coroutines/CoroutineContext;)V
 	public final fun setJson (Lkotlinx/serialization/json/Json;)V
 }
@@ -282,6 +284,7 @@ public final class com/okta/authfoundation/client/OAuth2ClientConfiguration {
 	public final fun getClientSecret ()Ljava/lang/String;
 	public final fun getClock ()Lcom/okta/authfoundation/client/OidcClock;
 	public final fun getDefaultScope ()Ljava/lang/String;
+	public final fun getIdTokenValidator ()Lcom/okta/authfoundation/client/kmp/IdTokenValidator;
 	public final fun getIssuerUrl ()Ljava/lang/String;
 	public final fun getJson ()Lkotlinx/serialization/json/Json;
 }
@@ -401,6 +404,46 @@ public final class com/okta/authfoundation/client/jvm/OAuth2ClientBuilder {
 	public final fun setIoDispatcher (Lkotlin/coroutines/CoroutineContext;)Lcom/okta/authfoundation/client/jvm/OAuth2ClientBuilder;
 }
 
+public final class com/okta/authfoundation/client/kmp/DefaultIdTokenValidator : com/okta/authfoundation/client/kmp/IdTokenValidator {
+	public fun <init> ()V
+	public fun validate (Ljava/lang/String;Ljava/lang/String;Lcom/okta/authfoundation/jwt/Jwt;Lcom/okta/authfoundation/client/OidcClock;ILcom/okta/authfoundation/client/kmp/IdTokenValidator$Parameters;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/okta/authfoundation/client/kmp/IdTokenValidator {
+	public abstract fun validate (Ljava/lang/String;Ljava/lang/String;Lcom/okta/authfoundation/jwt/Jwt;Lcom/okta/authfoundation/client/OidcClock;ILcom/okta/authfoundation/client/kmp/IdTokenValidator$Parameters;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun validate$default (Lcom/okta/authfoundation/client/kmp/IdTokenValidator;Ljava/lang/String;Ljava/lang/String;Lcom/okta/authfoundation/jwt/Jwt;Lcom/okta/authfoundation/client/OidcClock;ILcom/okta/authfoundation/client/kmp/IdTokenValidator$Parameters;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/okta/authfoundation/client/kmp/IdTokenValidator$DefaultImpls {
+	public static synthetic fun validate$default (Lcom/okta/authfoundation/client/kmp/IdTokenValidator;Ljava/lang/String;Ljava/lang/String;Lcom/okta/authfoundation/jwt/Jwt;Lcom/okta/authfoundation/client/OidcClock;ILcom/okta/authfoundation/client/kmp/IdTokenValidator$Parameters;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/okta/authfoundation/client/kmp/IdTokenValidator$Error : java/lang/IllegalStateException {
+	public static final field Companion Lcom/okta/authfoundation/client/kmp/IdTokenValidator$Error$Companion;
+	public static final field EXPIRED Ljava/lang/String;
+	public static final field INVALID_AUDIENCE Ljava/lang/String;
+	public static final field INVALID_ISSUER Ljava/lang/String;
+	public static final field INVALID_JWT_ALGORITHM Ljava/lang/String;
+	public static final field INVALID_JWT_SIGNATURE Ljava/lang/String;
+	public static final field INVALID_SUBJECT Ljava/lang/String;
+	public static final field ISSUED_AT_THRESHOLD_NOT_SATISFIED Ljava/lang/String;
+	public static final field ISSUER_NOT_HTTPS Ljava/lang/String;
+	public static final field MAX_AGE_NOT_SATISFIED Ljava/lang/String;
+	public static final field NONCE_MISMATCH Ljava/lang/String;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getIdentifier ()Ljava/lang/String;
+}
+
+public final class com/okta/authfoundation/client/kmp/IdTokenValidator$Error$Companion {
+}
+
+public final class com/okta/authfoundation/client/kmp/IdTokenValidator$Parameters {
+	public fun <init> (Ljava/lang/String;Ljava/lang/Integer;)V
+	public final fun getMaxAge ()Ljava/lang/Integer;
+	public final fun getNonce ()Ljava/lang/String;
+}
+
 public final class com/okta/authfoundation/client/kmp/OAuth2Client {
 	public static final field Companion Lcom/okta/authfoundation/client/kmp/OAuth2Client$Companion;
 	public final fun endpointsOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -415,6 +458,11 @@ public final class com/okta/authfoundation/client/kmp/OAuth2Client {
 
 public final class com/okta/authfoundation/client/kmp/OAuth2Client$Companion {
 	public final fun createFromConfiguration (Lcom/okta/authfoundation/client/OAuth2ClientConfiguration;)Lcom/okta/authfoundation/client/kmp/OAuth2Client;
+}
+
+public final class com/okta/authfoundation/client/kmp/events/ValidateIdTokenEvent : com/okta/authfoundation/events/Event {
+	public fun <init> ()V
+	public final fun getIssuedAtGracePeriodInSeconds ()I
 }
 
 public abstract interface class com/okta/authfoundation/credential/CredentialIdentifier {

--- a/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/client/internal/UserAgent.android.kt
+++ b/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/client/internal/UserAgent.android.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.client.internal
+
+import android.os.Build
+
+internal actual fun platformUserAgentSuffix(): String = "Android/${Build.VERSION.SDK_INT}"

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/OAuth2ClientBuilder.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/OAuth2ClientBuilder.kt
@@ -19,6 +19,8 @@ import com.okta.authfoundation.InternalAuthFoundationApi
 import com.okta.authfoundation.api.http.ApiExecutor
 import com.okta.authfoundation.api.http.KtorHttpExecutor
 import com.okta.authfoundation.client.internal.EndpointDiscovery
+import com.okta.authfoundation.client.kmp.DefaultIdTokenValidator
+import com.okta.authfoundation.client.kmp.IdTokenValidator
 import com.okta.authfoundation.client.kmp.OAuth2Client
 import com.okta.authfoundation.util.CoalescingOrchestrator
 import io.ktor.http.URLProtocol
@@ -29,7 +31,7 @@ import kotlin.coroutines.CoroutineContext
 import kotlin.time.Clock
 
 /**
- * Builder for creating a [OAuth2Client].
+ * Builder for creating an [OAuth2Client].
  *
  * Use the [create] factory method to construct an instance.
  *
@@ -74,6 +76,9 @@ class OAuth2ClientBuilder private constructor(
 
     /** Optional ACR values. */
     var acrValues: String? = null
+
+    /** ID token validator. When set, ID tokens are validated after token refresh. */
+    var idTokenValidator: IdTokenValidator = DefaultIdTokenValidator()
 
     companion object {
         /**
@@ -129,6 +134,7 @@ class OAuth2ClientBuilder private constructor(
             cache = cache,
             authorizationServerId = authorizationServerId,
             clientSecret = clientSecret,
-            acrValues = acrValues
+            acrValues = acrValues,
+            idTokenValidator = idTokenValidator
         )
 }

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/OAuth2ClientConfiguration.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/OAuth2ClientConfiguration.kt
@@ -16,6 +16,8 @@
 package com.okta.authfoundation.client
 
 import com.okta.authfoundation.api.http.ApiExecutor
+import com.okta.authfoundation.client.kmp.DefaultIdTokenValidator
+import com.okta.authfoundation.client.kmp.IdTokenValidator
 import kotlinx.serialization.json.Json
 
 /**
@@ -45,4 +47,6 @@ class OAuth2ClientConfiguration internal constructor(
     val clientSecret: String?,
     /** Optional ACR values. */
     val acrValues: String?,
+    /** Validator for ID tokens. ID tokens are validated after token refresh. */
+    val idTokenValidator: IdTokenValidator = DefaultIdTokenValidator(),
 )

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/internal/OAuth2HttpOperations.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/internal/OAuth2HttpOperations.kt
@@ -24,6 +24,9 @@ import com.okta.authfoundation.client.OAuth2ClientResult
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.json.Json
 
+private val defaultHeaders: Map<String, List<String>> =
+    mapOf("User-Agent" to listOf(UserAgent.value))
+
 /**
  * Executes a JSON GET request and deserializes the response.
  */
@@ -36,11 +39,12 @@ internal suspend fun <T> performJsonGetRequest(
     headers: Map<String, List<String>> = mapOf("Accept" to listOf("application/json")),
 ): OAuth2ClientResult<T> =
     runCatching {
+        val mergedHeaders = defaultHeaders + headers
         val request =
             object : ApiRequest {
                 override fun method(): ApiRequestMethod = ApiRequestMethod.GET
 
-                override fun headers(): Map<String, List<String>> = headers
+                override fun headers(): Map<String, List<String>> = mergedHeaders
 
                 override fun url(): String = url
             }
@@ -66,11 +70,12 @@ internal suspend fun <T> performJsonFormPost(
     deserializer: DeserializationStrategy<T>,
 ): OAuth2ClientResult<T> =
     runCatching {
+        val mergedHeaders = defaultHeaders + mapOf("Accept" to listOf("application/json"))
         val request =
             object : ApiFormRequest {
                 override fun method(): ApiRequestMethod = ApiRequestMethod.POST
 
-                override fun headers(): Map<String, List<String>> = mapOf("Accept" to listOf("application/json"))
+                override fun headers(): Map<String, List<String>> = mergedHeaders
 
                 override fun url(): String = url
 
@@ -102,7 +107,7 @@ internal suspend fun performFormPost(
             object : ApiFormRequest {
                 override fun method(): ApiRequestMethod = ApiRequestMethod.POST
 
-                override fun headers(): Map<String, List<String>> = emptyMap()
+                override fun headers(): Map<String, List<String>> = defaultHeaders
 
                 override fun url(): String = url
 

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/internal/UserAgent.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/internal/UserAgent.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.client.internal
+
+import com.okta.authfoundation.SDK_VERSION
+
+/**
+ * Returns the platform-specific suffix for the user agent string (e.g., "Android/33", "JVM/17.0.1").
+ */
+internal expect fun platformUserAgentSuffix(): String
+
+/**
+ * Builds the user agent string for all HTTP requests made by the SDK.
+ *
+ * Format: `okta-auth-foundation-kotlin/<version> <platform>`
+ */
+internal object UserAgent {
+    val value: String = "$SDK_VERSION ${platformUserAgentSuffix()}"
+}

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/kmp/DefaultIdTokenValidator.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/kmp/DefaultIdTokenValidator.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.client.kmp
+
+import com.okta.authfoundation.client.OidcClock
+import com.okta.authfoundation.jwt.Jwt
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.math.abs
+
+/**
+ * Default [IdTokenValidator] implementing the
+ * [OpenID Connect Core 1.0 ID Token Validation](https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation) checks.
+ *
+ * Validates: issuer, audience, HTTPS, algorithm (RS256), expiration, issued-at grace period,
+ * nonce, max_age, and subject.
+ */
+class DefaultIdTokenValidator : IdTokenValidator {
+    override suspend fun validate(
+        issuerUrl: String,
+        clientId: String,
+        idToken: Jwt,
+        clock: OidcClock,
+        issuedAtGracePeriodInSeconds: Int,
+        parameters: IdTokenValidator.Parameters,
+    ) {
+        val payload = idToken.deserializeClaims(IdTokenValidationPayload.serializer())
+
+        val normalizedIssuer = issuerUrl.trimEnd('/')
+        val normalizedTokenIssuer = payload.iss.trimEnd('/')
+        if (normalizedTokenIssuer != normalizedIssuer) {
+            throw IdTokenValidator.Error("Invalid issuer.", IdTokenValidator.Error.INVALID_ISSUER)
+        }
+        if (payload.aud != clientId) {
+            throw IdTokenValidator.Error("Invalid audience.", IdTokenValidator.Error.INVALID_AUDIENCE)
+        }
+        if (!payload.iss.startsWith("https://")) {
+            throw IdTokenValidator.Error("Issuer must use HTTPS.", IdTokenValidator.Error.ISSUER_NOT_HTTPS)
+        }
+        if (idToken.algorithm != "RS256") {
+            throw IdTokenValidator.Error("Invalid JWT algorithm.", IdTokenValidator.Error.INVALID_JWT_ALGORITHM)
+        }
+        if (payload.exp < clock.currentTimeEpochSecond()) {
+            throw IdTokenValidator.Error(
+                "The current time MUST be before the time represented by the exp Claim.",
+                IdTokenValidator.Error.EXPIRED
+            )
+        }
+        if (abs(payload.iat - clock.currentTimeEpochSecond()) > issuedAtGracePeriodInSeconds) {
+            throw IdTokenValidator.Error(
+                "Issued at time is not within the allowed threshold of now.",
+                IdTokenValidator.Error.ISSUED_AT_THRESHOLD_NOT_SATISFIED
+            )
+        }
+        if (payload.nonce != parameters.nonce) {
+            throw IdTokenValidator.Error("Nonce mismatch.", IdTokenValidator.Error.NONCE_MISMATCH)
+        }
+        if (parameters.maxAge != null) {
+            val authTime =
+                payload.authTime ?: throw IdTokenValidator.Error(
+                    "Auth time not available.",
+                    IdTokenValidator.Error.MAX_AGE_NOT_SATISFIED
+                )
+            val elapsedTime = payload.iat - authTime
+            if (elapsedTime < 0 || elapsedTime > parameters.maxAge) {
+                throw IdTokenValidator.Error("Max age not satisfied.", IdTokenValidator.Error.MAX_AGE_NOT_SATISFIED)
+            }
+        }
+        if (payload.sub.isNullOrBlank()) {
+            throw IdTokenValidator.Error("A valid sub claim is required.", IdTokenValidator.Error.INVALID_SUBJECT)
+        }
+    }
+}
+
+@Serializable
+internal class IdTokenValidationPayload(
+    @SerialName("iss") val iss: String,
+    @SerialName("aud") val aud: String,
+    @SerialName("exp") val exp: Int,
+    @SerialName("iat") val iat: Int,
+    @SerialName("nonce") val nonce: String? = null,
+    @SerialName("auth_time") val authTime: Int? = null,
+    @SerialName("sub") val sub: String? = null,
+)

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/kmp/IdTokenValidator.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/kmp/IdTokenValidator.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.client.kmp
+
+import com.okta.authfoundation.client.OidcClock
+import com.okta.authfoundation.jwt.Jwt
+
+/**
+ * Used for validating ID tokens minted by an Authorization Server.
+ *
+ * See [OpenID Connect Core 1.0 - ID Token Validation](https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation).
+ */
+interface IdTokenValidator {
+    /**
+     * An error describing a validation failure.
+     *
+     * @param message human-readable description of the failure.
+     * @param identifier machine-readable error code (see companion constants).
+     */
+    class Error(
+        message: String,
+        val identifier: String = "",
+    ) : IllegalStateException(message) {
+        companion object {
+            /** Issuer does not match the expected Authorization Server. */
+            const val INVALID_ISSUER = "invalid_issuer"
+
+            /** Audience (`aud`) does not match the client ID. */
+            const val INVALID_AUDIENCE = "invalid_audience"
+
+            /** Issuer does not use HTTPS. */
+            const val ISSUER_NOT_HTTPS = "issuer_not_https"
+
+            /** JWT signing algorithm is not RS256. */
+            const val INVALID_JWT_ALGORITHM = "invalid_jwt_algorithm"
+
+            /** JWT signature verification failed. */
+            const val INVALID_JWT_SIGNATURE = "invalid_jwt_signature"
+
+            /** Token has expired (`exp` is in the past). */
+            const val EXPIRED = "expired"
+
+            /** `iat` claim is outside the allowed grace period. */
+            const val ISSUED_AT_THRESHOLD_NOT_SATISFIED = "issued_at_threshold_not_satisfied"
+
+            /** Nonce does not match the value sent in the authorization request. */
+            const val NONCE_MISMATCH = "nonce_mismatch"
+
+            /** `auth_time` is missing or outside the allowed `max_age`. */
+            const val MAX_AGE_NOT_SATISFIED = "max_age_not_satisfied"
+
+            /** Token is missing a valid `sub` claim. */
+            const val INVALID_SUBJECT = "invalid_subject"
+        }
+    }
+
+    /**
+     * Parameters for ID token validation.
+     *
+     * @param nonce the `nonce` sent with the authorization request, if available.
+     * @param maxAge the `max_age` sent with the authorization request, if available.
+     */
+    class Parameters(
+        val nonce: String?,
+        val maxAge: Int?,
+    )
+
+    /**
+     * Validates the given [idToken].
+     *
+     * Implementations should throw [Error] (or another [Exception]) if validation fails.
+     *
+     * @param issuerUrl the expected issuer URL.
+     * @param clientId the expected client ID (audience).
+     * @param idToken the parsed [Jwt] to validate.
+     * @param clock the clock for time-based checks.
+     * @param issuedAtGracePeriodInSeconds the grace period for the `iat` claim check (default 600 = 10 minutes).
+     * @param parameters optional nonce/maxAge parameters.
+     */
+    suspend fun validate(
+        issuerUrl: String,
+        clientId: String,
+        idToken: Jwt,
+        clock: OidcClock,
+        issuedAtGracePeriodInSeconds: Int = 600,
+        parameters: Parameters = Parameters(nonce = null, maxAge = null),
+    )
+}

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/kmp/OAuth2Client.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/kmp/OAuth2Client.kt
@@ -29,10 +29,13 @@ import com.okta.authfoundation.client.internal.OAuth2TokenResponse
 import com.okta.authfoundation.client.internal.performFormPost
 import com.okta.authfoundation.client.internal.performJsonFormPost
 import com.okta.authfoundation.client.internal.performJsonGetRequest
+import com.okta.authfoundation.client.kmp.events.ValidateIdTokenEvent
 import com.okta.authfoundation.events.Event
 import com.okta.authfoundation.jwt.Jwks
+import com.okta.authfoundation.jwt.JwtParser
 import com.okta.authfoundation.jwt.SerializableJwks
 import com.okta.authfoundation.util.CoalescingOrchestrator
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -236,6 +239,41 @@ class OAuth2Client internal constructor(
             is OAuth2ClientResult.Error -> null
             is OAuth2ClientResult.Success -> result.result
         }
+
+    /**
+     * Validates the ID token in [tokenInfo] using the configured [IdTokenValidator].
+     *
+     * Verifies claims first, then JWT signature against JWKS.
+     */
+    private suspend fun validateIdToken(tokenInfo: TokenInfo) {
+        val idTokenStr = tokenInfo.idToken ?: return
+        val validator = configuration.idTokenValidator
+
+        val parser = JwtParser(configuration.json, Dispatchers.Default)
+        val jwt = parser.parse(idTokenStr)
+
+        val event = ValidateIdTokenEvent()
+        _events.tryEmit(event)
+
+        validator.validate(
+            issuerUrl = configuration.issuerUrl,
+            clientId = configuration.clientId,
+            idToken = jwt,
+            clock = configuration.clock,
+            issuedAtGracePeriodInSeconds = event.issuedAtGracePeriodInSeconds
+        )
+
+        // Verify signature against JWKS
+        val jwksResult = jwks()
+        if (jwksResult is OAuth2ClientResult.Success) {
+            if (!jwt.hasValidSignature(jwksResult.result)) {
+                throw IdTokenValidator.Error(
+                    "Invalid JWT signature.",
+                    IdTokenValidator.Error.INVALID_JWT_SIGNATURE
+                )
+            }
+        }
+    }
 
     private fun <T> endpointNotAvailableError(): OAuth2ClientResult.Error<T> = OAuth2ClientResult.Error(OAuth2ClientResult.Error.OidcEndpointsNotAvailableException())
 

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/kmp/events/ValidateIdTokenEvent.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/kmp/events/ValidateIdTokenEvent.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.client.kmp.events
+
+import com.okta.authfoundation.events.Event
+import com.okta.authfoundation.events.EventHandler
+import com.okta.authfoundation.jwt.Jwt
+
+/**
+ * Emitted via [EventHandler.onEvent] when an ID token [Jwt] is being validated.
+ *
+ * Listeners can customize the grace period for the `iat` claim check by modifying
+ * [issuedAtGracePeriodInSeconds].
+ */
+class ValidateIdTokenEvent internal constructor(
+    /**
+     * The grace period in seconds for the `iat` claim.
+     *
+     * The absolute difference between the token's `iat` and the current time must be
+     * within this period. Default is 600 seconds (10 minutes).
+     */
+    val issuedAtGracePeriodInSeconds: Int = 600,
+) : Event

--- a/auth-foundation/src/commonTest/kotlin/com/okta/authfoundation/client/OAuth2ClientSharedConfigTest.kt
+++ b/auth-foundation/src/commonTest/kotlin/com/okta/authfoundation/client/OAuth2ClientSharedConfigTest.kt
@@ -20,12 +20,17 @@ import com.okta.authfoundation.api.http.ApiExecutor
 import com.okta.authfoundation.api.http.ApiRequest
 import com.okta.authfoundation.api.http.ApiResponse
 import com.okta.authfoundation.client.internal.OAuth2Endpoints
+import com.okta.authfoundation.client.kmp.DefaultIdTokenValidator
+import com.okta.authfoundation.client.kmp.IdTokenValidator
 import com.okta.authfoundation.client.kmp.OAuth2Client
+import com.okta.authfoundation.jwt.Jwt
 import com.okta.authfoundation.util.CoalescingOrchestrator
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 import kotlin.test.assertNotSame
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 @OptIn(InternalAuthFoundationApi::class)
@@ -177,4 +182,46 @@ class OAuth2ClientSharedConfigTest {
             assertTrue(result2.isSuccess)
             assertEquals(2, requestCount)
         }
+
+    @Test
+    fun builder_defaultIdTokenValidator_IsDefaultIdTokenValidator() {
+        val client =
+            OAuth2ClientBuilder
+                .create(
+                    issuerUrl = "https://example.okta.com/oauth2/default",
+                    clientId = "client-1",
+                    scope = listOf("openid")
+                ).getOrThrow()
+
+        assertIs<DefaultIdTokenValidator>(client.configuration.idTokenValidator)
+    }
+
+    @Test
+    fun builder_customIdTokenValidator_IsUsed() {
+        val custom =
+            object : IdTokenValidator {
+                override suspend fun validate(
+                    issuerUrl: String,
+                    clientId: String,
+                    idToken: Jwt,
+                    clock: OidcClock,
+                    issuedAtGracePeriodInSeconds: Int,
+                    parameters: IdTokenValidator.Parameters,
+                ) {
+                    // no-op
+                }
+            }
+
+        val client =
+            OAuth2ClientBuilder
+                .create(
+                    issuerUrl = "https://example.okta.com/oauth2/default",
+                    clientId = "client-1",
+                    scope = listOf("openid")
+                ) {
+                    idTokenValidator = custom
+                }.getOrThrow()
+
+        assertSame(custom, client.configuration.idTokenValidator)
+    }
 }

--- a/auth-foundation/src/commonTest/kotlin/com/okta/authfoundation/client/kmp/DefaultIdTokenValidatorTest.kt
+++ b/auth-foundation/src/commonTest/kotlin/com/okta/authfoundation/client/kmp/DefaultIdTokenValidatorTest.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.client.kmp
+
+import com.okta.authfoundation.client.OidcClock
+import com.okta.authfoundation.credential.TestConfiguration
+import com.okta.authfoundation.jwt.JwtParser
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class DefaultIdTokenValidatorTest {
+    // Valid JWT from test fixtures — sub=00ub41z7mgzNqryMv696, iss=https://example-test.okta.com/oauth2/default
+    @Suppress("ktlint:standard:max-line-length")
+    private val validJwt =
+        "eyJraWQiOiJGSkEwSEdOdHN1dWRhX1BsNDVKNDJrdlFxY3N1XzBDNEZnN3BiSkxYVEhZIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiIwMHViNDF6N21nek5xcnlNdjY5NiIsIm5hbWUiOiJKYXkgTmV3c3Ryb20iLCJlbWFpbCI6ImpheW5ld3N0cm9tQGV4YW1wbGUuY29tIiwidmVyIjoxLCJpc3MiOiJodHRwczovL2V4YW1wbGUtdGVzdC5va3RhLmNvbS9vYXV0aDIvZGVmYXVsdCIsImF1ZCI6InVuaXRfdGVzdF9jbGllbnRfaWQiLCJpYXQiOjE2NDQzNDcwNjksImV4cCI6MTY0NDM1MDY2OSwianRpIjoiSUQuNTVjeEJ0ZFlsOGw2YXJLSVNQQndkMHlPVC05VUNUYVhhUVRYdDJsYVJMcyIsImFtciI6WyJwd2QiXSwiaWRwIjoiMDBvOGZvdTdzUmFHR3dkbjQ2OTYiLCJzaWQiOiJpZHhXeGtscF80a1N4dUNfblUxcFhELW5BIiwicHJlZmVycmVkX3VzZXJuYW1lIjoiamF5bmV3c3Ryb21AZXhhbXBsZS5jb20iLCJhdXRoX3RpbWUiOjE2NDQzNDcwNjgsImF0X2hhc2giOiJnTWNHVGJoR1QxR19sZHNIb0pzUHpRIiwiZHNfaGFzaCI6IkRBZUxPRlJxaWZ5c2Jnc3JiT2dib2cifQ.tT8aKK4r8yFcW9KgVtZxvjXRJVzz-_rve14CVtpUlyvCTE1yj20wmPS0z3-JirI9xXgt5KeNPYqo3Wbv8c9XY_HY3hsPQdILYpPsUkf-sctmzSoKC_dTbs5xe8uKSgmpMrggfUAWrNPiJt9Ek2p7GgP64Wx79Pq5vSHk0yWlonFfXut5ahpSfqWilmYlvLr8gFbqoLnAJfl4ZbTY8pPw_aQgCdcQ-ImHRu-8bCSCtbFRzZB-SMJFLfRF2kmx0H-QF855wUODTuUSydkff-BKb-8wnbqWg0R9NvRdoXhEybv8TXXZY3cQqgolWLAyiPMrz07n0q_UEjAilUiCjn1f4Q"
+
+    private val parser = JwtParser(kotlinx.serialization.json.Json { ignoreUnknownKeys = true }, Dispatchers.Default)
+    private val validator = DefaultIdTokenValidator()
+
+    // iat=1644347069, exp=1644350669
+    private val clockAtTokenTime = OidcClock { 1644347100L }
+
+    @Test
+    fun validate_ValidToken_Passes() =
+        runTest {
+            val jwt = parser.parse(validJwt)
+            validator.validate(
+                issuerUrl = "https://example-test.okta.com/oauth2/default",
+                clientId = "unit_test_client_id",
+                idToken = jwt,
+                clock = clockAtTokenTime
+            )
+        }
+
+    @Test
+    fun validate_InvalidIssuer_Throws() =
+        runTest {
+            val jwt = parser.parse(validJwt)
+            val error =
+                assertFailsWith<IdTokenValidator.Error> {
+                    validator.validate(
+                        issuerUrl = "https://wrong-issuer.okta.com",
+                        clientId = "unit_test_client_id",
+                        idToken = jwt,
+                        clock = clockAtTokenTime
+                    )
+                }
+            assertEquals(IdTokenValidator.Error.INVALID_ISSUER, error.identifier)
+        }
+
+    @Test
+    fun validate_InvalidAudience_Throws() =
+        runTest {
+            val jwt = parser.parse(validJwt)
+            val error =
+                assertFailsWith<IdTokenValidator.Error> {
+                    validator.validate(
+                        issuerUrl = "https://example-test.okta.com/oauth2/default",
+                        clientId = "wrong_client_id",
+                        idToken = jwt,
+                        clock = clockAtTokenTime
+                    )
+                }
+            assertEquals(IdTokenValidator.Error.INVALID_AUDIENCE, error.identifier)
+        }
+
+    @Test
+    fun validate_ExpiredToken_Throws() =
+        runTest {
+            val jwt = parser.parse(validJwt)
+            val futureClockPastExp = OidcClock { 1644350670L } // 1s past exp
+            val error =
+                assertFailsWith<IdTokenValidator.Error> {
+                    validator.validate(
+                        issuerUrl = "https://example-test.okta.com/oauth2/default",
+                        clientId = "unit_test_client_id",
+                        idToken = jwt,
+                        clock = futureClockPastExp
+                    )
+                }
+            assertEquals(IdTokenValidator.Error.EXPIRED, error.identifier)
+        }
+
+    @Test
+    fun validate_IatOutsideGracePeriod_Throws() =
+        runTest {
+            val jwt = parser.parse(validJwt)
+            // iat=1644347069, set clock far from iat (>600s)
+            val farClock = OidcClock { 1644347069L + 700 }
+            val error =
+                assertFailsWith<IdTokenValidator.Error> {
+                    validator.validate(
+                        issuerUrl = "https://example-test.okta.com/oauth2/default",
+                        clientId = "unit_test_client_id",
+                        idToken = jwt,
+                        clock = farClock
+                    )
+                }
+            assertEquals(IdTokenValidator.Error.ISSUED_AT_THRESHOLD_NOT_SATISFIED, error.identifier)
+        }
+
+    @Test
+    fun validate_IssuerWithTrailingSlash_Matches() =
+        runTest {
+            val jwt = parser.parse(validJwt)
+            validator.validate(
+                issuerUrl = "https://example-test.okta.com/oauth2/default/",
+                clientId = "unit_test_client_id",
+                idToken = jwt,
+                clock = clockAtTokenTime
+            )
+        }
+}

--- a/auth-foundation/src/jvmMain/kotlin/com/okta/authfoundation/client/internal/UserAgent.jvm.kt
+++ b/auth-foundation/src/jvmMain/kotlin/com/okta/authfoundation/client/internal/UserAgent.jvm.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.client.internal
+
+internal actual fun platformUserAgentSuffix(): String {
+    val javaVersion = System.getProperty("java.version") ?: "unknown"
+    val osName = System.getProperty("os.name") ?: "unknown"
+    val osArch = System.getProperty("os.arch") ?: "unknown"
+    return "JVM/$javaVersion ($osName; $osArch)"
+}

--- a/auth-foundation/src/jvmMain/kotlin/com/okta/authfoundation/client/jvm/OAuth2ClientBuilder.kt
+++ b/auth-foundation/src/jvmMain/kotlin/com/okta/authfoundation/client/jvm/OAuth2ClientBuilder.kt
@@ -135,7 +135,7 @@ class OAuth2ClientBuilder(
         }
 
     /**
-     * Creates a [OAuth2Client] instance with the configured parameters.
+     * Creates an [OAuth2Client] instance with the configured parameters.
      *
      * @return A [AuthFoundationResult] containing the [OAuth2Client] on success, or an exception on failure.
      */


### PR DESCRIPTION
User-Agent: use expect/actual platformUserAgentSuffix() so each target appends its own platform identifier (Android/SDK_INT, JVM/version with OS info). The header is injected in OAuth2HttpOperations for all commonMain network calls.

ID token validation: port DefaultIdTokenValidator from Android to commonMain, validating issuer, audience, HTTPS, RS256 algorithm, expiration, iat grace period, nonce, maxAge, and subject per OIDC Core 1.0. Opt-in via OAuth2ClientConfiguration.idTokenValidator. IdTokenValidator uses a plain issuedAtGracePeriodInSeconds Int parameter (no EventCoordinator dependency).

Rate limit retry logic intentionally omitted — left to the application layer, diverging from the Android SDK which handles retries internally.