### PR TITLE
Add KMP crypto abstraction, PkceGenerator, URL utilities, and BrowserRedirectHandler

### DIFF
--- a/auth-foundation/api/jvm/auth-foundation.api
+++ b/auth-foundation/api/jvm/auth-foundation.api
@@ -815,6 +815,11 @@ public final class com/okta/authfoundation/credential/kmp/storage/TokenDatabase_
 	public fun getRequiredAutoMigrationSpecClasses ()Ljava/util/Set;
 }
 
+public final class com/okta/authfoundation/crypto/CryptoProvider_jvmKt {
+	public static final fun secureRandomBytes (I)[B
+	public static final fun sha256Digest ([B)[B
+}
+
 public abstract interface class com/okta/authfoundation/events/Event {
 }
 

--- a/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/crypto/CryptoProvider.android.kt
+++ b/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/crypto/CryptoProvider.android.kt
@@ -13,20 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.okta.oauth2
+package com.okta.authfoundation.crypto
 
-import com.google.common.truth.Truth.assertThat
-import org.junit.Test
+import java.security.MessageDigest
+import java.security.SecureRandom
 
-class PkceGeneratorTest {
-    @Test fun testCodeVerifier() {
-        val codeVerifier = PkceGenerator.codeVerifier()
-        assertThat(codeVerifier).hasLength(43)
-    }
-
-    @Test fun testCodeChallenge() {
-        val codeVerifier = "6f4znUVL4KQJOUYrchTgKZ8Btrl0-kMt_23pvzEbGk8"
-        val codeChallenge = PkceGenerator.codeChallenge(codeVerifier)
-        assertThat(codeChallenge).isEqualTo("e4o5cyg_ZCmAMCweS_s076UN5tUR_idjxrckuiOCcOc")
-    }
+actual fun secureRandomBytes(size: Int): ByteArray {
+    val bytes = ByteArray(size)
+    SecureRandom().nextBytes(bytes)
+    return bytes
 }
+
+actual fun sha256Digest(data: ByteArray): ByteArray = MessageDigest.getInstance("SHA-256").digest(data)

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/crypto/CryptoProvider.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/crypto/CryptoProvider.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.crypto
+
+/**
+ * Generates cryptographically secure random bytes.
+ *
+ * @param size the number of random bytes to generate.
+ * @return a [ByteArray] of the specified size filled with secure random bytes.
+ */
+expect fun secureRandomBytes(size: Int): ByteArray
+
+/**
+ * Computes the SHA-256 digest of the given data.
+ *
+ * @param data the input bytes to hash.
+ * @return a [ByteArray] containing the 32-byte SHA-256 digest.
+ */
+expect fun sha256Digest(data: ByteArray): ByteArray

--- a/auth-foundation/src/commonTest/kotlin/com/okta/authfoundation/crypto/CryptoProviderTest.kt
+++ b/auth-foundation/src/commonTest/kotlin/com/okta/authfoundation/crypto/CryptoProviderTest.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.crypto
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class CryptoProviderTest {
+    @Test
+    fun secureRandomBytes_ReturnsCorrectSize() {
+        val bytes = secureRandomBytes(32)
+        assertEquals(32, bytes.size)
+    }
+
+    @Test
+    fun secureRandomBytes_ReturnsDifferentValues() {
+        val first = secureRandomBytes(32)
+        val second = secureRandomBytes(32)
+        assertNotEquals(first.toList(), second.toList())
+    }
+
+    @Test
+    fun secureRandomBytes_ZeroSize_ReturnsEmptyArray() {
+        val bytes = secureRandomBytes(0)
+        assertEquals(0, bytes.size)
+    }
+
+    @Test
+    fun sha256Digest_ReturnsCorrectLength() {
+        val digest = sha256Digest("test".toByteArray())
+        assertEquals(32, digest.size)
+    }
+
+    @Test
+    fun sha256Digest_ProducesConsistentResults() {
+        val first = sha256Digest("hello".toByteArray())
+        val second = sha256Digest("hello".toByteArray())
+        assertEquals(first.toList(), second.toList())
+    }
+
+    @Test
+    fun sha256Digest_DifferentInputs_ProduceDifferentDigests() {
+        val first = sha256Digest("hello".toByteArray())
+        val second = sha256Digest("world".toByteArray())
+        assertNotEquals(first.toList(), second.toList())
+    }
+
+    @Test
+    fun sha256Digest_KnownValue() {
+        // SHA-256 of empty string = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+        val digest = sha256Digest(ByteArray(0))
+        val hex = digest.joinToString("") { "%02x".format(it) }
+        assertEquals("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", hex)
+    }
+
+    @Test
+    fun secureRandomBytes_LargeSize() {
+        val bytes = secureRandomBytes(1024)
+        assertEquals(1024, bytes.size)
+        // Verify not all zeros (statistically impossible for secure random)
+        assertTrue(bytes.any { it != 0.toByte() })
+    }
+}

--- a/auth-foundation/src/jvmMain/kotlin/com/okta/authfoundation/crypto/CryptoProvider.jvm.kt
+++ b/auth-foundation/src/jvmMain/kotlin/com/okta/authfoundation/crypto/CryptoProvider.jvm.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.crypto
+
+import java.security.MessageDigest
+import java.security.SecureRandom
+
+actual fun secureRandomBytes(size: Int): ByteArray {
+    val bytes = ByteArray(size)
+    SecureRandom().nextBytes(bytes)
+    return bytes
+}
+
+actual fun sha256Digest(data: ByteArray): ByteArray = MessageDigest.getInstance("SHA-256").digest(data)

--- a/oauth2/api/jvm/oauth2.api
+++ b/oauth2/api/jvm/oauth2.api
@@ -1,0 +1,14 @@
+public abstract interface class com/okta/oauth2/BrowserRedirectHandler {
+	public abstract fun handleRedirect (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/okta/oauth2/LocalhostBrowserRedirectHandler : com/okta/oauth2/BrowserRedirectHandler {
+	public static final field Companion Lcom/okta/oauth2/LocalhostBrowserRedirectHandler$Companion;
+	public fun <init> (ILjava/lang/String;JLkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (ILjava/lang/String;JLkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun handleRedirect (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/okta/oauth2/LocalhostBrowserRedirectHandler$Companion {
+}
+

--- a/oauth2/build.gradle.kts
+++ b/oauth2/build.gradle.kts
@@ -88,6 +88,7 @@ kotlin {
                 api(project(":auth-foundation"))
                 implementation(libs.coroutines.core)
                 implementation(libs.kotlin.serialization.json)
+                implementation(libs.ktor.client.core)
                 implementation(libs.okio.core)
             }
         }

--- a/oauth2/src/commonMain/kotlin/com/okta/oauth2/BrowserRedirectHandler.kt
+++ b/oauth2/src/commonMain/kotlin/com/okta/oauth2/BrowserRedirectHandler.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2
+
+/**
+ * Abstracts browser launch and redirect capture for redirect-based OAuth2 flows.
+ *
+ * Implementations are platform-specific:
+ * - **JVM**: [LocalhostBrowserRedirectHandler] starts a localhost HTTP server and opens the system browser.
+ * - **Android**: `web-authentication-ui` provides an implementation using Custom Tabs and deep link intent filters.
+ *
+ * @see LocalhostBrowserRedirectHandler
+ */
+interface BrowserRedirectHandler {
+    /**
+     * Opens the given URL in a browser and suspends until the redirect callback is captured.
+     *
+     * @param url the authorization or logout URL to open in the browser.
+     * @return the full redirect callback URI string captured after the user completes the flow.
+     * @throws Exception if the redirect cannot be captured (timeout, port conflict, user cancellation).
+     */
+    suspend fun handleRedirect(url: String): String
+}

--- a/oauth2/src/commonMain/kotlin/com/okta/oauth2/PkceGenerator.kt
+++ b/oauth2/src/commonMain/kotlin/com/okta/oauth2/PkceGenerator.kt
@@ -15,27 +15,23 @@
  */
 package com.okta.oauth2
 
+import com.okta.authfoundation.crypto.secureRandomBytes
+import com.okta.authfoundation.crypto.sha256Digest
 import okio.ByteString.Companion.toByteString
-import java.security.MessageDigest
-import java.security.SecureRandom
 
 internal object PkceGenerator {
     const val CODE_CHALLENGE_METHOD = "S256"
 
     fun codeChallenge(codeVerifier: String): String {
         val bytes: ByteArray = codeVerifier.toByteArray(Charsets.US_ASCII)
-        val messageDigest: MessageDigest = MessageDigest.getInstance("SHA-256")
-        messageDigest.update(bytes, 0, bytes.size)
-        val digest: ByteArray = messageDigest.digest()
-        return base64Encode(digest)
+        val digest: ByteArray = sha256Digest(bytes)
+        return base64UrlEncode(digest)
     }
 
     fun codeVerifier(): String {
-        val secureRandom = SecureRandom()
-        val codeVerifier = ByteArray(32)
-        secureRandom.nextBytes(codeVerifier)
-        return base64Encode(codeVerifier)
+        val codeVerifier = secureRandomBytes(32)
+        return base64UrlEncode(codeVerifier)
     }
 
-    private fun base64Encode(source: ByteArray): String = source.toByteString().base64Url().trimEnd('=')
+    private fun base64UrlEncode(source: ByteArray): String = source.toByteString().base64Url().trimEnd('=')
 }

--- a/oauth2/src/commonMain/kotlin/com/okta/oauth2/internal/UrlUtils.kt
+++ b/oauth2/src/commonMain/kotlin/com/okta/oauth2/internal/UrlUtils.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.internal
+
+import io.ktor.http.Url
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/**
+ * Parses a query parameter value from a URL string.
+ *
+ * @param url the full URL string containing query parameters.
+ * @param key the parameter name to look up.
+ * @return the decoded parameter value, or null if not found.
+ */
+internal fun parseQueryParameter(
+    url: String,
+    key: String,
+): String? = Url(url).parameters[key]
+
+/**
+ * Generates a random UUID v4 string.
+ *
+ * @return a UUID string in standard 8-4-4-4-12 format.
+ */
+@OptIn(ExperimentalUuidApi::class)
+internal fun generateUuid(): String = Uuid.random().toString()

--- a/oauth2/src/commonTest/kotlin/com/okta/oauth2/PkceGeneratorTest.kt
+++ b/oauth2/src/commonTest/kotlin/com/okta/oauth2/PkceGeneratorTest.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class PkceGeneratorTest {
+    @Test
+    fun codeVerifier_MeetsRfc7636LengthRequirement() {
+        val verifier = PkceGenerator.codeVerifier()
+        // RFC 7636: code_verifier length must be between 43 and 128 characters
+        assertTrue(verifier.length in 43..128, "Verifier length ${verifier.length} not in [43, 128]")
+    }
+
+    @Test
+    fun codeVerifier_ContainsOnlyValidCharacters() {
+        val verifier = PkceGenerator.codeVerifier()
+        // RFC 7636: code_verifier uses unreserved characters [A-Z] / [a-z] / [0-9] / "-" / "." / "_" / "~"
+        // Base64url without padding uses [A-Za-z0-9_-]
+        val validChars = Regex("^[A-Za-z0-9_-]+$")
+        assertTrue(validChars.matches(verifier), "Verifier contains invalid characters: $verifier")
+    }
+
+    @Test
+    fun codeVerifier_GeneratesUniqueValues() {
+        val first = PkceGenerator.codeVerifier()
+        val second = PkceGenerator.codeVerifier()
+        assertNotEquals(first, second)
+    }
+
+    @Test
+    fun codeChallenge_ProducesValidBase64Url() {
+        val verifier = PkceGenerator.codeVerifier()
+        val challenge = PkceGenerator.codeChallenge(verifier)
+        val validChars = Regex("^[A-Za-z0-9_-]+$")
+        assertTrue(validChars.matches(challenge), "Challenge contains invalid characters: $challenge")
+    }
+
+    @Test
+    fun codeChallenge_ConsistentForSameVerifier() {
+        val verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+        val first = PkceGenerator.codeChallenge(verifier)
+        val second = PkceGenerator.codeChallenge(verifier)
+        assertEquals(first, second)
+    }
+
+    @Test
+    fun codeChallenge_DifferentVerifiers_ProduceDifferentChallenges() {
+        val verifier1 = PkceGenerator.codeVerifier()
+        val verifier2 = PkceGenerator.codeVerifier()
+        val challenge1 = PkceGenerator.codeChallenge(verifier1)
+        val challenge2 = PkceGenerator.codeChallenge(verifier2)
+        assertNotEquals(challenge1, challenge2)
+    }
+
+    @Test
+    fun codeChallengeMethod_IsS256() {
+        assertEquals("S256", PkceGenerator.CODE_CHALLENGE_METHOD)
+    }
+
+    @Test
+    fun codeChallenge_KnownVector() {
+        // RFC 7636 Appendix B test vector
+        // code_verifier = dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk
+        // code_challenge = E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM
+        val verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+        val challenge = PkceGenerator.codeChallenge(verifier)
+        assertEquals("E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM", challenge)
+    }
+}

--- a/oauth2/src/commonTest/kotlin/com/okta/oauth2/internal/UrlUtilsTest.kt
+++ b/oauth2/src/commonTest/kotlin/com/okta/oauth2/internal/UrlUtilsTest.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.internal
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class UrlUtilsTest {
+    @Test
+    fun parseQueryParameter_BasicParam() {
+        val result = parseQueryParameter("https://example.com?code=abc123", "code")
+        assertEquals("abc123", result)
+    }
+
+    @Test
+    fun parseQueryParameter_MultipleParams() {
+        val result = parseQueryParameter("https://example.com?state=xyz&code=abc123&scope=openid", "code")
+        assertEquals("abc123", result)
+    }
+
+    @Test
+    fun parseQueryParameter_MissingParam() {
+        val result = parseQueryParameter("https://example.com?state=xyz", "code")
+        assertNull(result)
+    }
+
+    @Test
+    fun parseQueryParameter_NoQueryString() {
+        val result = parseQueryParameter("https://example.com", "code")
+        assertNull(result)
+    }
+
+    @Test
+    fun parseQueryParameter_EncodedValue() {
+        val result = parseQueryParameter("https://example.com?error_description=An+error+occurred%21", "error_description")
+        assertEquals("An error occurred!", result)
+    }
+
+    @Test
+    fun parseQueryParameter_EmptyValue() {
+        val result = parseQueryParameter("https://example.com?key=", "key")
+        assertEquals("", result)
+    }
+
+    @Test
+    fun parseQueryParameter_WithFragment() {
+        val result = parseQueryParameter("https://example.com?code=abc123#fragment", "code")
+        assertEquals("abc123", result)
+    }
+
+    @Test
+    fun parseQueryParameter_FragmentParam_NotReturned() {
+        val result = parseQueryParameter("https://example.com?state=xyz#code=abc123", "code")
+        assertNull(result)
+    }
+
+    @Test
+    fun generateUuid_CorrectFormat() {
+        val uuid = generateUuid()
+        // UUID v4 format: 8-4-4-4-12 hex chars
+        val pattern = Regex("^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$")
+        assertTrue(pattern.matches(uuid), "UUID doesn't match v4 format: $uuid")
+    }
+
+    @Test
+    fun generateUuid_UniquenessAcrossCalls() {
+        val first = generateUuid()
+        val second = generateUuid()
+        assertNotEquals(first, second)
+    }
+
+    @Test
+    fun generateUuid_CorrectLength() {
+        val uuid = generateUuid()
+        assertEquals(36, uuid.length)
+    }
+
+    @Test
+    fun generateUuid_Version4Bits() {
+        val uuid = generateUuid()
+        // Character at index 14 must be '4' (version)
+        assertEquals('4', uuid[14])
+        // Character at index 19 must be 8, 9, a, or b (variant)
+        assertTrue(uuid[19] in listOf('8', '9', 'a', 'b'), "Variant bits incorrect: ${uuid[19]}")
+    }
+}

--- a/oauth2/src/jvmMain/kotlin/com/okta/oauth2/LocalhostBrowserRedirectHandler.kt
+++ b/oauth2/src/jvmMain/kotlin/com/okta/oauth2/LocalhostBrowserRedirectHandler.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2
+
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeout
+import java.awt.Desktop
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.net.URI
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+/**
+ * A [BrowserRedirectHandler] implementation for JVM that starts a localhost HTTP server,
+ * opens the system browser, and captures the redirect callback.
+ *
+ * The [port] and [path] must match the redirect URI registered in the Okta admin console.
+ * For example, if registered as `http://localhost:8080/callback`, use `port = 8080` and `path = "/callback"`.
+ *
+ * @param port the port to listen on. Must match the port in the registered redirect URI.
+ * @param path the expected callback path. Must match the path in the registered redirect URI.
+ * @param timeoutMs the maximum time in milliseconds to wait for the redirect. Defaults to 5 minutes.
+ * @param browserLauncher opens the given URL in a browser. Defaults to [Desktop.browse].
+ */
+class LocalhostBrowserRedirectHandler(
+    private val port: Int,
+    private val path: String,
+    private val timeoutMs: Long = DEFAULT_TIMEOUT_MS,
+    private val browserLauncher: (String) -> Unit = Companion::defaultBrowserLauncher,
+) : BrowserRedirectHandler {
+    override suspend fun handleRedirect(url: String): String =
+        withTimeout(timeoutMs) {
+            suspendCancellableCoroutine { continuation ->
+                val serverSocket = ServerSocket(port, 1, InetAddress.getLoopbackAddress())
+
+                val thread =
+                    Thread {
+                        try {
+                            val socket = serverSocket.accept()
+                            val reader = BufferedReader(InputStreamReader(socket.getInputStream()))
+                            val requestLine = reader.readLine() ?: throw IllegalStateException("Empty request")
+
+                            // Parse GET /callback?code=xxx&state=yyy HTTP/1.1
+                            val requestPath =
+                                requestLine.split(" ").getOrNull(1)
+                                    ?: throw IllegalStateException("Invalid request line: $requestLine")
+
+                            if (!requestPath.startsWith(path)) {
+                                throw IllegalStateException("Unexpected path: $requestPath (expected: $path)")
+                            }
+
+                            val callbackUri = "http://localhost:$port$requestPath"
+
+                            // Send success response
+                            val response =
+                                "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n" +
+                                    "<html><body><h1>Authentication Complete</h1>" +
+                                    "<p>You can close this window.</p></body></html>"
+                            socket.getOutputStream().write(response.toByteArray())
+                            socket.close()
+
+                            continuation.resume(callbackUri)
+                        } catch (e: Exception) {
+                            if (continuation.isActive) {
+                                continuation.resumeWithException(e)
+                            }
+                        } finally {
+                            runCatching { serverSocket.close() }
+                        }
+                    }
+                thread.isDaemon = true
+                thread.start()
+
+                continuation.invokeOnCancellation {
+                    runCatching { serverSocket.close() }
+                    thread.interrupt()
+                }
+
+                browserLauncher(url)
+            }
+        }
+
+    companion object {
+        private const val DEFAULT_TIMEOUT_MS = 300_000L // 5 minutes
+
+        private fun defaultBrowserLauncher(url: String) {
+            if (!Desktop.isDesktopSupported() || !Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
+                throw UnsupportedOperationException("Desktop browser launch not supported on this platform")
+            }
+            Desktop.getDesktop().browse(URI(url))
+        }
+    }
+}

--- a/oauth2/src/jvmTest/kotlin/com/okta/oauth2/LocalhostBrowserRedirectHandlerTest.kt
+++ b/oauth2/src/jvmTest/kotlin/com/okta/oauth2/LocalhostBrowserRedirectHandlerTest.kt
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2
+
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.net.Socket
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class LocalhostBrowserRedirectHandlerTest {
+    private fun findAvailablePort(): Int {
+        val socket = ServerSocket(0, 1, InetAddress.getLoopbackAddress())
+        val port = socket.localPort
+        socket.close()
+        return port
+    }
+
+    private fun simulateRedirect(
+        port: Int,
+        requestLine: String,
+    ) {
+        // Retry connection until the server socket is listening
+        var socket: Socket? = null
+        for (attempt in 1..20) {
+            try {
+                socket = Socket(InetAddress.getLoopbackAddress(), port)
+                break
+            } catch (_: java.net.ConnectException) {
+                Thread.sleep(50)
+            }
+        }
+        checkNotNull(socket) { "Failed to connect to localhost:$port" }
+        socket.getOutputStream().write("$requestLine\r\n".toByteArray())
+        socket.getOutputStream().flush()
+        // Read response to avoid connection reset
+        socket.getInputStream().readAllBytes()
+        socket.close()
+    }
+
+    @Test
+    fun handleRedirect_CapturesCodeAndState() =
+        runBlocking<Unit> {
+            val port = findAvailablePort()
+            val handler =
+                LocalhostBrowserRedirectHandler(
+                    port = port,
+                    path = "/callback",
+                    browserLauncher = { _ ->
+                        Thread { simulateRedirect(port, "GET /callback?code=abc123&state=xyz HTTP/1.1") }.start()
+                    }
+                )
+
+            val result = handler.handleRedirect("https://example.com/authorize")
+            assertEquals("http://localhost:$port/callback?code=abc123&state=xyz", result)
+        }
+
+    @Test
+    fun handleRedirect_NestedPath() =
+        runBlocking<Unit> {
+            val port = findAvailablePort()
+            val handler =
+                LocalhostBrowserRedirectHandler(
+                    port = port,
+                    path = "/callback/signin/myorg",
+                    browserLauncher = { _ ->
+                        Thread { simulateRedirect(port, "GET /callback/signin/myorg?code=abc123 HTTP/1.1") }.start()
+                    }
+                )
+
+            val result = handler.handleRedirect("https://example.com/authorize")
+            assertEquals("http://localhost:$port/callback/signin/myorg?code=abc123", result)
+        }
+
+    @Test
+    fun handleRedirect_RejectsUnexpectedPath() =
+        runBlocking<Unit> {
+            val port = findAvailablePort()
+            val handler =
+                LocalhostBrowserRedirectHandler(
+                    port = port,
+                    path = "/callback",
+                    browserLauncher = { _ ->
+                        Thread { simulateRedirect(port, "GET /wrong?code=abc123 HTTP/1.1") }.start()
+                    }
+                )
+
+            val exception =
+                assertFailsWith<IllegalStateException> {
+                    handler.handleRedirect("https://example.com/authorize")
+                }
+            assertTrue(exception.message!!.contains("Unexpected path"))
+        }
+
+    @Test
+    fun handleRedirect_EmptyRequest_Fails() =
+        runBlocking<Unit> {
+            val port = findAvailablePort()
+            val handler =
+                LocalhostBrowserRedirectHandler(
+                    port = port,
+                    path = "/callback",
+                    browserLauncher = { _ ->
+                        Thread {
+                            var socket: Socket? = null
+                            for (attempt in 1..20) {
+                                try {
+                                    socket = Socket(InetAddress.getLoopbackAddress(), port)
+                                    break
+                                } catch (_: java.net.ConnectException) {
+                                    Thread.sleep(50)
+                                }
+                            }
+                            socket?.close()
+                        }.start()
+                    }
+                )
+
+            assertFailsWith<IllegalStateException> {
+                handler.handleRedirect("https://example.com/authorize")
+            }
+        }
+
+    @Test
+    fun handleRedirect_Timeout() =
+        runBlocking<Unit> {
+            val port = findAvailablePort()
+            val handler =
+                LocalhostBrowserRedirectHandler(
+                    port = port,
+                    path = "/callback",
+                    timeoutMs = 200,
+                    browserLauncher = { }
+                )
+
+            assertFailsWith<TimeoutCancellationException> {
+                handler.handleRedirect("https://example.com/authorize")
+            }
+        }
+
+    @Test
+    fun handleRedirect_PassesUrlToBrowserLauncher() =
+        runBlocking<Unit> {
+            val port = findAvailablePort()
+            var launchedUrl: String? = null
+            val handler =
+                LocalhostBrowserRedirectHandler(
+                    port = port,
+                    path = "/callback",
+                    browserLauncher = { url ->
+                        launchedUrl = url
+                        Thread { simulateRedirect(port, "GET /callback?code=abc HTTP/1.1") }.start()
+                    }
+                )
+
+            handler.handleRedirect("https://example.com/authorize?client_id=test")
+            assertEquals("https://example.com/authorize?client_id=test", launchedUrl)
+        }
+
+    @Test
+    fun handleRedirect_CancellationClosesSocket() =
+        runBlocking<Unit> {
+            val port = findAvailablePort()
+            val handler =
+                LocalhostBrowserRedirectHandler(
+                    port = port,
+                    path = "/callback",
+                    browserLauncher = { }
+                )
+
+            val deferred = async { handler.handleRedirect("https://example.com/authorize") }
+            deferred.cancel()
+
+            // Allow cancellation to propagate and close the socket
+            Thread.sleep(100)
+
+            // Port should be freed after cancellation — verify by binding it again
+            val socket = ServerSocket(port, 1, InetAddress.getLoopbackAddress())
+            socket.close()
+        }
+}


### PR DESCRIPTION
Add expect/actual crypto functions (secureRandomBytes, sha256Digest) to auth-foundation for cross-module reuse across Android, JVM, and future iOS/JS targets. Migrate PkceGenerator from androidMain to oauth2 commonMain using the new crypto abstraction. Add URL parsing utilities (parseQueryParameter, generateUuid) and BrowserRedirectHandler interface with JVM localhost server implementation. Include tests for all new components.