### PR TITLE
Add KMP AuthorizationCodeFlow interface, implementation, and Java wrapper

### DIFF
--- a/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/AuthorizationCodeFlow.kt
+++ b/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/AuthorizationCodeFlow.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp
+
+import com.okta.authfoundation.client.TokenInfo
+import com.okta.authfoundation.client.kmp.OAuth2Client
+
+/**
+ * Encapsulates the behavior required to authenticate using the OIDC Authorization Code flow with PKCE.
+ *
+ * See [Authorization Code Flow documentation](https://developer.okta.com/docs/guides/implement-grant-type/authcodepkce/main/)
+ */
+interface AuthorizationCodeFlow {
+    /**
+     * Thrown by [resume] when the authorization server returns an error.
+     *
+     * @property errorId the OAuth2 error code returned by the server.
+     */
+    class ResumeException(
+        message: String,
+        val errorId: String,
+    ) : Exception(message)
+
+    /**
+     * Thrown by [resume] when the redirect URI scheme does not match the configured redirect URL.
+     */
+    class RedirectSchemeMismatchException : Exception()
+
+    /**
+     * Thrown by [resume] when no authorization code is present in the redirect URI.
+     */
+    class MissingResultCodeException : Exception()
+
+    /**
+     * Initiates the Authorization Code redirect flow.
+     *
+     * @param redirectUrl the registered redirect URI for this client.
+     * @param extraRequestParameters additional query parameters for the authorization endpoint.
+     * @param scope the scopes to request.
+     * @return a [Result] containing an [AuthorizationCodeFlowContext] with the authorization URL and state.
+     */
+    suspend fun start(
+        redirectUrl: String,
+        extraRequestParameters: Map<String, String> = emptyMap(),
+        scope: String = "openid profile email offline_access",
+    ): Result<AuthorizationCodeFlowContext>
+
+    /**
+     * Completes the Authorization Code redirect flow by exchanging the authorization code for tokens.
+     *
+     * @param uri the redirect URI received from the browser after authorization.
+     * @param flowContext the [AuthorizationCodeFlowContext] returned by [start].
+     * @return a [Result] containing [TokenInfo] on success.
+     */
+    suspend fun resume(
+        uri: String,
+        flowContext: AuthorizationCodeFlowContext,
+    ): Result<TokenInfo>
+
+    companion object {
+        /**
+         * Creates an [AuthorizationCodeFlow] backed by the given [OAuth2Client].
+         */
+        operator fun invoke(client: OAuth2Client): AuthorizationCodeFlow = AuthorizationCodeFlowImpl(client)
+    }
+}

--- a/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/AuthorizationCodeFlowContext.kt
+++ b/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/AuthorizationCodeFlowContext.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp
+
+/**
+ * A model representing the context and current state for an authorization code session.
+ *
+ * @property url the authorization URL to open in a browser.
+ * @property redirectUrl the redirect URL configured for the client.
+ * @property codeVerifier the PKCE code verifier (internal).
+ * @property state the random state parameter for CSRF protection (internal).
+ * @property nonce the random nonce for replay protection (internal).
+ * @property maxAge the max_age value from the request if provided (internal).
+ */
+data class AuthorizationCodeFlowContext(
+    val url: String,
+    val redirectUrl: String,
+    internal val codeVerifier: String,
+    internal val state: String,
+    internal val nonce: String,
+    internal val maxAge: Int?,
+)

--- a/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/AuthorizationCodeFlowImpl.kt
+++ b/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/AuthorizationCodeFlowImpl.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp
+
+import com.okta.authfoundation.InternalAuthFoundationApi
+import com.okta.authfoundation.client.TokenInfo
+import com.okta.authfoundation.client.kmp.OAuth2Client
+import com.okta.oauth2.PkceGenerator
+import com.okta.oauth2.internal.generateUuid
+import com.okta.oauth2.internal.parseQueryParameter
+import io.ktor.http.URLBuilder
+import io.ktor.http.takeFrom
+
+@OptIn(InternalAuthFoundationApi::class)
+internal class AuthorizationCodeFlowImpl(
+    private val client: OAuth2Client,
+) : AuthorizationCodeFlow {
+    override suspend fun start(
+        redirectUrl: String,
+        extraRequestParameters: Map<String, String>,
+        scope: String,
+    ): Result<AuthorizationCodeFlowContext> =
+        runCatching {
+            val endpoints =
+                client.endpointsOrNull()
+                    ?: throw IllegalStateException("OIDC Endpoints not available.")
+            val authorizationEndpoint =
+                endpoints.authorizationEndpoint
+                    ?: throw IllegalStateException("Authorization endpoint not available.")
+
+            val codeVerifier = PkceGenerator.codeVerifier()
+            val state = generateUuid()
+            val nonce = generateUuid()
+            val maxAge = extraRequestParameters["max_age"]?.toIntOrNull()
+
+            val urlBuilder = URLBuilder().takeFrom(authorizationEndpoint)
+
+            for ((key, value) in extraRequestParameters) {
+                urlBuilder.parameters.append(key, value)
+            }
+
+            urlBuilder.parameters.append("code_challenge", PkceGenerator.codeChallenge(codeVerifier))
+            urlBuilder.parameters.append("code_challenge_method", PkceGenerator.CODE_CHALLENGE_METHOD)
+            urlBuilder.parameters.append("client_id", client.configuration.clientId)
+            urlBuilder.parameters.append("scope", scope)
+            urlBuilder.parameters.append("redirect_uri", redirectUrl)
+            urlBuilder.parameters.append("response_type", "code")
+            urlBuilder.parameters.append("state", state)
+            urlBuilder.parameters.append("nonce", nonce)
+
+            AuthorizationCodeFlowContext(
+                url = urlBuilder.buildString(),
+                redirectUrl = redirectUrl,
+                codeVerifier = codeVerifier,
+                state = state,
+                nonce = nonce,
+                maxAge = maxAge
+            )
+        }
+
+    override suspend fun resume(
+        uri: String,
+        flowContext: AuthorizationCodeFlowContext,
+    ): Result<TokenInfo> =
+        runCatching {
+            if (!uri.startsWith(flowContext.redirectUrl)) {
+                throw AuthorizationCodeFlow.RedirectSchemeMismatchException()
+            }
+
+            val error = parseQueryParameter(uri, "error")
+            if (error != null) {
+                val errorDescription = parseQueryParameter(uri, "error_description") ?: "An error occurred."
+                throw AuthorizationCodeFlow.ResumeException(errorDescription, error)
+            }
+
+            val stateParam = parseQueryParameter(uri, "state")
+            if (flowContext.state != stateParam) {
+                throw AuthorizationCodeFlow.ResumeException("Failed due to state mismatch.", "state_mismatch")
+            }
+
+            val code = parseQueryParameter(uri, "code") ?: throw AuthorizationCodeFlow.MissingResultCodeException()
+
+            val formParams =
+                mapOf(
+                    "redirect_uri" to flowContext.redirectUrl,
+                    "code_verifier" to flowContext.codeVerifier,
+                    "client_id" to client.configuration.clientId,
+                    "grant_type" to "authorization_code",
+                    "code" to code
+                )
+
+            client
+                .tokenRequest(
+                    formParams = formParams,
+                    nonce = flowContext.nonce,
+                    maxAge = flowContext.maxAge
+                ).getOrThrow()
+        }
+}

--- a/oauth2/src/commonTest/kotlin/com/okta/oauth2/kmp/AuthorizationCodeFlowTest.kt
+++ b/oauth2/src/commonTest/kotlin/com/okta/oauth2/kmp/AuthorizationCodeFlowTest.kt
@@ -1,0 +1,258 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp
+
+import com.okta.authfoundation.client.TokenInfo
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class AuthorizationCodeFlowTest {
+    @Test
+    fun start_WhenSuccess_ReturnsContext() =
+        runTest {
+            val mockFlow =
+                object : AuthorizationCodeFlow {
+                    override suspend fun start(
+                        redirectUrl: String,
+                        extraRequestParameters: Map<String, String>,
+                        scope: String,
+                    ): Result<AuthorizationCodeFlowContext> =
+                        Result.success(
+                            AuthorizationCodeFlowContext(
+                                url = "https://example.okta.com/authorize?response_type=code",
+                                redirectUrl = redirectUrl,
+                                codeVerifier = "test-code-verifier",
+                                state = "test-state",
+                                nonce = "test-nonce",
+                                maxAge = null
+                            )
+                        )
+
+                    override suspend fun resume(
+                        uri: String,
+                        flowContext: AuthorizationCodeFlowContext,
+                    ): Result<TokenInfo> = Result.success(FakeAuthCodeTokenInfo())
+                }
+
+            val result = mockFlow.start("com.example.app:/callback")
+
+            assertTrue(result.isSuccess)
+            val context = result.getOrNull()
+            assertNotNull(context)
+            assertEquals("com.example.app:/callback", context.redirectUrl)
+            assertTrue(context.url.contains("response_type=code"))
+        }
+
+    @Test
+    fun resume_WhenSuccess_ReturnsTokenInfo() =
+        runTest {
+            val fakeToken = FakeAuthCodeTokenInfo()
+            val mockFlow =
+                object : AuthorizationCodeFlow {
+                    override suspend fun start(
+                        redirectUrl: String,
+                        extraRequestParameters: Map<String, String>,
+                        scope: String,
+                    ): Result<AuthorizationCodeFlowContext> =
+                        Result.success(
+                            AuthorizationCodeFlowContext(
+                                url = "https://example.okta.com/authorize",
+                                redirectUrl = "com.example.app:/callback",
+                                codeVerifier = "test-code-verifier",
+                                state = "test-state",
+                                nonce = "test-nonce",
+                                maxAge = null
+                            )
+                        )
+
+                    override suspend fun resume(
+                        uri: String,
+                        flowContext: AuthorizationCodeFlowContext,
+                    ): Result<TokenInfo> = Result.success(fakeToken)
+                }
+
+            val context =
+                AuthorizationCodeFlowContext(
+                    url = "https://example.okta.com/authorize",
+                    redirectUrl = "com.example.app:/callback",
+                    codeVerifier = "test-code-verifier",
+                    state = "test-state",
+                    nonce = "test-nonce",
+                    maxAge = null
+                )
+            val uri = "com.example.app:/callback?code=auth-code&state=test-state"
+            val result = mockFlow.resume(uri, context)
+
+            assertTrue(result.isSuccess)
+            val tokenInfo = result.getOrNull()
+            assertNotNull(tokenInfo)
+            assertEquals("test-access-token", tokenInfo.accessToken)
+            assertEquals("Bearer", tokenInfo.tokenType)
+        }
+
+    @Test
+    fun resume_WhenStateMismatch_ThrowsResumeException() =
+        runTest {
+            val mockFlow =
+                object : AuthorizationCodeFlow {
+                    override suspend fun start(
+                        redirectUrl: String,
+                        extraRequestParameters: Map<String, String>,
+                        scope: String,
+                    ): Result<AuthorizationCodeFlowContext> = Result.failure(IllegalStateException())
+
+                    override suspend fun resume(
+                        uri: String,
+                        flowContext: AuthorizationCodeFlowContext,
+                    ): Result<TokenInfo> =
+                        Result.failure(
+                            AuthorizationCodeFlow.ResumeException(
+                                "Failed due to state mismatch.",
+                                "state_mismatch"
+                            )
+                        )
+                }
+
+            val context =
+                AuthorizationCodeFlowContext(
+                    url = "https://example.okta.com/authorize",
+                    redirectUrl = "com.example.app:/callback",
+                    codeVerifier = "test-code-verifier",
+                    state = "expected-state",
+                    nonce = "test-nonce",
+                    maxAge = null
+                )
+            val uri = "com.example.app:/callback?code=auth-code&state=wrong-state"
+            val result = mockFlow.resume(uri, context)
+
+            assertTrue(result.isFailure)
+            val exception = result.exceptionOrNull()
+            assertTrue(exception is AuthorizationCodeFlow.ResumeException)
+            assertEquals("state_mismatch", exception.errorId)
+        }
+
+    @Test
+    fun resume_WhenErrorReturned_ThrowsResumeException() =
+        runTest {
+            val mockFlow =
+                object : AuthorizationCodeFlow {
+                    override suspend fun start(
+                        redirectUrl: String,
+                        extraRequestParameters: Map<String, String>,
+                        scope: String,
+                    ): Result<AuthorizationCodeFlowContext> = Result.failure(IllegalStateException())
+
+                    override suspend fun resume(
+                        uri: String,
+                        flowContext: AuthorizationCodeFlowContext,
+                    ): Result<TokenInfo> =
+                        Result.failure(
+                            AuthorizationCodeFlow.ResumeException("Access denied by user.", "access_denied")
+                        )
+                }
+
+            val context =
+                AuthorizationCodeFlowContext(
+                    url = "https://example.okta.com/authorize",
+                    redirectUrl = "com.example.app:/callback",
+                    codeVerifier = "test-code-verifier",
+                    state = "test-state",
+                    nonce = "test-nonce",
+                    maxAge = null
+                )
+            val uri = "com.example.app:/callback?error=access_denied&error_description=Access+denied"
+            val result = mockFlow.resume(uri, context)
+
+            assertTrue(result.isFailure)
+            val exception = result.exceptionOrNull()
+            assertTrue(exception is AuthorizationCodeFlow.ResumeException)
+            assertEquals("access_denied", exception.errorId)
+        }
+
+    @Test
+    fun resume_WhenRedirectSchemeMismatch_ThrowsRedirectSchemeMismatchException() =
+        runTest {
+            val mockFlow =
+                object : AuthorizationCodeFlow {
+                    override suspend fun start(
+                        redirectUrl: String,
+                        extraRequestParameters: Map<String, String>,
+                        scope: String,
+                    ): Result<AuthorizationCodeFlowContext> = Result.failure(IllegalStateException())
+
+                    override suspend fun resume(
+                        uri: String,
+                        flowContext: AuthorizationCodeFlowContext,
+                    ): Result<TokenInfo> = Result.failure(AuthorizationCodeFlow.RedirectSchemeMismatchException())
+                }
+
+            val context =
+                AuthorizationCodeFlowContext(
+                    url = "https://example.okta.com/authorize",
+                    redirectUrl = "com.example.app:/callback",
+                    codeVerifier = "test-code-verifier",
+                    state = "test-state",
+                    nonce = "test-nonce",
+                    maxAge = null
+                )
+            val uri = "com.different.app:/callback?code=auth-code"
+            val result = mockFlow.resume(uri, context)
+
+            assertTrue(result.isFailure)
+            assertTrue(result.exceptionOrNull() is AuthorizationCodeFlow.RedirectSchemeMismatchException)
+        }
+
+    @Test
+    fun start_WhenEndpointUnavailable_ReturnsFailure() =
+        runTest {
+            val mockFlow =
+                object : AuthorizationCodeFlow {
+                    override suspend fun start(
+                        redirectUrl: String,
+                        extraRequestParameters: Map<String, String>,
+                        scope: String,
+                    ): Result<AuthorizationCodeFlowContext> = Result.failure(IllegalStateException("OIDC Endpoints not available."))
+
+                    override suspend fun resume(
+                        uri: String,
+                        flowContext: AuthorizationCodeFlowContext,
+                    ): Result<TokenInfo> = Result.failure(IllegalStateException())
+                }
+
+            val result = mockFlow.start("com.example.app:/callback")
+
+            assertTrue(result.isFailure)
+            assertTrue(result.exceptionOrNull()?.message?.contains("OIDC Endpoints not available.") == true)
+        }
+}
+
+private class FakeAuthCodeTokenInfo : TokenInfo {
+    override val id: String = "test-id"
+    override val clientId: String = "test-client"
+    override val issuerUrl: String = "https://example.okta.com"
+    override val tokenType: String = "Bearer"
+    override val expiresIn: Int = 3600
+    override val accessToken: String = "test-access-token"
+    override val scope: String? = "openid profile"
+    override val refreshToken: String? = "test-refresh-token"
+    override val idToken: String? = null
+    override val deviceSecret: String? = null
+    override val issuedTokenType: String? = null
+}

--- a/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/jvm/AuthorizationCodeFlow.kt
+++ b/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/jvm/AuthorizationCodeFlow.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp.jvm
+
+import com.okta.authfoundation.client.TokenInfo
+import com.okta.oauth2.kmp.BrowserRedirectHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.future.future
+import java.io.Closeable
+import java.util.concurrent.CompletableFuture
+import com.okta.oauth2.kmp.AuthorizationCodeFlow as KotlinAuthorizationCodeFlow
+
+/**
+ * A Java-friendly wrapper around the Kotlin [KotlinAuthorizationCodeFlow].
+ *
+ * This class combines the [start][KotlinAuthorizationCodeFlow.start] and
+ * [resume][KotlinAuthorizationCodeFlow.resume] steps into a single
+ * [start] method that uses a [BrowserRedirectHandler] to open the browser and capture
+ * the redirect callback. Java consumers can use [CompletableFuture] without dealing
+ * with Kotlin coroutines.
+ *
+ * Must be [closed][close] when no longer needed to release coroutine resources.
+ *
+ * @param delegate the underlying Kotlin [KotlinAuthorizationCodeFlow] instance.
+ */
+class AuthorizationCodeFlow(
+    private val delegate: KotlinAuthorizationCodeFlow,
+) : Closeable {
+    private val coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    /**
+     * Performs the full Authorization Code flow asynchronously.
+     *
+     * Opens [redirectUrl] in a browser via [browserRedirectHandler], waits for the
+     * redirect callback, and exchanges the authorization code for tokens.
+     *
+     * @param redirectUrl the registered redirect URI for this client.
+     * @param browserRedirectHandler handles opening the browser and capturing the redirect.
+     * @param extraRequestParameters additional authorization endpoint parameters.
+     * @param scope the scopes to request.
+     * @return a [CompletableFuture] that completes with [TokenInfo] on success,
+     *   or completes exceptionally on failure.
+     */
+    @JvmOverloads
+    fun start(
+        redirectUrl: String,
+        browserRedirectHandler: BrowserRedirectHandler,
+        extraRequestParameters: Map<String, String> = emptyMap(),
+        scope: String = "openid profile email offline_access",
+    ): CompletableFuture<TokenInfo> =
+        coroutineScope.future {
+            val flowContext =
+                delegate
+                    .start(
+                        redirectUrl = redirectUrl,
+                        extraRequestParameters = extraRequestParameters,
+                        scope = scope
+                    ).getOrThrow()
+            val redirectUri = browserRedirectHandler.handleRedirect(flowContext.url)
+            delegate.resume(redirectUri, flowContext).getOrThrow()
+        }
+
+    override fun close() {
+        coroutineScope.cancel()
+    }
+}

--- a/oauth2/src/jvmTest/java/com/okta/oauth2/kmp/jvm/AuthorizationCodeFlowTest.java
+++ b/oauth2/src/jvmTest/java/com/okta/oauth2/kmp/jvm/AuthorizationCodeFlowTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp.jvm;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.okta.authfoundation.client.TokenInfo;
+import com.okta.oauth2.kmp.BrowserRedirectHandler;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.junit.Test;
+
+/**
+ * Java-language tests for {@link AuthorizationCodeFlow} CompletableFuture wrapper. Validates that
+ * the API is ergonomic from actual Java code.
+ */
+public class AuthorizationCodeFlowTest {
+
+  /** A {@link BrowserRedirectHandler} stub that immediately returns a fake redirect URI. */
+  private static final BrowserRedirectHandler FAKE_REDIRECT_HANDLER =
+      TestFlowFactory.createFakeBrowserRedirectHandler(
+          "com.example.app:/callback?code=auth-code&state=test-state");
+
+  @Test
+  public void start_ReturnsCompletableFutureWithTokenInfo()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    AuthorizationCodeFlow flow = TestFlowFactory.createSuccessAuthorizationCodeFlow();
+    try {
+      CompletableFuture<TokenInfo> future =
+          flow.start("com.example.app:/callback", FAKE_REDIRECT_HANDLER);
+      assertNotNull("Future should not be null", future);
+
+      TokenInfo tokenInfo = future.get(5, TimeUnit.SECONDS);
+      assertNotNull("TokenInfo should not be null", tokenInfo);
+      assertEquals("Bearer", tokenInfo.getTokenType());
+      assertEquals("test-access-token", tokenInfo.getAccessToken());
+    } finally {
+      flow.close();
+    }
+  }
+
+  @Test
+  public void start_WithAllParams_UsesProvidedScope()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    AuthorizationCodeFlow flow = TestFlowFactory.createSuccessAuthorizationCodeFlow();
+    try {
+      CompletableFuture<TokenInfo> future =
+          flow.start(
+              "com.example.app:/callback",
+              FAKE_REDIRECT_HANDLER,
+              Collections.emptyMap(),
+              "openid profile email");
+      TokenInfo tokenInfo = future.get(5, TimeUnit.SECONDS);
+      assertNotNull("TokenInfo should not be null", tokenInfo);
+    } finally {
+      flow.close();
+    }
+  }
+
+  @Test
+  public void start_WithDefaults_UsesDefaultScopeAndNoExtraParams()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    AuthorizationCodeFlow flow = TestFlowFactory.createSuccessAuthorizationCodeFlow();
+    try {
+      // Uses @JvmOverloads defaults — only redirectUrl and browserRedirectHandler required
+      CompletableFuture<TokenInfo> future =
+          flow.start("com.example.app:/callback", FAKE_REDIRECT_HANDLER);
+      TokenInfo tokenInfo = future.get(5, TimeUnit.SECONDS);
+      assertNotNull("TokenInfo should not be null", tokenInfo);
+    } finally {
+      flow.close();
+    }
+  }
+
+  @Test
+  public void start_WithError_CompletesExceptionally()
+      throws TimeoutException, InterruptedException {
+    AuthorizationCodeFlow flow = TestFlowFactory.createFailingAuthorizationCodeFlow();
+    try {
+      CompletableFuture<TokenInfo> future =
+          flow.start("com.example.app:/callback", FAKE_REDIRECT_HANDLER);
+      try {
+        future.get(5, TimeUnit.SECONDS);
+        fail("Should have thrown ExecutionException");
+      } catch (ExecutionException e) {
+        assertNotNull("Cause should not be null", e.getCause());
+        assertTrue(
+            "Should contain error message",
+            e.getCause().getMessage().contains("OIDC Endpoints not available."));
+      }
+    } finally {
+      flow.close();
+    }
+  }
+
+  @Test
+  public void close_IsIdempotent() {
+    AuthorizationCodeFlow flow = TestFlowFactory.createSuccessAuthorizationCodeFlow();
+    flow.close();
+    flow.close(); // Should not throw
+  }
+}


### PR DESCRIPTION
Implements the Authorization Code + PKCE flow for KMP targets (Android + JVM). Builds the authorization URL with PKCE (S256), validates state and redirect scheme on resume, extracts the authorization code, and exchanges it for tokens. Includes ResumeException, RedirectSchemeMismatchException, and a Java wrapper that combines start/resume via BrowserRedirectHandler.