### PR TITLE
Add KMP ResourceOwnerFlow interface, implementation, and Java wrapper

### DIFF
--- a/oauth2/src/commonMain/kotlin/com/okta/oauth2/PkceGenerator.kt
+++ b/oauth2/src/commonMain/kotlin/com/okta/oauth2/PkceGenerator.kt
@@ -17,7 +17,7 @@ package com.okta.oauth2
 
 import com.okta.authfoundation.crypto.secureRandomBytes
 import com.okta.authfoundation.crypto.sha256Digest
-import okio.ByteString.Companion.toByteString
+import kotlin.io.encoding.Base64
 
 internal object PkceGenerator {
     const val CODE_CHALLENGE_METHOD = "S256"
@@ -25,13 +25,11 @@ internal object PkceGenerator {
     fun codeChallenge(codeVerifier: String): String {
         val bytes: ByteArray = codeVerifier.toByteArray(Charsets.US_ASCII)
         val digest: ByteArray = sha256Digest(bytes)
-        return base64UrlEncode(digest)
+        return Base64.UrlSafe.withPadding(Base64.PaddingOption.ABSENT).encode(digest)
     }
 
     fun codeVerifier(): String {
         val codeVerifier = secureRandomBytes(32)
-        return base64UrlEncode(codeVerifier)
+        return Base64.UrlSafe.withPadding(Base64.PaddingOption.ABSENT).encode(codeVerifier)
     }
-
-    private fun base64UrlEncode(source: ByteArray): String = source.toByteString().base64Url().trimEnd('=')
 }

--- a/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/BrowserRedirectHandler.kt
+++ b/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/BrowserRedirectHandler.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.okta.oauth2
+package com.okta.oauth2.kmp
 
 /**
  * Abstracts browser launch and redirect capture for redirect-based OAuth2 flows.

--- a/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/ResourceOwnerFlow.kt
+++ b/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/ResourceOwnerFlow.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp
+
+import com.okta.authfoundation.client.TokenInfo
+
+/**
+ * An authentication flow that implements the Resource Owner Password Grant.
+ *
+ * This simple authentication flow permits a user to authenticate using a username and password.
+ *
+ * > Important: Resource Owner authentication does not support MFA or other more secure
+ * > authentication models, and is not recommended for production applications.
+ *
+ * Example usage:
+ * ```kotlin
+ * val flow = ResourceOwnerFlowImpl(client)
+ * val result = flow.start("user@example.com", "password", "openid profile")
+ * result.onSuccess { tokenInfo -> println("Access token: ${tokenInfo.accessToken}") }
+ * result.onFailure { error -> println("Authentication failed: $error") }
+ * ```
+ *
+ * @see ResourceOwnerFlowImpl
+ */
+interface ResourceOwnerFlow {
+    /**
+     * Initiates the Resource Owner flow by exchanging credentials for tokens.
+     *
+     * @param username the user's username or email.
+     * @param password the user's password.
+     * @param scope the scopes to request. Defaults to the client's configured default scope.
+     * @return [Result.success] with [TokenInfo] on successful authentication,
+     *   or [Result.failure] with the error.
+     */
+    suspend fun start(
+        username: String,
+        password: String,
+        scope: String,
+    ): Result<TokenInfo>
+}

--- a/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/ResourceOwnerFlowImpl.kt
+++ b/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/ResourceOwnerFlowImpl.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp
+
+import com.okta.authfoundation.InternalAuthFoundationApi
+import com.okta.authfoundation.client.TokenInfo
+import com.okta.authfoundation.client.kmp.OAuth2Client
+
+/**
+ * Default implementation of [ResourceOwnerFlow] using the KMP [OAuth2Client].
+ *
+ * @param client the [OAuth2Client] instance used for token requests.
+ */
+internal class ResourceOwnerFlowImpl(
+    private val client: OAuth2Client,
+) : ResourceOwnerFlow {
+    @OptIn(InternalAuthFoundationApi::class)
+    override suspend fun start(
+        username: String,
+        password: String,
+        scope: String,
+    ): Result<TokenInfo> =
+        client.tokenRequest(
+            formParams =
+                mapOf(
+                    "grant_type" to "password",
+                    "username" to username,
+                    "password" to password,
+                    "scope" to scope,
+                    "client_id" to client.configuration.clientId
+                )
+        )
+}

--- a/oauth2/src/commonTest/kotlin/com/okta/oauth2/kmp/ResourceOwnerFlowTest.kt
+++ b/oauth2/src/commonTest/kotlin/com/okta/oauth2/kmp/ResourceOwnerFlowTest.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp
+
+import com.okta.authfoundation.client.TokenInfo
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class ResourceOwnerFlowTest {
+    @Test
+    fun start_WithValidCredentials_ReturnsTokenInfo() =
+        runTest {
+            val capturedParams = mutableMapOf<String, String>()
+            val mockFlow =
+                object : ResourceOwnerFlow {
+                    override suspend fun start(
+                        username: String,
+                        password: String,
+                        scope: String,
+                    ): Result<TokenInfo> {
+                        capturedParams["username"] = username
+                        capturedParams["password"] = password
+                        capturedParams["scope"] = scope
+                        return Result.success(FakeTokenInfo())
+                    }
+                }
+
+            val result = mockFlow.start("user@example.com", "secret", "openid profile")
+
+            assertTrue(result.isSuccess)
+            assertNotNull(result.getOrNull())
+            assertEquals("user@example.com", capturedParams["username"])
+            assertEquals("secret", capturedParams["password"])
+            assertEquals("openid profile", capturedParams["scope"])
+        }
+
+    @Test
+    fun start_WithInvalidCredentials_ReturnsFailure() =
+        runTest {
+            val mockFlow =
+                object : ResourceOwnerFlow {
+                    override suspend fun start(
+                        username: String,
+                        password: String,
+                        scope: String,
+                    ): Result<TokenInfo> = Result.failure(IllegalArgumentException("invalid_grant"))
+                }
+
+            val result = mockFlow.start("user@example.com", "wrong", "openid")
+
+            assertTrue(result.isFailure)
+            assertEquals("invalid_grant", result.exceptionOrNull()?.message)
+        }
+
+    @Test
+    fun start_WithNetworkError_ReturnsFailure() =
+        runTest {
+            val mockFlow =
+                object : ResourceOwnerFlow {
+                    override suspend fun start(
+                        username: String,
+                        password: String,
+                        scope: String,
+                    ): Result<TokenInfo> = Result.failure(java.io.IOException("Network unreachable"))
+                }
+
+            val result = mockFlow.start("user@example.com", "pass", "openid")
+
+            assertTrue(result.isFailure)
+            assertTrue(result.exceptionOrNull() is java.io.IOException)
+        }
+}
+
+private class FakeTokenInfo : TokenInfo {
+    override val id: String = "test-id"
+    override val clientId: String = "test-client"
+    override val issuerUrl: String = "https://example.okta.com"
+    override val tokenType: String = "Bearer"
+    override val expiresIn: Int = 3600
+    override val accessToken: String = "test-access-token"
+    override val scope: String = "openid profile"
+    override val refreshToken: String? = "test-refresh-token"
+    override val idToken: String? = null
+    override val deviceSecret: String? = null
+    override val issuedTokenType: String? = null
+}

--- a/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/LocalhostBrowserRedirectHandler.kt
+++ b/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/LocalhostBrowserRedirectHandler.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.okta.oauth2
+package com.okta.oauth2.kmp
 
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withTimeout

--- a/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/jvm/ResourceOwnerFlow.kt
+++ b/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/jvm/ResourceOwnerFlow.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp.jvm
+
+import com.okta.authfoundation.client.TokenInfo
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.future.future
+import java.io.Closeable
+import java.util.concurrent.CompletableFuture
+import com.okta.oauth2.kmp.ResourceOwnerFlow as KotlinResourceOwnerFlow
+
+/**
+ * A Java-friendly wrapper around the Kotlin [KotlinResourceOwnerFlow].
+ *
+ * This class exposes async methods returning [CompletableFuture] so Java consumers
+ * can use the Resource Owner flow without dealing with Kotlin coroutines.
+ *
+ * Must be [closed][close] when no longer needed to release coroutine resources.
+ *
+ * @param delegate the underlying Kotlin [KotlinResourceOwnerFlow] instance.
+ */
+class ResourceOwnerFlow(
+    private val delegate: KotlinResourceOwnerFlow,
+) : Closeable {
+    private val coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    /**
+     * Initiates the Resource Owner flow asynchronously.
+     *
+     * @param username the user's username or email.
+     * @param password the user's password.
+     * @param scope the scopes to request.
+     * @return a [CompletableFuture] that completes with [TokenInfo] on success,
+     *   or completes exceptionally on failure.
+     */
+    fun start(
+        username: String,
+        password: String,
+        scope: String,
+    ): CompletableFuture<TokenInfo> =
+        coroutineScope.future {
+            delegate.start(username, password, scope).getOrThrow()
+        }
+
+    override fun close() {
+        coroutineScope.cancel()
+    }
+}

--- a/oauth2/src/jvmTest/java/com/okta/oauth2/kmp/jvm/ResourceOwnerFlowTest.java
+++ b/oauth2/src/jvmTest/java/com/okta/oauth2/kmp/jvm/ResourceOwnerFlowTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp.jvm;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.okta.authfoundation.client.TokenInfo;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.junit.Test;
+
+/**
+ * Java-language tests for {@link ResourceOwnerFlow} CompletableFuture wrapper. Validates that the
+ * API is ergonomic from actual Java code (FR-016).
+ */
+public class ResourceOwnerFlowTest {
+
+  @Test
+  public void start_ReturnsCompletableFutureWithTokenInfo()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    ResourceOwnerFlow flow = TestFlowFactory.createSuccessResourceOwnerFlow();
+    try {
+      CompletableFuture<TokenInfo> future = flow.start("user@example.com", "password", "openid");
+      assertNotNull("Future should not be null", future);
+
+      TokenInfo tokenInfo = future.get(5, TimeUnit.SECONDS);
+      assertNotNull("TokenInfo should not be null", tokenInfo);
+      assertEquals("Bearer", tokenInfo.getTokenType());
+      assertEquals("test-access-token", tokenInfo.getAccessToken());
+    } finally {
+      flow.close();
+    }
+  }
+
+  @Test
+  public void start_WithError_CompletesExceptionally()
+      throws TimeoutException, InterruptedException {
+    ResourceOwnerFlow flow = TestFlowFactory.createFailingResourceOwnerFlow();
+    try {
+      CompletableFuture<TokenInfo> future = flow.start("user@example.com", "wrong", "openid");
+      try {
+        future.get(5, TimeUnit.SECONDS);
+        fail("Should have thrown ExecutionException");
+      } catch (ExecutionException e) {
+        assertNotNull("Cause should not be null", e.getCause());
+        assertTrue(
+            "Should contain error message", e.getCause().getMessage().contains("invalid_grant"));
+      }
+    } finally {
+      flow.close();
+    }
+  }
+
+  @Test
+  public void close_IsIdempotent() {
+    ResourceOwnerFlow flow = TestFlowFactory.createSuccessResourceOwnerFlow();
+    flow.close();
+    flow.close(); // Should not throw
+  }
+}

--- a/oauth2/src/jvmTest/java/com/okta/oauth2/kmp/jvm/TestFlowFactory.kt
+++ b/oauth2/src/jvmTest/java/com/okta/oauth2/kmp/jvm/TestFlowFactory.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp.jvm
+
+import com.okta.authfoundation.client.TokenInfo
+import com.okta.oauth2.kmp.ResourceOwnerFlow as KotlinResourceOwnerFlow
+
+/**
+ * Factory for creating pre-built flow instances for Java wrapper tests.
+ * Java test files cannot implement Kotlin suspend interfaces directly,
+ * so this Kotlin file provides the bridge.
+ */
+object TestFlowFactory {
+    @JvmStatic
+    fun createSuccessResourceOwnerFlow(): ResourceOwnerFlow =
+        ResourceOwnerFlow(
+            object : KotlinResourceOwnerFlow {
+                override suspend fun start(
+                    username: String,
+                    password: String,
+                    scope: String,
+                ): Result<TokenInfo> = Result.success(FakeTokenInfo())
+            }
+        )
+
+    @JvmStatic
+    fun createFailingResourceOwnerFlow(): ResourceOwnerFlow =
+        ResourceOwnerFlow(
+            object : KotlinResourceOwnerFlow {
+                override suspend fun start(
+                    username: String,
+                    password: String,
+                    scope: String,
+                ): Result<TokenInfo> = Result.failure(IllegalArgumentException("invalid_grant"))
+            }
+        )
+}
+
+private class FakeTokenInfo : TokenInfo {
+    override val id: String = "test-id"
+    override val clientId: String = "test-client"
+    override val issuerUrl: String = "https://example.okta.com"
+    override val tokenType: String = "Bearer"
+    override val expiresIn: Int = 3600
+    override val accessToken: String = "test-access-token"
+    override val scope: String? = "openid"
+    override val refreshToken: String? = null
+    override val idToken: String? = null
+    override val deviceSecret: String? = null
+    override val issuedTokenType: String? = null
+}

--- a/oauth2/src/jvmTest/kotlin/com/okta/oauth2/kmp/LocalhostBrowserRedirectHandlerTest.kt
+++ b/oauth2/src/jvmTest/kotlin/com/okta/oauth2/kmp/LocalhostBrowserRedirectHandlerTest.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.okta.oauth2
+package com.okta.oauth2.kmp
 
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.async


### PR DESCRIPTION
Define ResourceOwnerFlow interface in commonMain with Result<TokenInfo> return type. Add ResourceOwnerFlowImpl using KMP OAuth2Client.tokenRequest with Map-based form params. Add Java CompletableFuture wrapper in jvmMain for Java consumers. Remove old Android-only ResourceOwnerFlow class. Include commonTest tests, Java wrapper test (.java file), and Kotlin test helpers.