### PR TITLE
Add KMP TokenExchangeFlow interface, implementation, and Java wrapper

### DIFF
--- a/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/TokenExchangeFlow.kt
+++ b/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/TokenExchangeFlow.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp
+
+import com.okta.authfoundation.client.TokenInfo
+import com.okta.authfoundation.client.kmp.OAuth2Client
+
+/**
+ * Implements the [Token Exchange](https://openid.net/specs/openid-connect-native-sso-1_0.html) flow
+ * for Native SSO.
+ *
+ * Use [start] to exchange an existing ID token and device secret for new tokens:
+ *
+ * ```kotlin
+ * val flow = TokenExchangeFlow(client)
+ * val tokenInfo = flow.start(idToken = "...", deviceSecret = "...").getOrThrow()
+ * ```
+ */
+interface TokenExchangeFlow {
+    /**
+     * Initiates the token exchange flow.
+     *
+     * @param idToken the ID token for the user.
+     * @param deviceSecret the device secret obtained from a previous authentication flow.
+     * @param audience the audience of the authorization server. Defaults to `api://default`.
+     * @param scope the OAuth2 scopes to request.
+     * @return [Result.success] with [TokenInfo] on success, or [Result.failure] with:
+     * - [com.okta.authfoundation.client.OAuth2ClientResult.Error.OidcEndpointsNotAvailableException] if endpoints are unavailable.
+     * - [com.okta.authfoundation.client.OAuth2ClientResult.Error.HttpResponseException] on server errors.
+     * - Other exceptions for network or parsing failures.
+     */
+    suspend fun start(
+        idToken: String,
+        deviceSecret: String,
+        audience: String? = null,
+        scope: String = "openid profile email offline_access",
+    ): Result<TokenInfo>
+
+    companion object {
+        /**
+         * Creates a [TokenExchangeFlow] backed by the given [OAuth2Client].
+         */
+        operator fun invoke(client: OAuth2Client): TokenExchangeFlow = TokenExchangeFlowImpl(client)
+    }
+}

--- a/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/TokenExchangeFlowImpl.kt
+++ b/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/TokenExchangeFlowImpl.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp
+
+import com.okta.authfoundation.InternalAuthFoundationApi
+import com.okta.authfoundation.client.TokenInfo
+import com.okta.authfoundation.client.kmp.OAuth2Client
+
+/**
+ * Default implementation of [TokenExchangeFlow] using the KMP [OAuth2Client].
+ *
+ * @param client the [OAuth2Client] instance used for token requests.
+ */
+internal class TokenExchangeFlowImpl(
+    private val client: OAuth2Client,
+) : TokenExchangeFlow {
+    @OptIn(InternalAuthFoundationApi::class)
+    override suspend fun start(
+        idToken: String,
+        deviceSecret: String,
+        audience: String?,
+        scope: String,
+    ): Result<TokenInfo> {
+        val formParams =
+            buildMap {
+                if (audience != null) put("audience", audience)
+                put("subject_token_type", "urn:ietf:params:oauth:token-type:id_token")
+                put("subject_token", idToken)
+                put("actor_token_type", "urn:x-oath:params:oauth:token-type:device-secret")
+                put("actor_token", deviceSecret)
+                put("client_id", client.configuration.clientId)
+                put("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange")
+                put("scope", scope)
+            }
+        return client.tokenRequest(formParams = formParams)
+    }
+}

--- a/oauth2/src/commonTest/kotlin/com/okta/oauth2/kmp/TokenExchangeFlowTest.kt
+++ b/oauth2/src/commonTest/kotlin/com/okta/oauth2/kmp/TokenExchangeFlowTest.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp
+
+import com.okta.authfoundation.client.TokenInfo
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class TokenExchangeFlowTest {
+    @Test
+    fun start_WhenSuccess_ReturnsTokenInfo() =
+        runTest {
+            val fakeToken = FakeTokenExchangeTokenInfo()
+            val mockFlow =
+                object : TokenExchangeFlow {
+                    override suspend fun start(
+                        idToken: String,
+                        deviceSecret: String,
+                        audience: String?,
+                        scope: String,
+                    ): Result<TokenInfo> = Result.success(fakeToken)
+                }
+
+            val result = mockFlow.start("id-token", "device-secret")
+
+            assertTrue(result.isSuccess)
+            val tokenInfo = result.getOrNull()
+            assertNotNull(tokenInfo)
+            assertEquals("test-access-token", tokenInfo.accessToken)
+            assertEquals("Bearer", tokenInfo.tokenType)
+        }
+
+    @Test
+    fun start_WhenError_ReturnsFailure() =
+        runTest {
+            val mockFlow =
+                object : TokenExchangeFlow {
+                    override suspend fun start(
+                        idToken: String,
+                        deviceSecret: String,
+                        audience: String?,
+                        scope: String,
+                    ): Result<TokenInfo> = Result.failure(IllegalStateException("invalid_grant"))
+                }
+
+            val result = mockFlow.start("id-token", "device-secret")
+
+            assertTrue(result.isFailure)
+            assertTrue(result.exceptionOrNull()?.message?.contains("invalid_grant") == true)
+        }
+
+    @Test
+    fun start_WhenEndpointUnavailable_ReturnsFailure() =
+        runTest {
+            val mockFlow =
+                object : TokenExchangeFlow {
+                    override suspend fun start(
+                        idToken: String,
+                        deviceSecret: String,
+                        audience: String?,
+                        scope: String,
+                    ): Result<TokenInfo> = Result.failure(IllegalStateException("OIDC Endpoints not available."))
+                }
+
+            val result = mockFlow.start("id-token", "device-secret")
+
+            assertTrue(result.isFailure)
+        }
+
+    @Test
+    fun start_WithAudience_PassesAudience() =
+        runTest {
+            var capturedAudience: String? = null
+            val mockFlow =
+                object : TokenExchangeFlow {
+                    override suspend fun start(
+                        idToken: String,
+                        deviceSecret: String,
+                        audience: String?,
+                        scope: String,
+                    ): Result<TokenInfo> {
+                        capturedAudience = audience
+                        return Result.success(FakeTokenExchangeTokenInfo())
+                    }
+                }
+
+            mockFlow.start("id-token", "device-secret", audience = "api://custom")
+
+            assertEquals("api://custom", capturedAudience)
+        }
+}
+
+private class FakeTokenExchangeTokenInfo : TokenInfo {
+    override val id: String = "test-id"
+    override val clientId: String = "test-client"
+    override val issuerUrl: String = "https://example.okta.com"
+    override val tokenType: String = "Bearer"
+    override val expiresIn: Int = 3600
+    override val accessToken: String = "test-access-token"
+    override val scope: String? = "openid profile"
+    override val refreshToken: String? = "test-refresh-token"
+    override val idToken: String? = null
+    override val deviceSecret: String? = null
+    override val issuedTokenType: String? = null
+}

--- a/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/jvm/TokenExchangeFlow.kt
+++ b/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/jvm/TokenExchangeFlow.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp.jvm
+
+import com.okta.authfoundation.client.TokenInfo
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.future.future
+import java.io.Closeable
+import java.util.concurrent.CompletableFuture
+import com.okta.oauth2.kmp.TokenExchangeFlow as KotlinTokenExchangeFlow
+
+/**
+ * A Java-friendly wrapper around the Kotlin [KotlinTokenExchangeFlow].
+ *
+ * This class exposes async methods returning [CompletableFuture] so Java consumers
+ * can use the Token Exchange flow without dealing with Kotlin coroutines.
+ *
+ * Must be [closed][close] when no longer needed to release coroutine resources.
+ *
+ * @param delegate the underlying Kotlin [KotlinTokenExchangeFlow] instance.
+ */
+class TokenExchangeFlow(
+    private val delegate: KotlinTokenExchangeFlow,
+) : Closeable {
+    private val coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    /**
+     * Initiates the token exchange flow asynchronously.
+     *
+     * @param idToken the ID token for the user.
+     * @param deviceSecret the device secret from a previous authentication flow.
+     * @param audience optional audience; pass null to omit from the request.
+     * @param scope the scopes to request.
+     * @return a [CompletableFuture] that completes with [TokenInfo] on success,
+     *   or completes exceptionally on failure.
+     */
+    @JvmOverloads
+    fun start(
+        idToken: String,
+        deviceSecret: String,
+        audience: String? = null,
+        scope: String = "openid profile email offline_access",
+    ): CompletableFuture<TokenInfo> =
+        coroutineScope.future {
+            delegate.start(idToken, deviceSecret, audience, scope).getOrThrow()
+        }
+
+    override fun close() {
+        coroutineScope.cancel()
+    }
+}

--- a/oauth2/src/jvmTest/java/com/okta/oauth2/kmp/jvm/TokenExchangeFlowTest.java
+++ b/oauth2/src/jvmTest/java/com/okta/oauth2/kmp/jvm/TokenExchangeFlowTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp.jvm;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.okta.authfoundation.client.TokenInfo;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.junit.Test;
+
+/**
+ * Java-language tests for {@link TokenExchangeFlow} CompletableFuture wrapper. Validates that the
+ * API is ergonomic from actual Java code.
+ */
+public class TokenExchangeFlowTest {
+
+  @Test
+  public void start_ReturnsCompletableFutureWithTokenInfo()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    TokenExchangeFlow flow = TestFlowFactory.createSuccessTokenExchangeFlow();
+    try {
+      CompletableFuture<TokenInfo> future =
+          flow.start("id-token", "device-secret", null, "openid profile email offline_access");
+      assertNotNull("Future should not be null", future);
+
+      TokenInfo tokenInfo = future.get(5, TimeUnit.SECONDS);
+      assertNotNull("TokenInfo should not be null", tokenInfo);
+      assertEquals("Bearer", tokenInfo.getTokenType());
+      assertEquals("test-access-token", tokenInfo.getAccessToken());
+    } finally {
+      flow.close();
+    }
+  }
+
+  @Test
+  public void start_WithDefaults_UsesDefaultScope()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    TokenExchangeFlow flow = TestFlowFactory.createSuccessTokenExchangeFlow();
+    try {
+      // Uses @JvmOverloads defaults — only required params
+      CompletableFuture<TokenInfo> future = flow.start("id-token", "device-secret");
+      TokenInfo tokenInfo = future.get(5, TimeUnit.SECONDS);
+      assertNotNull("TokenInfo should not be null", tokenInfo);
+    } finally {
+      flow.close();
+    }
+  }
+
+  @Test
+  public void start_WithError_CompletesExceptionally()
+      throws TimeoutException, InterruptedException {
+    TokenExchangeFlow flow = TestFlowFactory.createFailingTokenExchangeFlow();
+    try {
+      CompletableFuture<TokenInfo> future = flow.start("id-token", "device-secret");
+      try {
+        future.get(5, TimeUnit.SECONDS);
+        fail("Should have thrown ExecutionException");
+      } catch (ExecutionException e) {
+        assertNotNull("Cause should not be null", e.getCause());
+        assertTrue(
+            "Should contain error message", e.getCause().getMessage().contains("invalid_grant"));
+      }
+    } finally {
+      flow.close();
+    }
+  }
+
+  @Test
+  public void close_IsIdempotent() {
+    TokenExchangeFlow flow = TestFlowFactory.createSuccessTokenExchangeFlow();
+    flow.close();
+    flow.close(); // Should not throw
+  }
+}


### PR DESCRIPTION
Implements the Token Exchange Grant (RFC 8693) for KMP targets (Android + JVM). Exchanges an ID token and device secret for a new token set using urn:ietf:params:oauth:grant-type:token-exchange. Includes Java-friendly CompletableFuture wrapper.

RESOLVES: OKTA-1162033