### PR TITLE
Add KMP DeviceAuthorizationFlow interface, implementation, and Java wrapper

### DIFF
--- a/auth-foundation/api/jvm/auth-foundation.api
+++ b/auth-foundation/api/jvm/auth-foundation.api
@@ -341,6 +341,27 @@ public abstract interface class com/okta/authfoundation/client/TokenInfo {
 	public abstract fun getTokenType ()Ljava/lang/String;
 }
 
+public final class com/okta/authfoundation/client/dto/DeviceAuthorizationInfo {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;II)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()I
+	public final fun component6 ()I
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;II)Lcom/okta/authfoundation/client/dto/DeviceAuthorizationInfo;
+	public static synthetic fun copy$default (Lcom/okta/authfoundation/client/dto/DeviceAuthorizationInfo;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IIILjava/lang/Object;)Lcom/okta/authfoundation/client/dto/DeviceAuthorizationInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeviceCode ()Ljava/lang/String;
+	public final fun getExpiresIn ()I
+	public final fun getInterval ()I
+	public final fun getUserCode ()Ljava/lang/String;
+	public final fun getVerificationUri ()Ljava/lang/String;
+	public final fun getVerificationUriComplete ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract class com/okta/authfoundation/client/dto/IntrospectInfo {
 	public synthetic fun <init> (ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getActive ()Z
@@ -483,6 +504,7 @@ public final class com/okta/authfoundation/client/kmp/IdTokenValidator$Parameter
 
 public final class com/okta/authfoundation/client/kmp/OAuth2Client {
 	public static final field Companion Lcom/okta/authfoundation/client/kmp/OAuth2Client$Companion;
+	public final fun deviceAuthorizationRequest-gIAlu-s (Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun endpointsOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getConfiguration ()Lcom/okta/authfoundation/client/OAuth2ClientConfiguration;
 	public final fun getEvents ()Lkotlinx/coroutines/flow/SharedFlow;

--- a/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/client/internal/NetworkUtils.kt
+++ b/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/client/internal/NetworkUtils.kt
@@ -30,8 +30,6 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.okio.decodeFromBufferedSource
 import okhttp3.Call
 import okhttp3.Callback
@@ -164,12 +162,6 @@ private suspend fun OidcConfiguration.executeRequest(
 
     return response
 }
-
-@Serializable
-internal class ErrorResponse(
-    @SerialName("error") val error: String? = null,
-    @SerialName("error_description") val errorDescription: String? = null,
-)
 
 @OptIn(ExperimentalSerializationApi::class)
 private fun <T> Response.toOAuth2ClientResultError(

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/dto/DeviceAuthorizationInfo.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/dto/DeviceAuthorizationInfo.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.client.dto
+
+/**
+ * Response from a device authorization request per
+ * [RFC 8628](https://datatracker.ietf.org/doc/html/rfc8628).
+ *
+ * @property verificationUri the URI the user should visit to authorize the device.
+ * @property verificationUriComplete a convenience URI combining [verificationUri] and [userCode].
+ * @property deviceCode the device verification code used to poll for tokens.
+ * @property userCode the short code the user enters at [verificationUri].
+ * @property interval the minimum polling interval in seconds.
+ * @property expiresIn the lifetime in seconds of [deviceCode] and [userCode].
+ */
+data class DeviceAuthorizationInfo(
+    val verificationUri: String,
+    val verificationUriComplete: String?,
+    val deviceCode: String,
+    val userCode: String,
+    val interval: Int,
+    val expiresIn: Int,
+)

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/internal/OAuth2HttpOperations.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/internal/OAuth2HttpOperations.kt
@@ -27,11 +27,19 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.format.DateTimeComponents
 import kotlinx.datetime.toInstant
 import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlin.time.Clock
 
 private val defaultHeaders: Map<String, List<String>> =
     mapOf("User-Agent" to listOf(UserAgent.value))
+
+@Serializable
+internal class ErrorResponse(
+    @SerialName("error") val error: String? = null,
+    @SerialName("error_description") val errorDescription: String? = null,
+)
 
 private val HTTP_DATE_MONTHS =
     mapOf(
@@ -244,6 +252,16 @@ internal suspend fun <T> performJsonFormPost(
         val body =
             response.body?.decodeToString()
                 ?: throw IllegalStateException("Empty response body")
+
+        if (response.statusCode !in 200..299) {
+            val errorResponse = runCatching { json.decodeFromString(ErrorResponse.serializer(), body) }.getOrNull()
+            throw OAuth2ClientResult.Error.HttpResponseException(
+                responseCode = response.statusCode,
+                error = errorResponse?.error,
+                errorDescription = errorResponse?.errorDescription
+            )
+        }
+
         json.decodeFromString(deserializer, body)
     }.fold(
         onSuccess = { OAuth2ClientResult.Success(it) },

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/internal/SerializableDeviceAuthorizationResponse.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/internal/SerializableDeviceAuthorizationResponse.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.client.internal
+
+import com.okta.authfoundation.client.dto.DeviceAuthorizationInfo
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal class SerializableDeviceAuthorizationResponse(
+    @SerialName("verification_uri") val verificationUri: String,
+    @SerialName("verification_uri_complete") val verificationUriComplete: String? = null,
+    @SerialName("device_code") val deviceCode: String,
+    @SerialName("user_code") val userCode: String,
+    @SerialName("interval") val interval: Int = 5,
+    @SerialName("expires_in") val expiresIn: Int,
+) {
+    fun toDeviceAuthorizationInfo(): DeviceAuthorizationInfo =
+        DeviceAuthorizationInfo(
+            verificationUri = verificationUri,
+            verificationUriComplete = verificationUriComplete,
+            deviceCode = deviceCode,
+            userCode = userCode,
+            interval = interval,
+            expiresIn = expiresIn
+        )
+}

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/kmp/OAuth2Client.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/kmp/OAuth2Client.kt
@@ -19,6 +19,7 @@ import com.okta.authfoundation.InternalAuthFoundationApi
 import com.okta.authfoundation.client.OAuth2ClientConfiguration
 import com.okta.authfoundation.client.OAuth2ClientResult
 import com.okta.authfoundation.client.TokenInfo
+import com.okta.authfoundation.client.dto.DeviceAuthorizationInfo
 import com.okta.authfoundation.client.dto.IntrospectInfo
 import com.okta.authfoundation.client.dto.OidcUserInfo
 import com.okta.authfoundation.client.events.TokenRefreshedEvent
@@ -26,6 +27,7 @@ import com.okta.authfoundation.client.events.TokenRevokedEvent
 import com.okta.authfoundation.client.internal.EndpointDiscovery
 import com.okta.authfoundation.client.internal.OAuth2Endpoints
 import com.okta.authfoundation.client.internal.OAuth2TokenResponse
+import com.okta.authfoundation.client.internal.SerializableDeviceAuthorizationResponse
 import com.okta.authfoundation.client.internal.performFormPost
 import com.okta.authfoundation.client.internal.performJsonFormPost
 import com.okta.authfoundation.client.internal.performJsonGetRequest
@@ -291,6 +293,40 @@ class OAuth2Client internal constructor(
                 )
             when (result) {
                 is OAuth2ClientResult.Success -> IntrospectInfo.fromJsonObject(result.result, configuration.json)
+                is OAuth2ClientResult.Error -> throw result.exception
+            }
+        }
+
+    /**
+     * Performs a device authorization request per
+     * [RFC 8628](https://datatracker.ietf.org/doc/html/rfc8628).
+     *
+     * Posts [formParams] to the device authorization endpoint and returns a [DeviceAuthorizationInfo]
+     * containing the device code, user code, and verification URIs needed to complete the flow.
+     *
+     * @param formParams the form parameters (at minimum `client_id` and `scope`).
+     * @return [Result.success] with [DeviceAuthorizationInfo], or [Result.failure] with:
+     * - [OAuth2ClientResult.Error.OidcEndpointsNotAvailableException] if the device authorization endpoint is not available.
+     * - [OAuth2ClientResult.Error.HttpResponseException] if the server returns an error.
+     * - Other exceptions for network or parsing failures.
+     */
+    suspend fun deviceAuthorizationRequest(formParams: Map<String, String>): Result<DeviceAuthorizationInfo> =
+        runCatching {
+            val endpoint =
+                endpointsOrNull()?.deviceAuthorizationEndpoint
+                    ?: throw OAuth2ClientResult.Error.OidcEndpointsNotAvailableException()
+
+            val result =
+                performJsonFormPost(
+                    apiExecutor = configuration.apiExecutor,
+                    json = configuration.json,
+                    url = endpoint,
+                    formParams = formParams,
+                    deserializer = SerializableDeviceAuthorizationResponse.serializer(),
+                    onRateLimitExceeded = { event -> _events.tryEmit(event) }
+                )
+            when (result) {
+                is OAuth2ClientResult.Success -> result.result.toDeviceAuthorizationInfo()
                 is OAuth2ClientResult.Error -> throw result.exception
             }
         }

--- a/auth-foundation/src/commonTest/kotlin/com/okta/authfoundation/client/kmp/OAuth2ClientTest.kt
+++ b/auth-foundation/src/commonTest/kotlin/com/okta/authfoundation/client/kmp/OAuth2ClientTest.kt
@@ -51,6 +51,19 @@ class OAuth2ClientTest {
             deviceAuthorizationEndpoint = null
         )
 
+    private val testEndpointsWithDeviceAuth =
+        OAuth2Endpoints(
+            issuer = "https://example.okta.com/oauth2/default",
+            authorizationEndpoint = "https://example.okta.com/oauth2/default/v1/authorize",
+            tokenEndpoint = "https://example.okta.com/oauth2/default/v1/token",
+            userInfoEndpoint = "https://example.okta.com/oauth2/default/v1/userinfo",
+            jwksUri = "https://example.okta.com/oauth2/default/v1/keys",
+            introspectionEndpoint = "https://example.okta.com/oauth2/default/v1/introspect",
+            revocationEndpoint = "https://example.okta.com/oauth2/default/v1/revoke",
+            endSessionEndpoint = "https://example.okta.com/oauth2/default/v1/logout",
+            deviceAuthorizationEndpoint = "https://example.okta.com/oauth2/default/v1/device/authorize"
+        )
+
     private fun createClient(
         apiExecutor: ApiExecutor,
         endpoints: OAuth2Endpoints = testEndpoints,
@@ -288,6 +301,111 @@ class OAuth2ClientTest {
 
             val result = client.refreshToken("token")
             assertTrue(result.isFailure)
+        }
+
+    @Test
+    fun deviceAuthorizationRequest_ReturnsDeviceAuthorizationInfo() =
+        runTest {
+            val deviceAuthJson =
+                """
+                {
+                    "device_code": "1a521d9f-0922-4e6d-8db9-8b654297435a",
+                    "user_code": "GDLMZQCT",
+                    "verification_uri": "https://example.okta.com/activate",
+                    "verification_uri_complete": "https://example.okta.com/activate?user_code=GDLMZQCT",
+                    "expires_in": 600,
+                    "interval": 10
+                }
+                """.trimIndent()
+
+            val client = createClient(mockApiExecutor(deviceAuthJson), testEndpointsWithDeviceAuth)
+            val result =
+                client.deviceAuthorizationRequest(
+                    mapOf("client_id" to "test-client-id", "scope" to "openid")
+                )
+
+            assertTrue(result.isSuccess)
+            val info = result.getOrThrow()
+            assertEquals("1a521d9f-0922-4e6d-8db9-8b654297435a", info.deviceCode)
+            assertEquals("GDLMZQCT", info.userCode)
+            assertEquals("https://example.okta.com/activate", info.verificationUri)
+            assertEquals("https://example.okta.com/activate?user_code=GDLMZQCT", info.verificationUriComplete)
+            assertEquals(600, info.expiresIn)
+            assertEquals(10, info.interval)
+        }
+
+    @Test
+    fun deviceAuthorizationRequest_WithMinimalJson_ReturnsDeviceAuthorizationInfo() =
+        runTest {
+            val deviceAuthJson =
+                """
+                {
+                    "device_code": "abc123",
+                    "user_code": "WXYZ",
+                    "verification_uri": "https://example.okta.com/activate",
+                    "expires_in": 300
+                }
+                """.trimIndent()
+
+            val client = createClient(mockApiExecutor(deviceAuthJson), testEndpointsWithDeviceAuth)
+            val result =
+                client.deviceAuthorizationRequest(
+                    mapOf("client_id" to "test-client-id", "scope" to "openid")
+                )
+
+            assertTrue(result.isSuccess)
+            val info = result.getOrThrow()
+            assertEquals("abc123", info.deviceCode)
+            assertEquals("WXYZ", info.userCode)
+            assertEquals(null, info.verificationUriComplete)
+            assertEquals(5, info.interval)
+            assertEquals(300, info.expiresIn)
+        }
+
+    @Test
+    fun deviceAuthorizationRequest_WithNoDeviceAuthorizationEndpoint_ReturnsError() =
+        runTest {
+            val client = createClient(mockApiExecutor(""), testEndpoints)
+            val result =
+                client.deviceAuthorizationRequest(
+                    mapOf("client_id" to "test-client-id", "scope" to "openid")
+                )
+
+            assertTrue(result.isFailure)
+            assertIs<OAuth2ClientResult.Error.OidcEndpointsNotAvailableException>(result.exceptionOrNull())
+        }
+
+    @Test
+    fun deviceAuthorizationRequest_WithNoEndpoints_ReturnsError() =
+        runTest {
+            val config =
+                OAuth2ClientBuilder
+                    .create(
+                        issuerUrl = "https://example.okta.com/oauth2/default",
+                        clientId = "test-client-id",
+                        scope = listOf("openid")
+                    ) {
+                        apiExecutor = mockApiExecutor("")
+                    }.getOrThrow()
+                    .configuration
+
+            val client =
+                OAuth2Client(
+                    configuration = config,
+                    endpointsOrchestrator =
+                        CoalescingOrchestrator(
+                            factory = {
+                                OAuth2ClientResult.Error(
+                                    OAuth2ClientResult.Error.OidcEndpointsNotAvailableException()
+                                )
+                            },
+                            keepDataInMemory = { false }
+                        )
+                )
+
+            val result = client.deviceAuthorizationRequest(mapOf("client_id" to "test-client-id"))
+            assertTrue(result.isFailure)
+            assertIs<OAuth2ClientResult.Error.OidcEndpointsNotAvailableException>(result.exceptionOrNull())
         }
 
     @Test

--- a/oauth2/api/jvm/oauth2.api
+++ b/oauth2/api/jvm/oauth2.api
@@ -1,14 +1,68 @@
-public abstract interface class com/okta/oauth2/BrowserRedirectHandler {
+public abstract interface class com/okta/oauth2/kmp/BrowserRedirectHandler {
 	public abstract fun handleRedirect (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public final class com/okta/oauth2/LocalhostBrowserRedirectHandler : com/okta/oauth2/BrowserRedirectHandler {
-	public static final field Companion Lcom/okta/oauth2/LocalhostBrowserRedirectHandler$Companion;
+public abstract interface class com/okta/oauth2/kmp/DeviceAuthorizationFlow {
+	public static final field Companion Lcom/okta/oauth2/kmp/DeviceAuthorizationFlow$Companion;
+	public abstract fun resume-gIAlu-s (Lcom/okta/oauth2/kmp/DeviceAuthorizationFlowContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun start-gIAlu-s (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun start-gIAlu-s$default (Lcom/okta/oauth2/kmp/DeviceAuthorizationFlow;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/okta/oauth2/kmp/DeviceAuthorizationFlow$Companion {
+	public final fun invoke (Lcom/okta/authfoundation/client/kmp/OAuth2Client;)Lcom/okta/oauth2/kmp/DeviceAuthorizationFlow;
+}
+
+public final class com/okta/oauth2/kmp/DeviceAuthorizationFlow$DefaultImpls {
+	public static synthetic fun start-gIAlu-s$default (Lcom/okta/oauth2/kmp/DeviceAuthorizationFlow;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/okta/oauth2/kmp/DeviceAuthorizationFlow$TimeoutException : java/lang/Exception {
+	public fun <init> ()V
+}
+
+public final class com/okta/oauth2/kmp/DeviceAuthorizationFlowContext {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;I)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()I
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;I)Lcom/okta/oauth2/kmp/DeviceAuthorizationFlowContext;
+	public static synthetic fun copy$default (Lcom/okta/oauth2/kmp/DeviceAuthorizationFlowContext;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;IILjava/lang/Object;)Lcom/okta/oauth2/kmp/DeviceAuthorizationFlowContext;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getExpiresIn ()I
+	public final fun getUserCode ()Ljava/lang/String;
+	public final fun getVerificationUri ()Ljava/lang/String;
+	public final fun getVerificationUriComplete ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/okta/oauth2/kmp/LocalhostBrowserRedirectHandler : com/okta/oauth2/kmp/BrowserRedirectHandler {
+	public static final field Companion Lcom/okta/oauth2/kmp/LocalhostBrowserRedirectHandler$Companion;
 	public fun <init> (ILjava/lang/String;JLkotlin/jvm/functions/Function1;)V
 	public synthetic fun <init> (ILjava/lang/String;JLkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun handleRedirect (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public final class com/okta/oauth2/LocalhostBrowserRedirectHandler$Companion {
+public final class com/okta/oauth2/kmp/LocalhostBrowserRedirectHandler$Companion {
+}
+
+public abstract interface class com/okta/oauth2/kmp/ResourceOwnerFlow {
+	public abstract fun start-BWLJW6A (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/okta/oauth2/kmp/jvm/DeviceAuthorizationFlow : java/io/Closeable {
+	public fun <init> (Lcom/okta/oauth2/kmp/DeviceAuthorizationFlow;)V
+	public fun close ()V
+	public final fun resume (Lcom/okta/oauth2/kmp/DeviceAuthorizationFlowContext;)Ljava/util/concurrent/CompletableFuture;
+	public final fun start (Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
+	public static synthetic fun start$default (Lcom/okta/oauth2/kmp/jvm/DeviceAuthorizationFlow;Ljava/lang/String;ILjava/lang/Object;)Ljava/util/concurrent/CompletableFuture;
+}
+
+public final class com/okta/oauth2/kmp/jvm/ResourceOwnerFlow : java/io/Closeable {
+	public fun <init> (Lcom/okta/oauth2/kmp/ResourceOwnerFlow;)V
+	public fun close ()V
+	public final fun start (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
 }
 

--- a/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/DeviceAuthorizationFlow.kt
+++ b/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/DeviceAuthorizationFlow.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp
+
+import com.okta.authfoundation.client.TokenInfo
+import com.okta.authfoundation.client.kmp.OAuth2Client
+
+/**
+ * Implements the [Device Authorization Grant](https://datatracker.ietf.org/doc/html/rfc8628) flow.
+ *
+ * Use [start] to obtain a [DeviceAuthorizationFlowContext] containing the user code and verification
+ * URI to display to the user, then poll [resume] until the user completes authorization or the
+ * session expires.
+ *
+ * ```kotlin
+ * val flow = DeviceAuthorizationFlow(client)
+ * val ctx = flow.start().getOrThrow()
+ * println("Visit ${ctx.verificationUriComplete} and enter ${ctx.userCode}")
+ * val tokenInfo = flow.resume(ctx).getOrThrow()
+ * ```
+ */
+interface DeviceAuthorizationFlow {
+    /**
+     * Initiates the device authorization flow.
+     *
+     * @param scope the OAuth2 scopes to request.
+     * @return [Result.success] with a [DeviceAuthorizationFlowContext], or [Result.failure] with:
+     * - [com.okta.authfoundation.client.OAuth2ClientResult.Error.OidcEndpointsNotAvailableException] if the device authorization endpoint is unavailable.
+     * - Other exceptions for network or parse failures.
+     */
+    suspend fun start(scope: String = "openid profile email offline_access"): Result<DeviceAuthorizationFlowContext>
+
+    /**
+     * Polls the token endpoint until the user authorizes or the session expires.
+     *
+     * Should be called repeatedly after [start]. Retries automatically on
+     * `authorization_pending` and `slow_down` errors per RFC 8628 §3.5.
+     *
+     * @param flowContext the context returned from [start].
+     * @return [Result.success] with [TokenInfo] on authorization, or [Result.failure] with:
+     * - [TimeoutException] if [DeviceAuthorizationFlowContext.expiresIn] elapses.
+     * - [com.okta.authfoundation.client.OAuth2ClientResult.Error.HttpResponseException] on non-recoverable server errors.
+     * - Other exceptions for network failures.
+     */
+    suspend fun resume(flowContext: DeviceAuthorizationFlowContext): Result<TokenInfo>
+
+    /**
+     * An error due to the authorization session expiring before the user completed sign in.
+     */
+    class TimeoutException : Exception("Device authorization timed out.")
+
+    companion object {
+        /**
+         * Creates a [DeviceAuthorizationFlow] backed by the given [OAuth2Client].
+         */
+        operator fun invoke(client: OAuth2Client): DeviceAuthorizationFlow = DeviceAuthorizationFlowImpl(client)
+    }
+}

--- a/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/DeviceAuthorizationFlowContext.kt
+++ b/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/DeviceAuthorizationFlowContext.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp
+
+/**
+ * Holds the state for an in-progress [DeviceAuthorizationFlow] session.
+ *
+ * @property verificationUri the URI the user should visit on another device to authorize.
+ * @property verificationUriComplete a convenience URI that includes the [userCode], or null if not provided.
+ * @property userCode the short code to display to the user.
+ * @property expiresIn seconds until this authorization session expires.
+ */
+data class DeviceAuthorizationFlowContext(
+    val verificationUri: String,
+    val verificationUriComplete: String?,
+    val userCode: String,
+    val expiresIn: Int,
+    internal val deviceCode: String,
+    internal val interval: Int,
+)

--- a/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/DeviceAuthorizationFlowImpl.kt
+++ b/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/DeviceAuthorizationFlowImpl.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp
+
+import com.okta.authfoundation.client.OAuth2ClientResult
+import com.okta.authfoundation.client.TokenInfo
+import com.okta.authfoundation.client.kmp.OAuth2Client
+import kotlinx.coroutines.delay
+
+/**
+ * Default implementation of [DeviceAuthorizationFlow] using the KMP [OAuth2Client].
+ *
+ * @param client the [OAuth2Client] instance used for token requests.
+ */
+internal class DeviceAuthorizationFlowImpl(
+    private val client: OAuth2Client,
+) : DeviceAuthorizationFlow {
+    internal var delayFunction: suspend (Long) -> Unit = ::delay
+
+    override suspend fun start(scope: String): Result<DeviceAuthorizationFlowContext> =
+        client
+            .deviceAuthorizationRequest(
+                formParams =
+                    mapOf(
+                        "client_id" to client.configuration.clientId,
+                        "scope" to scope
+                    )
+            ).map { info ->
+                DeviceAuthorizationFlowContext(
+                    verificationUri = info.verificationUri,
+                    verificationUriComplete = info.verificationUriComplete,
+                    userCode = info.userCode,
+                    expiresIn = info.expiresIn,
+                    deviceCode = info.deviceCode,
+                    interval = info.interval
+                )
+            }
+
+    override suspend fun resume(flowContext: DeviceAuthorizationFlowContext): Result<TokenInfo> =
+        runCatching {
+            val formParams =
+                mapOf(
+                    "client_id" to client.configuration.clientId,
+                    "device_code" to flowContext.deviceCode,
+                    "grant_type" to "urn:ietf:params:oauth:grant-type:device_code"
+                )
+
+            var timeLeft = flowContext.expiresIn
+            var interval = flowContext.interval
+
+            while (timeLeft > 0) {
+                timeLeft -= interval
+                delayFunction(interval.toLong() * 1000L)
+
+                val tokenResult = client.tokenRequest(formParams = formParams)
+                if (tokenResult.isSuccess) {
+                    return@runCatching tokenResult.getOrThrow()
+                }
+
+                val error =
+                    (tokenResult.exceptionOrNull() as? OAuth2ClientResult.Error.HttpResponseException)?.error
+                when (error) {
+                    "authorization_pending" -> {
+                        continue
+                    }
+
+                    "slow_down" -> {
+                        interval += 5
+                        continue
+                    }
+
+                    else -> {
+                        tokenResult.getOrThrow()
+                    } // re-throw the original exception
+                }
+            }
+
+            throw DeviceAuthorizationFlow.TimeoutException()
+        }
+}

--- a/oauth2/src/commonTest/kotlin/com/okta/oauth2/kmp/DeviceAuthorizationFlowImplTest.kt
+++ b/oauth2/src/commonTest/kotlin/com/okta/oauth2/kmp/DeviceAuthorizationFlowImplTest.kt
@@ -1,0 +1,292 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp
+
+import com.okta.authfoundation.api.http.ApiExecutor
+import com.okta.authfoundation.api.http.ApiFormRequest
+import com.okta.authfoundation.api.http.ApiRequest
+import com.okta.authfoundation.api.http.ApiResponse
+import com.okta.authfoundation.client.OAuth2ClientBuilder
+import com.okta.authfoundation.client.OAuth2ClientResult
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class DeviceAuthorizationFlowImplTest {
+    // Discovery JSON with device_authorization_endpoint populated.
+    private val discoveryWithDevice =
+        """
+        {
+            "issuer": "https://example.okta.com/oauth2/default",
+            "authorization_endpoint": "https://example.okta.com/oauth2/default/v1/authorize",
+            "token_endpoint": "https://example.okta.com/oauth2/default/v1/token",
+            "device_authorization_endpoint": "https://example.okta.com/oauth2/default/v1/device/authorize"
+        }
+        """.trimIndent()
+
+    // Discovery JSON without device_authorization_endpoint.
+    private val discoveryWithoutDevice =
+        """
+        {
+            "issuer": "https://example.okta.com/oauth2/default",
+            "authorization_endpoint": "https://example.okta.com/oauth2/default/v1/authorize",
+            "token_endpoint": "https://example.okta.com/oauth2/default/v1/token"
+        }
+        """.trimIndent()
+
+    private val deviceAuthResponse =
+        """
+        {
+            "device_code": "dc-test-123",
+            "user_code": "ABCD-1234",
+            "verification_uri": "https://example.okta.com/activate",
+            "verification_uri_complete": "https://example.okta.com/activate?user_code=ABCD-1234",
+            "expires_in": 600,
+            "interval": 5
+        }
+        """.trimIndent()
+
+    private val tokenResponse =
+        """
+        {
+            "token_type": "Bearer",
+            "expires_in": 3600,
+            "access_token": "test-access-token",
+            "scope": "openid"
+        }
+        """.trimIndent()
+
+    /**
+     * Creates a [DeviceAuthorizationFlowImpl] backed by a stub [ApiExecutor].
+     *
+     * The first response is always the discovery response (consumed when endpoints are first resolved).
+     * Subsequent responses are consumed in order for each API call made by the flow.
+     */
+    private fun createFlow(
+        discovery: String,
+        vararg apiResponses: Pair<Int, String>,
+    ): DeviceAuthorizationFlowImpl {
+        val allResponses = listOf(200 to discovery) + apiResponses.toList()
+        var callIndex = 0
+        val apiExecutor =
+            object : ApiExecutor {
+                override suspend fun execute(request: ApiRequest): Result<ApiResponse> {
+                    val (statusCode, body) = allResponses[callIndex++ % allResponses.size]
+                    return Result.success(
+                        object : ApiResponse {
+                            override val statusCode: Int = statusCode
+                            override val body: ByteArray = body.toByteArray()
+                            override val headers: Map<String, List<String>> = emptyMap()
+                            override val contentLength: Long = body.length.toLong()
+                            override val contentType: String = "application/json"
+                        }
+                    )
+                }
+            }
+        val client =
+            OAuth2ClientBuilder
+                .create(
+                    issuerUrl = "https://example.okta.com/oauth2/default",
+                    clientId = "test-client-id",
+                    scope = listOf("openid")
+                ) {
+                    this.apiExecutor = apiExecutor
+                }.getOrThrow()
+        return DeviceAuthorizationFlowImpl(client)
+    }
+
+    // ──────────────────────────── start() ────────────────────────────
+
+    @Test
+    fun start_WithValidScope_ReturnsFlowContext() =
+        runTest {
+            // Responses: [discovery, deviceAuthResponse]
+            val flow = createFlow(discoveryWithDevice, 200 to deviceAuthResponse)
+            val result = flow.start("openid profile")
+
+            assertTrue(result.isSuccess)
+            val ctx = result.getOrThrow()
+            assertEquals("dc-test-123", ctx.deviceCode)
+            assertEquals("ABCD-1234", ctx.userCode)
+            assertEquals("https://example.okta.com/activate", ctx.verificationUri)
+            assertEquals("https://example.okta.com/activate?user_code=ABCD-1234", ctx.verificationUriComplete)
+            assertEquals(600, ctx.expiresIn)
+            assertEquals(5, ctx.interval)
+        }
+
+    @Test
+    fun start_WhenDeviceEndpointNull_ReturnsFailure() =
+        runTest {
+            // Responses: [discovery without device endpoint] — no further calls expected
+            val flow = createFlow(discoveryWithoutDevice)
+            val result = flow.start("openid")
+
+            assertTrue(result.isFailure)
+            assertIs<OAuth2ClientResult.Error.OidcEndpointsNotAvailableException>(result.exceptionOrNull())
+        }
+
+    @Test
+    fun start_SendsCorrectFormParams() =
+        runTest {
+            var capturedRequest: ApiRequest? = null
+            var callIndex = 0
+            val responses = listOf(200 to discoveryWithDevice, 200 to deviceAuthResponse)
+            val apiExecutor =
+                object : ApiExecutor {
+                    override suspend fun execute(request: ApiRequest): Result<ApiResponse> {
+                        val (statusCode, body) = responses[callIndex % responses.size]
+                        if (callIndex == 1) capturedRequest = request
+                        callIndex++
+                        return Result.success(
+                            object : ApiResponse {
+                                override val statusCode = statusCode
+                                override val body = body.toByteArray()
+                                override val headers: Map<String, List<String>> = emptyMap()
+                                override val contentLength = body.length.toLong()
+                                override val contentType = "application/json"
+                            }
+                        )
+                    }
+                }
+            val client =
+                OAuth2ClientBuilder
+                    .create(
+                        issuerUrl = "https://example.okta.com/oauth2/default",
+                        clientId = "test-client-id",
+                        scope = listOf("openid")
+                    ) {
+                        this.apiExecutor = apiExecutor
+                    }.getOrThrow()
+            val flow = DeviceAuthorizationFlowImpl(client)
+
+            flow.start("openid profile")
+
+            val formRequest = assertIs<ApiFormRequest>(capturedRequest)
+            assertEquals(
+                "https://example.okta.com/oauth2/default/v1/device/authorize",
+                formRequest.url()
+            )
+            val params = formRequest.formParameters().mapValues { (_, v) -> v.first() }
+            assertEquals("test-client-id", params["client_id"])
+            assertEquals("openid profile", params["scope"])
+        }
+
+    // ──────────────────────────── resume() ────────────────────────────
+
+    private fun makeContext(
+        expiresIn: Int = 60,
+        interval: Int = 5,
+    ) = DeviceAuthorizationFlowContext(
+        verificationUri = "https://example.okta.com/activate",
+        verificationUriComplete = null,
+        userCode = "ABCD-1234",
+        expiresIn = expiresIn,
+        deviceCode = "dc-test-123",
+        interval = interval
+    )
+
+    @Test
+    fun resume_WhenImmediateSuccess_ReturnsTokenInfo() =
+        runTest {
+            // Responses: [discovery, tokenResponse]
+            val flow = createFlow(discoveryWithDevice, 200 to tokenResponse)
+            val delays = mutableListOf<Long>()
+            flow.delayFunction = { ms -> delays += ms }
+
+            val result = flow.resume(makeContext())
+
+            assertTrue(result.isSuccess)
+            assertEquals("test-access-token", result.getOrThrow().accessToken)
+            assertEquals(listOf(5000L), delays)
+        }
+
+    @Test
+    fun resume_WhenAuthorizationPending_PollsUntilSuccess() =
+        runTest {
+            val pending = """{"error":"authorization_pending","error_description":"Authorization pending"}"""
+            // Responses: [discovery, pending, pending, tokenResponse]
+            val flow =
+                createFlow(
+                    discoveryWithDevice,
+                    400 to pending,
+                    400 to pending,
+                    200 to tokenResponse
+                )
+            val delays = mutableListOf<Long>()
+            flow.delayFunction = { ms -> delays += ms }
+
+            val result = flow.resume(makeContext())
+
+            assertTrue(result.isSuccess)
+            assertEquals("test-access-token", result.getOrThrow().accessToken)
+            assertEquals(listOf(5000L, 5000L, 5000L), delays)
+        }
+
+    @Test
+    fun resume_WhenSlowDown_IncreasesInterval() =
+        runTest {
+            val slowDown = """{"error":"slow_down","error_description":"Slow down"}"""
+            // Responses: [discovery, slowDown, tokenResponse]
+            val flow =
+                createFlow(
+                    discoveryWithDevice,
+                    400 to slowDown,
+                    200 to tokenResponse
+                )
+            val delays = mutableListOf<Long>()
+            flow.delayFunction = { ms -> delays += ms }
+
+            val result = flow.resume(makeContext())
+
+            assertTrue(result.isSuccess)
+            assertEquals("test-access-token", result.getOrThrow().accessToken)
+            // First iteration uses interval=5s; slow_down bumps to 10s for the second
+            assertEquals(listOf(5000L, 10000L), delays)
+        }
+
+    @Test
+    fun resume_WhenTimeout_ThrowsTimeoutException() =
+        runTest {
+            val pending = """{"error":"authorization_pending","error_description":"Authorization pending"}"""
+            // expiresIn=10, interval=5 → 2 iterations, then timeout
+            // Responses: [discovery, pending, pending]
+            val flow = createFlow(discoveryWithDevice, 400 to pending, 400 to pending)
+            flow.delayFunction = { /* no-op */ }
+
+            val result = flow.resume(makeContext(expiresIn = 10, interval = 5))
+
+            assertTrue(result.isFailure)
+            assertIs<DeviceAuthorizationFlow.TimeoutException>(result.exceptionOrNull())
+        }
+
+    @Test
+    fun resume_WhenNonPollingError_PropagatesError() =
+        runTest {
+            val denied = """{"error":"access_denied","error_description":"Access denied"}"""
+            // Responses: [discovery, access_denied]
+            val flow = createFlow(discoveryWithDevice, 400 to denied)
+            flow.delayFunction = { /* no-op */ }
+
+            val result = flow.resume(makeContext())
+
+            assertTrue(result.isFailure)
+            val ex = assertIs<OAuth2ClientResult.Error.HttpResponseException>(result.exceptionOrNull())
+            assertEquals("access_denied", ex.error)
+            assertEquals(400, ex.responseCode)
+        }
+}

--- a/oauth2/src/commonTest/kotlin/com/okta/oauth2/kmp/DeviceAuthorizationFlowTest.kt
+++ b/oauth2/src/commonTest/kotlin/com/okta/oauth2/kmp/DeviceAuthorizationFlowTest.kt
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp
+
+import com.okta.authfoundation.client.TokenInfo
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class DeviceAuthorizationFlowTest {
+    @Test
+    fun start_ReturnsFlowContext() =
+        runTest {
+            val mockFlow =
+                object : DeviceAuthorizationFlow {
+                    override suspend fun start(scope: String): Result<DeviceAuthorizationFlowContext> =
+                        Result.success(
+                            DeviceAuthorizationFlowContext(
+                                verificationUri = "https://example.okta.com/activate",
+                                verificationUriComplete = "https://example.okta.com/activate?user_code=ABCD-1234",
+                                userCode = "ABCD-1234",
+                                expiresIn = 600,
+                                deviceCode = "device-code-xyz",
+                                interval = 5
+                            )
+                        )
+
+                    override suspend fun resume(flowContext: DeviceAuthorizationFlowContext): Result<TokenInfo> = Result.failure(NotImplementedError())
+                }
+
+            val result = mockFlow.start("openid")
+
+            assertTrue(result.isSuccess)
+            val ctx = result.getOrNull()
+            assertNotNull(ctx)
+            assertEquals("https://example.okta.com/activate", ctx.verificationUri)
+            assertEquals("ABCD-1234", ctx.userCode)
+            assertEquals(600, ctx.expiresIn)
+        }
+
+    @Test
+    fun resume_WhenSuccess_ReturnsTokenInfo() =
+        runTest {
+            val fakeToken = FakeDeviceTokenInfo()
+            val mockFlow =
+                object : DeviceAuthorizationFlow {
+                    override suspend fun start(scope: String): Result<DeviceAuthorizationFlowContext> = Result.failure(NotImplementedError())
+
+                    override suspend fun resume(flowContext: DeviceAuthorizationFlowContext): Result<TokenInfo> = Result.success(fakeToken)
+                }
+
+            val ctx =
+                DeviceAuthorizationFlowContext(
+                    verificationUri = "https://example.okta.com/activate",
+                    verificationUriComplete = null,
+                    userCode = "XY12",
+                    expiresIn = 600,
+                    deviceCode = "dc",
+                    interval = 5
+                )
+            val result = mockFlow.resume(ctx)
+
+            assertTrue(result.isSuccess)
+            assertEquals("test-access-token", result.getOrNull()?.accessToken)
+        }
+
+    @Test
+    fun resume_WhenError_ReturnsFailure() =
+        runTest {
+            val mockFlow =
+                object : DeviceAuthorizationFlow {
+                    override suspend fun start(scope: String): Result<DeviceAuthorizationFlowContext> = Result.failure(NotImplementedError())
+
+                    override suspend fun resume(flowContext: DeviceAuthorizationFlowContext): Result<TokenInfo> = Result.failure(IllegalStateException("access_denied"))
+                }
+
+            val ctx =
+                DeviceAuthorizationFlowContext(
+                    verificationUri = "https://example.okta.com/activate",
+                    verificationUriComplete = null,
+                    userCode = "XY12",
+                    expiresIn = 600,
+                    deviceCode = "dc",
+                    interval = 5
+                )
+            val result = mockFlow.resume(ctx)
+
+            assertTrue(result.isFailure)
+            assertTrue(result.exceptionOrNull()?.message?.contains("access_denied") == true)
+        }
+
+    @Test
+    fun start_WhenEndpointUnavailable_ReturnsFailure() =
+        runTest {
+            val mockFlow =
+                object : DeviceAuthorizationFlow {
+                    override suspend fun start(scope: String): Result<DeviceAuthorizationFlowContext> = Result.failure(IllegalStateException("OIDC Endpoints not available."))
+
+                    override suspend fun resume(flowContext: DeviceAuthorizationFlowContext): Result<TokenInfo> = Result.failure(NotImplementedError())
+                }
+
+            val result = mockFlow.start("openid")
+
+            assertTrue(result.isFailure)
+        }
+}
+
+private class FakeDeviceTokenInfo : TokenInfo {
+    override val id: String = "test-id"
+    override val clientId: String = "test-client"
+    override val issuerUrl: String = "https://example.okta.com"
+    override val tokenType: String = "Bearer"
+    override val expiresIn: Int = 3600
+    override val accessToken: String = "test-access-token"
+    override val scope: String = "openid profile"
+    override val refreshToken: String? = "test-refresh-token"
+    override val idToken: String? = null
+    override val deviceSecret: String? = null
+    override val issuedTokenType: String? = null
+}

--- a/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/jvm/DeviceAuthorizationFlow.kt
+++ b/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/jvm/DeviceAuthorizationFlow.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp.jvm
+
+import com.okta.authfoundation.client.TokenInfo
+import com.okta.oauth2.kmp.DeviceAuthorizationFlowContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.future.future
+import java.io.Closeable
+import java.util.concurrent.CompletableFuture
+import com.okta.oauth2.kmp.DeviceAuthorizationFlow as KotlinDeviceAuthorizationFlow
+
+/**
+ * A Java-friendly wrapper around the Kotlin [KotlinDeviceAuthorizationFlow].
+ *
+ * This class exposes async methods returning [CompletableFuture] so Java consumers
+ * can use the Device Authorization flow without dealing with Kotlin coroutines.
+ *
+ * Must be [closed][close] when no longer needed to release coroutine resources.
+ *
+ * @param delegate the underlying Kotlin [KotlinDeviceAuthorizationFlow] instance.
+ */
+class DeviceAuthorizationFlow(
+    private val delegate: KotlinDeviceAuthorizationFlow,
+) : Closeable {
+    private val coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    /**
+     * Initiates the device authorization flow asynchronously.
+     *
+     * @param scope the scopes to request.
+     * @return a [CompletableFuture] that completes with [DeviceAuthorizationFlowContext] on success,
+     *   or completes exceptionally on failure.
+     */
+    fun start(scope: String = "openid profile email offline_access"): CompletableFuture<DeviceAuthorizationFlowContext> =
+        coroutineScope.future {
+            delegate.start(scope).getOrThrow()
+        }
+
+    /**
+     * Polls for authorization completion asynchronously.
+     *
+     * @param flowContext the context returned from [start].
+     * @return a [CompletableFuture] that completes with [TokenInfo] on success,
+     *   or completes exceptionally on failure or timeout.
+     */
+    fun resume(flowContext: DeviceAuthorizationFlowContext): CompletableFuture<TokenInfo> =
+        coroutineScope.future {
+            delegate.resume(flowContext).getOrThrow()
+        }
+
+    override fun close() {
+        coroutineScope.cancel()
+    }
+}

--- a/oauth2/src/jvmTest/java/com/okta/oauth2/kmp/jvm/DeviceAuthorizationFlowTest.java
+++ b/oauth2/src/jvmTest/java/com/okta/oauth2/kmp/jvm/DeviceAuthorizationFlowTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp.jvm;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.okta.authfoundation.client.TokenInfo;
+import com.okta.oauth2.kmp.DeviceAuthorizationFlowContext;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.junit.Test;
+
+/**
+ * Java-language tests for {@link DeviceAuthorizationFlow} CompletableFuture wrapper. Validates that
+ * the API is ergonomic from actual Java code.
+ */
+public class DeviceAuthorizationFlowTest {
+
+  @Test
+  public void start_ReturnsCompletableFutureWithContext()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    DeviceAuthorizationFlow flow = TestFlowFactory.createSuccessDeviceAuthorizationFlow();
+    try {
+      CompletableFuture<DeviceAuthorizationFlowContext> future =
+          flow.start("openid profile email offline_access");
+      assertNotNull("Future should not be null", future);
+
+      DeviceAuthorizationFlowContext ctx = future.get(5, TimeUnit.SECONDS);
+      assertNotNull("Context should not be null", ctx);
+      assertEquals("https://example.okta.com/activate", ctx.getVerificationUri());
+      assertEquals("ABCD-1234", ctx.getUserCode());
+      assertEquals(600, ctx.getExpiresIn());
+    } finally {
+      flow.close();
+    }
+  }
+
+  @Test
+  public void resume_ReturnsCompletableFutureWithTokenInfo()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    DeviceAuthorizationFlow flow = TestFlowFactory.createSuccessDeviceAuthorizationFlow();
+    try {
+      DeviceAuthorizationFlowContext ctx = flow.start("openid").get(5, TimeUnit.SECONDS);
+      CompletableFuture<TokenInfo> future = flow.resume(ctx);
+      assertNotNull("Future should not be null", future);
+
+      TokenInfo tokenInfo = future.get(5, TimeUnit.SECONDS);
+      assertNotNull("TokenInfo should not be null", tokenInfo);
+      assertEquals("Bearer", tokenInfo.getTokenType());
+      assertEquals("test-access-token", tokenInfo.getAccessToken());
+    } finally {
+      flow.close();
+    }
+  }
+
+  @Test
+  public void start_WithError_CompletesExceptionally()
+      throws TimeoutException, InterruptedException {
+    DeviceAuthorizationFlow flow = TestFlowFactory.createFailingDeviceAuthorizationFlow();
+    try {
+      CompletableFuture<DeviceAuthorizationFlowContext> future = flow.start("openid");
+      try {
+        future.get(5, TimeUnit.SECONDS);
+        fail("Should have thrown ExecutionException");
+      } catch (ExecutionException e) {
+        assertNotNull("Cause should not be null", e.getCause());
+        assertTrue(
+            "Should contain error message",
+            e.getCause().getMessage().contains("OIDC Endpoints not available."));
+      }
+    } finally {
+      flow.close();
+    }
+  }
+
+  @Test
+  public void resume_WithError_CompletesExceptionally()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    DeviceAuthorizationFlow successStart = TestFlowFactory.createSuccessDeviceAuthorizationFlow();
+    DeviceAuthorizationFlow failingResume = TestFlowFactory.createFailingDeviceAuthorizationFlow();
+    try {
+      // Get a valid context from the success flow
+      DeviceAuthorizationFlowContext ctx = successStart.start("openid").get(5, TimeUnit.SECONDS);
+
+      // Resume with the failing flow
+      CompletableFuture<TokenInfo> future = failingResume.resume(ctx);
+      try {
+        future.get(5, TimeUnit.SECONDS);
+        fail("Should have thrown ExecutionException");
+      } catch (ExecutionException e) {
+        assertNotNull("Cause should not be null", e.getCause());
+        assertTrue(
+            "Should contain error message", e.getCause().getMessage().contains("access_denied"));
+      }
+    } finally {
+      successStart.close();
+      failingResume.close();
+    }
+  }
+
+  @Test
+  public void close_IsIdempotent() {
+    DeviceAuthorizationFlow flow = TestFlowFactory.createSuccessDeviceAuthorizationFlow();
+    flow.close();
+    flow.close(); // Should not throw
+  }
+}

--- a/oauth2/src/jvmTest/java/com/okta/oauth2/kmp/jvm/TestFlowFactory.kt
+++ b/oauth2/src/jvmTest/java/com/okta/oauth2/kmp/jvm/TestFlowFactory.kt
@@ -16,6 +16,8 @@
 package com.okta.oauth2.kmp.jvm
 
 import com.okta.authfoundation.client.TokenInfo
+import com.okta.oauth2.kmp.DeviceAuthorizationFlowContext
+import com.okta.oauth2.kmp.DeviceAuthorizationFlow as KotlinDeviceAuthorizationFlow
 import com.okta.oauth2.kmp.ResourceOwnerFlow as KotlinResourceOwnerFlow
 
 /**
@@ -24,6 +26,36 @@ import com.okta.oauth2.kmp.ResourceOwnerFlow as KotlinResourceOwnerFlow
  * so this Kotlin file provides the bridge.
  */
 object TestFlowFactory {
+    @JvmStatic
+    fun createSuccessDeviceAuthorizationFlow(): DeviceAuthorizationFlow =
+        DeviceAuthorizationFlow(
+            object : KotlinDeviceAuthorizationFlow {
+                override suspend fun start(scope: String): Result<DeviceAuthorizationFlowContext> =
+                    Result.success(
+                        DeviceAuthorizationFlowContext(
+                            verificationUri = "https://example.okta.com/activate",
+                            verificationUriComplete = "https://example.okta.com/activate?user_code=ABCD-1234",
+                            userCode = "ABCD-1234",
+                            expiresIn = 600,
+                            deviceCode = "dc-test-123",
+                            interval = 5
+                        )
+                    )
+
+                override suspend fun resume(flowContext: DeviceAuthorizationFlowContext): Result<TokenInfo> = Result.success(FakeTokenInfo())
+            }
+        )
+
+    @JvmStatic
+    fun createFailingDeviceAuthorizationFlow(): DeviceAuthorizationFlow =
+        DeviceAuthorizationFlow(
+            object : KotlinDeviceAuthorizationFlow {
+                override suspend fun start(scope: String): Result<DeviceAuthorizationFlowContext> = Result.failure(IllegalStateException("OIDC Endpoints not available."))
+
+                override suspend fun resume(flowContext: DeviceAuthorizationFlowContext): Result<TokenInfo> = Result.failure(IllegalStateException("access_denied"))
+            }
+        )
+
     @JvmStatic
     fun createSuccessResourceOwnerFlow(): ResourceOwnerFlow =
         ResourceOwnerFlow(


### PR DESCRIPTION
Implements the Device Authorization Grant flow (RFC 8628) for KMP targets (Android + JVM). Includes polling loop with authorization_pending/slow_down handling, DeviceAuthorizationFlowContext data class, and a Java-friendly CompletableFuture wrapper backed by a supervised CoroutineScope.

RESOLVES: OKTA-1162031