### PR TITLE
Add KMP SessionTokenFlow interface, implementation, and Java wrapper

### DIFF
--- a/oauth2/src/commonMain/kotlin/com/okta/oauth2/internal/HttpUtils.kt
+++ b/oauth2/src/commonMain/kotlin/com/okta/oauth2/internal/HttpUtils.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.internal
+
+import com.okta.authfoundation.api.http.ApiExecutor
+import com.okta.authfoundation.api.http.ApiFormRequest
+import com.okta.authfoundation.api.http.ApiRequest
+import com.okta.authfoundation.api.http.ApiRequestMethod
+import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.json.Json
+
+/**
+ * Executes a JSON form POST request and deserializes the response body.
+ *
+ * Uses only public [ApiExecutor] APIs to remain accessible from the oauth2 module.
+ *
+ * @param apiExecutor the HTTP executor.
+ * @param json the JSON serializer.
+ * @param url the endpoint URL.
+ * @param formParams the form parameters to POST.
+ * @param deserializer the response deserializer.
+ * @return [Result.success] with the deserialized value, or [Result.failure] on HTTP or parse error.
+ */
+internal suspend fun <T> performJsonFormPost(
+    apiExecutor: ApiExecutor,
+    json: Json,
+    url: String,
+    formParams: Map<String, String>,
+    deserializer: DeserializationStrategy<T>,
+): Result<T> =
+    runCatching {
+        val request =
+            object : ApiFormRequest {
+                override fun method(): ApiRequestMethod = ApiRequestMethod.POST
+
+                override fun headers(): Map<String, List<String>> = mapOf("Accept" to listOf("application/json"))
+
+                override fun url(): String = url
+
+                override fun contentType(): String = "application/x-www-form-urlencoded"
+
+                override fun formParameters(): Map<String, List<String>> = formParams.mapValues { (_, v) -> listOf(v) }
+            }
+        val response = apiExecutor.execute(request).getOrThrow()
+        val body =
+            response.body?.decodeToString()
+                ?: throw IllegalStateException("Empty response body")
+        json.decodeFromString(deserializer, body)
+    }
+
+/**
+ * Executes a GET request and returns the `Location` response header without following redirects.
+ *
+ * Used by [com.okta.oauth2.kmp.SessionTokenFlowImpl] to capture the authorization code redirect.
+ *
+ * @param apiExecutor the HTTP executor.
+ * @param url the URL to GET.
+ * @return [Result.success] with the Location header value, or [Result.failure] if not present.
+ */
+internal suspend fun performGetCaptureLocationHeader(
+    apiExecutor: ApiExecutor,
+    url: String,
+): Result<String> =
+    runCatching {
+        val request =
+            object : ApiRequest {
+                override fun method(): ApiRequestMethod = ApiRequestMethod.GET
+
+                override fun headers(): Map<String, List<String>> = emptyMap()
+
+                override fun url(): String = url
+            }
+        val response = apiExecutor.execute(request).getOrThrow()
+        response.headers["location"]?.firstOrNull()
+            ?: response.headers["Location"]?.firstOrNull()
+            ?: throw IllegalStateException("No location header in response.")
+    }

--- a/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/SessionTokenFlow.kt
+++ b/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/SessionTokenFlow.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp
+
+import com.okta.authfoundation.client.TokenInfo
+import com.okta.authfoundation.client.kmp.OAuth2Client
+
+/**
+ * Implements the Session Token authentication flow.
+ *
+ * Exchanges a session token (obtained from the Okta legacy Authn API) for OAuth2 tokens by:
+ * 1. Building an authorization URL with the session token as an extra parameter.
+ * 2. Making a GET request to the authorization URL and capturing the redirect `Location` header.
+ * 3. Exchanging the authorization code in the redirect URI for tokens.
+ */
+interface SessionTokenFlow {
+    /**
+     * Initiates the session token flow and returns a [TokenInfo] on success.
+     *
+     * @param sessionToken the session token obtained from Okta legacy Authn APIs.
+     * @param redirectUrl the redirect URL registered with the authorization server.
+     * @param extraRequestParameters additional key-value pairs appended to the authorization URL.
+     * @param scope the space-delimited scopes to request.
+     * @return [Result.success] with [TokenInfo] on success, or [Result.failure] on error.
+     */
+    suspend fun start(
+        sessionToken: String,
+        redirectUrl: String,
+        extraRequestParameters: Map<String, String> = emptyMap(),
+        scope: String = "openid profile email offline_access",
+    ): Result<TokenInfo>
+
+    companion object {
+        /**
+         * Creates a [SessionTokenFlow] backed by the given [OAuth2Client].
+         *
+         * @param client the [OAuth2Client] used for token requests.
+         */
+        operator fun invoke(client: OAuth2Client): SessionTokenFlow = SessionTokenFlowImpl(client)
+    }
+}

--- a/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/SessionTokenFlowImpl.kt
+++ b/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/SessionTokenFlowImpl.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp
+
+import com.okta.authfoundation.InternalAuthFoundationApi
+import com.okta.authfoundation.client.TokenInfo
+import com.okta.authfoundation.client.kmp.OAuth2Client
+import com.okta.oauth2.internal.performGetCaptureLocationHeader
+
+/**
+ * Default implementation of [SessionTokenFlow] using the KMP [OAuth2Client].
+ *
+ * @param client the [OAuth2Client] instance used for authorization and token requests.
+ */
+@OptIn(InternalAuthFoundationApi::class)
+internal class SessionTokenFlowImpl(
+    private val client: OAuth2Client,
+) : SessionTokenFlow {
+    override suspend fun start(
+        sessionToken: String,
+        redirectUrl: String,
+        extraRequestParameters: Map<String, String>,
+        scope: String,
+    ): Result<TokenInfo> =
+        runCatching {
+            val authorizationCodeFlow = AuthorizationCodeFlowImpl(client)
+            val mutableParameters = extraRequestParameters.toMutableMap()
+            mutableParameters["sessionToken"] = sessionToken
+
+            val flowContext =
+                authorizationCodeFlow
+                    .start(
+                        redirectUrl = redirectUrl,
+                        extraRequestParameters = mutableParameters,
+                        scope = scope
+                    ).getOrThrow()
+
+            val locationHeader =
+                performGetCaptureLocationHeader(
+                    apiExecutor = client.configuration.apiExecutor,
+                    url = flowContext.url
+                ).getOrThrow()
+
+            authorizationCodeFlow.resume(locationHeader, flowContext).getOrThrow()
+        }
+}

--- a/oauth2/src/commonTest/kotlin/com/okta/oauth2/kmp/SessionTokenFlowTest.kt
+++ b/oauth2/src/commonTest/kotlin/com/okta/oauth2/kmp/SessionTokenFlowTest.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp
+
+import com.okta.authfoundation.client.TokenInfo
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class SessionTokenFlowTest {
+    @Test
+    fun start_WhenSuccess_ReturnsTokenInfo() =
+        runTest {
+            val fakeToken = FakeSessionTokenInfo()
+            val mockFlow =
+                object : SessionTokenFlow {
+                    override suspend fun start(
+                        sessionToken: String,
+                        redirectUrl: String,
+                        extraRequestParameters: Map<String, String>,
+                        scope: String,
+                    ): Result<TokenInfo> = Result.success(fakeToken)
+                }
+
+            val result = mockFlow.start("example-session-token", "com.example.app:/callback")
+
+            assertTrue(result.isSuccess)
+            val tokenInfo = result.getOrNull()
+            assertNotNull(tokenInfo)
+            assertEquals("Bearer", tokenInfo.tokenType)
+            assertEquals("test-access-token", tokenInfo.accessToken)
+        }
+
+    @Test
+    fun start_WhenEndpointUnavailable_ReturnsFailure() =
+        runTest {
+            val mockFlow =
+                object : SessionTokenFlow {
+                    override suspend fun start(
+                        sessionToken: String,
+                        redirectUrl: String,
+                        extraRequestParameters: Map<String, String>,
+                        scope: String,
+                    ): Result<TokenInfo> = Result.failure(IllegalStateException("OIDC Endpoints not available."))
+                }
+
+            val result = mockFlow.start("example-session-token", "com.example.app:/callback")
+
+            assertTrue(result.isFailure)
+            assertTrue(result.exceptionOrNull()?.message?.contains("OIDC Endpoints not available.") == true)
+        }
+
+    @Test
+    fun start_WhenNoLocationHeader_ReturnsFailure() =
+        runTest {
+            val mockFlow =
+                object : SessionTokenFlow {
+                    override suspend fun start(
+                        sessionToken: String,
+                        redirectUrl: String,
+                        extraRequestParameters: Map<String, String>,
+                        scope: String,
+                    ): Result<TokenInfo> = Result.failure(IllegalStateException("No location header in response."))
+                }
+
+            val result = mockFlow.start("example-session-token", "com.example.app:/callback")
+
+            assertTrue(result.isFailure)
+            assertTrue(result.exceptionOrNull()?.message?.contains("No location header") == true)
+        }
+
+    @Test
+    fun start_WithExtraParameters_ReturnsTokenInfo() =
+        runTest {
+            var capturedExtraParams: Map<String, String>? = null
+            val mockFlow =
+                object : SessionTokenFlow {
+                    override suspend fun start(
+                        sessionToken: String,
+                        redirectUrl: String,
+                        extraRequestParameters: Map<String, String>,
+                        scope: String,
+                    ): Result<TokenInfo> {
+                        capturedExtraParams = extraRequestParameters
+                        return Result.success(FakeSessionTokenInfo())
+                    }
+                }
+
+            mockFlow.start(
+                sessionToken = "example-session-token",
+                redirectUrl = "com.example.app:/callback",
+                extraRequestParameters = mapOf("extraOne" to "bar"),
+                scope = "openid profile email"
+            )
+
+            assertNotNull(capturedExtraParams)
+            assertEquals("bar", capturedExtraParams["extraOne"])
+        }
+}
+
+private class FakeSessionTokenInfo : TokenInfo {
+    override val id: String = "test-id"
+    override val clientId: String = "test-client"
+    override val issuerUrl: String = "https://example.okta.com"
+    override val tokenType: String = "Bearer"
+    override val expiresIn: Int = 3600
+    override val accessToken: String = "test-access-token"
+    override val scope: String? = "openid profile"
+    override val refreshToken: String? = "test-refresh-token"
+    override val idToken: String? = null
+    override val deviceSecret: String? = null
+    override val issuedTokenType: String? = null
+}

--- a/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/jvm/SessionTokenFlow.kt
+++ b/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/jvm/SessionTokenFlow.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp.jvm
+
+import com.okta.authfoundation.client.TokenInfo
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.future.future
+import java.io.Closeable
+import java.util.concurrent.CompletableFuture
+import com.okta.oauth2.kmp.SessionTokenFlow as KotlinSessionTokenFlow
+
+/**
+ * A Java-friendly wrapper around the Kotlin [KotlinSessionTokenFlow].
+ *
+ * This class exposes async methods returning [CompletableFuture] so Java consumers
+ * can use the Session Token flow without dealing with Kotlin coroutines.
+ *
+ * Must be [closed][close] when no longer needed to release coroutine resources.
+ *
+ * @param delegate the underlying Kotlin [KotlinSessionTokenFlow] instance.
+ */
+class SessionTokenFlow(
+    private val delegate: KotlinSessionTokenFlow,
+) : Closeable {
+    private val coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    /**
+     * Initiates the Session Token flow asynchronously.
+     *
+     * @param sessionToken the session token obtained from the Okta legacy Authn API.
+     * @param redirectUrl the redirect URL registered with the authorization server.
+     * @param extraRequestParameters additional key-value pairs appended to the authorization URL.
+     * @param scope the space-delimited scopes to request.
+     * @return a [CompletableFuture] that completes with [TokenInfo] on success,
+     *   or completes exceptionally on failure.
+     */
+    @JvmOverloads
+    fun start(
+        sessionToken: String,
+        redirectUrl: String,
+        extraRequestParameters: Map<String, String> = emptyMap(),
+        scope: String = "openid profile email offline_access",
+    ): CompletableFuture<TokenInfo> =
+        coroutineScope.future {
+            delegate.start(sessionToken, redirectUrl, extraRequestParameters, scope).getOrThrow()
+        }
+
+    override fun close() {
+        coroutineScope.cancel()
+    }
+}

--- a/oauth2/src/jvmTest/java/com/okta/oauth2/kmp/jvm/SessionTokenFlowTest.java
+++ b/oauth2/src/jvmTest/java/com/okta/oauth2/kmp/jvm/SessionTokenFlowTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp.jvm;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.okta.authfoundation.client.TokenInfo;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.junit.Test;
+
+/**
+ * Java-language tests for {@link SessionTokenFlow} CompletableFuture wrapper. Validates that the
+ * API is ergonomic from actual Java code.
+ */
+public class SessionTokenFlowTest {
+
+  @Test
+  public void start_ReturnsCompletableFutureWithTokenInfo()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    SessionTokenFlow flow = TestFlowFactory.createSuccessSessionTokenFlow();
+    try {
+      CompletableFuture<TokenInfo> future =
+          flow.start("example-session-token", "com.example.app:/callback");
+      assertNotNull("Future should not be null", future);
+
+      TokenInfo tokenInfo = future.get(5, TimeUnit.SECONDS);
+      assertNotNull("TokenInfo should not be null", tokenInfo);
+      assertEquals("Bearer", tokenInfo.getTokenType());
+      assertEquals("test-access-token", tokenInfo.getAccessToken());
+    } finally {
+      flow.close();
+    }
+  }
+
+  @Test
+  public void start_WithAllParams_ReturnsTokenInfo()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    SessionTokenFlow flow = TestFlowFactory.createSuccessSessionTokenFlow();
+    try {
+      CompletableFuture<TokenInfo> future =
+          flow.start(
+              "example-session-token",
+              "com.example.app:/callback",
+              Collections.emptyMap(),
+              "openid profile email");
+      TokenInfo tokenInfo = future.get(5, TimeUnit.SECONDS);
+      assertNotNull("TokenInfo should not be null", tokenInfo);
+    } finally {
+      flow.close();
+    }
+  }
+
+  @Test
+  public void start_WithError_CompletesExceptionally()
+      throws TimeoutException, InterruptedException {
+    SessionTokenFlow flow = TestFlowFactory.createFailingSessionTokenFlow();
+    try {
+      CompletableFuture<TokenInfo> future = flow.start("bad-token", "com.example.app:/callback");
+      try {
+        future.get(5, TimeUnit.SECONDS);
+        fail("Should have thrown ExecutionException");
+      } catch (ExecutionException e) {
+        assertNotNull("Cause should not be null", e.getCause());
+        assertTrue(
+            "Should contain error message",
+            e.getCause().getMessage().contains("OIDC Endpoints not available."));
+      }
+    } finally {
+      flow.close();
+    }
+  }
+
+  @Test
+  public void close_IsIdempotent() {
+    SessionTokenFlow flow = TestFlowFactory.createSuccessSessionTokenFlow();
+    flow.close();
+    flow.close(); // Should not throw
+  }
+}


### PR DESCRIPTION
Implements the Session Token flow for KMP targets (Android + JVM). Exchanges a session token for an OAuth2 token set by building an authorization URL (PKCE), making a non-redirecting GET via HttpUtils to capture the Location header, then exchanging the code at the token endpoint. Includes internal HttpUtils helper and Java-friendly CompletableFuture wrapper.

RESOLVES: OKTA-1162035