### PR TITLE
Add KMP RedirectEndSessionFlow interface, implementation, and Java wrapper

### DIFF
--- a/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/RedirectEndSessionFlow.kt
+++ b/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/RedirectEndSessionFlow.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp
+
+import com.okta.authfoundation.client.kmp.OAuth2Client
+
+/**
+ * [RedirectEndSessionFlow] encapsulates the behavior required to log out using an OIDC browser
+ * redirect flow.
+ *
+ * Call [start] to build the logout URL, then open it in a browser. Once the user is redirected
+ * back to your app, call [resume] with the redirect URI to complete the flow.
+ */
+interface RedirectEndSessionFlow {
+    /**
+     * Initiates the redirect end-session flow.
+     *
+     * @param idToken the ID token hint identifying the session to log out.
+     * @param redirectUrl the post-logout redirect URI registered with the authorization server.
+     * @param extraRequestParameters additional key-value pairs appended to the end-session URL.
+     * @return a [Result] containing a [RedirectEndSessionFlowContext] with the logout URL and state.
+     */
+    suspend fun start(
+        idToken: String,
+        redirectUrl: String,
+        extraRequestParameters: Map<String, String> = emptyMap(),
+    ): Result<RedirectEndSessionFlowContext>
+
+    /**
+     * Resumes the redirect end-session flow after the browser redirect.
+     *
+     * @param uri the redirect URI received from the browser after logout.
+     * @param flowContext the [RedirectEndSessionFlowContext] returned by [start].
+     * @return a [Result] containing [Unit] on success, or a failure wrapping a [ResumeException].
+     */
+    fun resume(
+        uri: String,
+        flowContext: RedirectEndSessionFlowContext,
+    ): Result<Unit>
+
+    /**
+     * Thrown from [resume] when the logout redirect cannot be completed successfully.
+     *
+     * @param message a human-readable description of the failure.
+     */
+    class ResumeException internal constructor(
+        message: String,
+    ) : Exception(message)
+
+    companion object {
+        /**
+         * Creates a [RedirectEndSessionFlow] backed by the given [OAuth2Client].
+         *
+         * @param client the KMP [OAuth2Client] to use for this flow.
+         */
+        operator fun invoke(client: OAuth2Client): RedirectEndSessionFlow = RedirectEndSessionFlowImpl(client)
+    }
+}

--- a/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/RedirectEndSessionFlowContext.kt
+++ b/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/RedirectEndSessionFlowContext.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp
+
+/**
+ * A model representing the context and current state for a redirect end-session flow.
+ *
+ * @property url the end-session URL to open in a browser.
+ * @property redirectUrl the post-logout redirect URI configured for the client.
+ * @property state the random state parameter for CSRF protection (internal).
+ */
+data class RedirectEndSessionFlowContext(
+    val url: String,
+    val redirectUrl: String,
+    internal val state: String,
+)

--- a/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/RedirectEndSessionFlowImpl.kt
+++ b/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/RedirectEndSessionFlowImpl.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp
+
+import com.okta.authfoundation.InternalAuthFoundationApi
+import com.okta.authfoundation.client.kmp.OAuth2Client
+import com.okta.oauth2.internal.generateUuid
+import com.okta.oauth2.internal.parseQueryParameter
+import io.ktor.http.URLBuilder
+import io.ktor.http.takeFrom
+
+@OptIn(InternalAuthFoundationApi::class)
+internal class RedirectEndSessionFlowImpl(
+    private val client: OAuth2Client,
+) : RedirectEndSessionFlow {
+    override suspend fun start(
+        idToken: String,
+        redirectUrl: String,
+        extraRequestParameters: Map<String, String>,
+    ): Result<RedirectEndSessionFlowContext> =
+        runCatching {
+            val endpoints =
+                client.endpointsOrNull()
+                    ?: throw IllegalStateException("OIDC Endpoints not available.")
+            val endSessionEndpoint =
+                endpoints.endSessionEndpoint
+                    ?: throw IllegalStateException("End session endpoint not available.")
+
+            val state = generateUuid()
+
+            val urlBuilder = URLBuilder().takeFrom(endSessionEndpoint)
+
+            for ((key, value) in extraRequestParameters) {
+                urlBuilder.parameters.append(key, value)
+            }
+
+            urlBuilder.parameters.append("id_token_hint", idToken)
+            urlBuilder.parameters.append("post_logout_redirect_uri", redirectUrl)
+            urlBuilder.parameters.append("state", state)
+
+            RedirectEndSessionFlowContext(
+                url = urlBuilder.buildString(),
+                redirectUrl = redirectUrl,
+                state = state
+            )
+        }
+
+    override fun resume(
+        uri: String,
+        flowContext: RedirectEndSessionFlowContext,
+    ): Result<Unit> =
+        runCatching {
+            if (!uri.startsWith(flowContext.redirectUrl)) {
+                throw RedirectEndSessionFlow.ResumeException("Redirect scheme mismatch.")
+            }
+
+            val error = parseQueryParameter(uri, "error")
+            if (error != null) {
+                val errorDescription = parseQueryParameter(uri, "error_description") ?: "An error occurred."
+                throw RedirectEndSessionFlow.ResumeException(errorDescription)
+            }
+
+            val stateParam = parseQueryParameter(uri, "state")
+            if (flowContext.state != stateParam) {
+                throw RedirectEndSessionFlow.ResumeException("Failed due to state mismatch.")
+            }
+        }
+}

--- a/oauth2/src/commonTest/kotlin/com/okta/oauth2/kmp/RedirectEndSessionFlowTest.kt
+++ b/oauth2/src/commonTest/kotlin/com/okta/oauth2/kmp/RedirectEndSessionFlowTest.kt
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class RedirectEndSessionFlowTest {
+    @Test
+    fun start_WhenSuccess_ReturnsFlowContext() =
+        runTest {
+            val mockFlow =
+                object : RedirectEndSessionFlow {
+                    override suspend fun start(
+                        idToken: String,
+                        redirectUrl: String,
+                        extraRequestParameters: Map<String, String>,
+                    ): Result<RedirectEndSessionFlowContext> =
+                        Result.success(
+                            RedirectEndSessionFlowContext(
+                                url = "https://example.okta.com/logout?id_token_hint=$idToken",
+                                redirectUrl = redirectUrl,
+                                state = "test-state"
+                            )
+                        )
+
+                    override fun resume(
+                        uri: String,
+                        flowContext: RedirectEndSessionFlowContext,
+                    ): Result<Unit> = Result.success(Unit)
+                }
+
+            val result = mockFlow.start("test-id-token", "com.example.app:/logout")
+
+            assertTrue(result.isSuccess)
+            val context = result.getOrNull()
+            assertNotNull(context)
+            assertEquals("com.example.app:/logout", context.redirectUrl)
+            assertTrue(context.url.contains("test-id-token"))
+        }
+
+    @Test
+    fun resume_WhenSuccess_ReturnsUnit() =
+        runTest {
+            val mockFlow =
+                object : RedirectEndSessionFlow {
+                    override suspend fun start(
+                        idToken: String,
+                        redirectUrl: String,
+                        extraRequestParameters: Map<String, String>,
+                    ): Result<RedirectEndSessionFlowContext> =
+                        Result.success(
+                            RedirectEndSessionFlowContext(
+                                url = "https://example.okta.com/logout",
+                                redirectUrl = "com.example.app:/logout",
+                                state = "test-state"
+                            )
+                        )
+
+                    override fun resume(
+                        uri: String,
+                        flowContext: RedirectEndSessionFlowContext,
+                    ): Result<Unit> = Result.success(Unit)
+                }
+
+            val context = mockFlow.start("id-token", "com.example.app:/logout").getOrThrow()
+            val result = mockFlow.resume("com.example.app:/logout?state=test-state", context)
+
+            assertTrue(result.isSuccess)
+        }
+
+    @Test
+    fun resume_WhenEndpointUnavailable_ReturnsFailure() =
+        runTest {
+            val mockFlow =
+                object : RedirectEndSessionFlow {
+                    override suspend fun start(
+                        idToken: String,
+                        redirectUrl: String,
+                        extraRequestParameters: Map<String, String>,
+                    ): Result<RedirectEndSessionFlowContext> = Result.failure(IllegalStateException("OIDC Endpoints not available."))
+
+                    override fun resume(
+                        uri: String,
+                        flowContext: RedirectEndSessionFlowContext,
+                    ): Result<Unit> = Result.success(Unit)
+                }
+
+            val result = mockFlow.start("id-token", "com.example.app:/logout")
+
+            assertTrue(result.isFailure)
+            assertTrue(result.exceptionOrNull()?.message?.contains("OIDC Endpoints not available.") == true)
+        }
+
+    @Test
+    fun resume_WhenStateMismatch_ReturnsFailure() =
+        runTest {
+            val mockFlow =
+                object : RedirectEndSessionFlow {
+                    override suspend fun start(
+                        idToken: String,
+                        redirectUrl: String,
+                        extraRequestParameters: Map<String, String>,
+                    ): Result<RedirectEndSessionFlowContext> =
+                        Result.success(
+                            RedirectEndSessionFlowContext(
+                                url = "https://example.okta.com/logout",
+                                redirectUrl = "com.example.app:/logout",
+                                state = "expected-state"
+                            )
+                        )
+
+                    override fun resume(
+                        uri: String,
+                        flowContext: RedirectEndSessionFlowContext,
+                    ): Result<Unit> =
+                        if (uri.contains("wrong-state")) {
+                            Result.failure(RedirectEndSessionFlow.ResumeException("Failed due to state mismatch."))
+                        } else {
+                            Result.success(Unit)
+                        }
+                }
+
+            val context = mockFlow.start("id-token", "com.example.app:/logout").getOrThrow()
+            val result = mockFlow.resume("com.example.app:/logout?state=wrong-state", context)
+
+            assertTrue(result.isFailure)
+            assertTrue(result.exceptionOrNull()?.message?.contains("state mismatch") == true)
+        }
+
+    @Test
+    fun resume_WhenErrorReturned_ReturnsFailure() =
+        runTest {
+            val mockFlow =
+                object : RedirectEndSessionFlow {
+                    override suspend fun start(
+                        idToken: String,
+                        redirectUrl: String,
+                        extraRequestParameters: Map<String, String>,
+                    ): Result<RedirectEndSessionFlowContext> =
+                        Result.success(
+                            RedirectEndSessionFlowContext(
+                                url = "https://example.okta.com/logout",
+                                redirectUrl = "com.example.app:/logout",
+                                state = "test-state"
+                            )
+                        )
+
+                    override fun resume(
+                        uri: String,
+                        flowContext: RedirectEndSessionFlowContext,
+                    ): Result<Unit> = Result.failure(RedirectEndSessionFlow.ResumeException("access_denied"))
+                }
+
+            val context = mockFlow.start("id-token", "com.example.app:/logout").getOrThrow()
+            val result = mockFlow.resume("com.example.app:/logout?error=access_denied", context)
+
+            assertTrue(result.isFailure)
+            assertNotNull(result.exceptionOrNull())
+        }
+
+    @Test
+    fun start_WithExtraParameters_IncludesThemInContext() =
+        runTest {
+            var capturedExtraParams: Map<String, String>? = null
+            val mockFlow =
+                object : RedirectEndSessionFlow {
+                    override suspend fun start(
+                        idToken: String,
+                        redirectUrl: String,
+                        extraRequestParameters: Map<String, String>,
+                    ): Result<RedirectEndSessionFlowContext> {
+                        capturedExtraParams = extraRequestParameters
+                        return Result.success(
+                            RedirectEndSessionFlowContext(
+                                url = "https://example.okta.com/logout",
+                                redirectUrl = redirectUrl,
+                                state = "test-state"
+                            )
+                        )
+                    }
+
+                    override fun resume(
+                        uri: String,
+                        flowContext: RedirectEndSessionFlowContext,
+                    ): Result<Unit> = Result.success(Unit)
+                }
+
+            mockFlow.start(
+                idToken = "test-id-token",
+                redirectUrl = "com.example.app:/logout",
+                extraRequestParameters = mapOf("ui_locales" to "en")
+            )
+
+            assertNotNull(capturedExtraParams)
+            assertEquals("en", capturedExtraParams["ui_locales"])
+        }
+}

--- a/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/jvm/RedirectEndSessionFlow.kt
+++ b/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/jvm/RedirectEndSessionFlow.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp.jvm
+
+import com.okta.oauth2.kmp.BrowserRedirectHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.future.future
+import java.io.Closeable
+import java.util.concurrent.CompletableFuture
+import com.okta.oauth2.kmp.RedirectEndSessionFlow as KotlinRedirectEndSessionFlow
+
+/**
+ * A Java-friendly wrapper around the Kotlin [KotlinRedirectEndSessionFlow].
+ *
+ * This class combines the [start][KotlinRedirectEndSessionFlow.start] and
+ * [resume][KotlinRedirectEndSessionFlow.resume] steps into a single
+ * [start] method that uses a [BrowserRedirectHandler] to open the browser and capture
+ * the redirect callback. Java consumers can use [CompletableFuture] without dealing
+ * with Kotlin coroutines.
+ *
+ * Must be [closed][close] when no longer needed to release coroutine resources.
+ *
+ * @param delegate the underlying Kotlin [KotlinRedirectEndSessionFlow] instance.
+ */
+class RedirectEndSessionFlow(
+    private val delegate: KotlinRedirectEndSessionFlow,
+) : Closeable {
+    private val coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    /**
+     * Performs the full redirect end-session flow asynchronously.
+     *
+     * Builds the logout URL, opens it via [browserRedirectHandler], and validates the redirect.
+     *
+     * @param idToken the ID token hint identifying the session to log out.
+     * @param redirectUrl the post-logout redirect URI registered with the authorization server.
+     * @param browserRedirectHandler handles opening the browser and capturing the redirect URI.
+     * @param extraRequestParameters additional key-value pairs appended to the end-session URL.
+     * @return a [CompletableFuture] that completes with [Unit] on success,
+     *   or completes exceptionally on failure.
+     */
+    @JvmOverloads
+    fun start(
+        idToken: String,
+        redirectUrl: String,
+        browserRedirectHandler: BrowserRedirectHandler,
+        extraRequestParameters: Map<String, String> = emptyMap(),
+    ): CompletableFuture<Unit> =
+        coroutineScope.future {
+            val flowContext =
+                delegate
+                    .start(
+                        idToken = idToken,
+                        redirectUrl = redirectUrl,
+                        extraRequestParameters = extraRequestParameters
+                    ).getOrThrow()
+            val redirectUri = browserRedirectHandler.handleRedirect(flowContext.url)
+            delegate.resume(redirectUri, flowContext).getOrThrow()
+        }
+
+    override fun close() {
+        coroutineScope.cancel()
+    }
+}

--- a/oauth2/src/jvmTest/java/com/okta/oauth2/kmp/jvm/RedirectEndSessionFlowTest.java
+++ b/oauth2/src/jvmTest/java/com/okta/oauth2/kmp/jvm/RedirectEndSessionFlowTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp.jvm;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.okta.oauth2.kmp.BrowserRedirectHandler;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import kotlin.Unit;
+import org.junit.Test;
+
+/**
+ * Java-language tests for {@link RedirectEndSessionFlow} CompletableFuture wrapper. Validates that
+ * the API is ergonomic from actual Java code.
+ */
+public class RedirectEndSessionFlowTest {
+
+  @Test
+  public void start_ReturnsCompletableFutureOnSuccess()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    BrowserRedirectHandler handler =
+        TestFlowFactory.createFakeBrowserRedirectHandler(
+            "com.example.app:/logout?state=test-state");
+    RedirectEndSessionFlow flow =
+        TestFlowFactory.createSuccessRedirectEndSessionFlow("com.example.app:/logout");
+    try {
+      CompletableFuture<Unit> future =
+          flow.start("example-id-token", "com.example.app:/logout", handler);
+      assertNotNull("Future should not be null", future);
+      future.get(5, TimeUnit.SECONDS);
+    } finally {
+      flow.close();
+    }
+  }
+
+  @Test
+  public void start_WithAllParams_ReturnsUnit()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    BrowserRedirectHandler handler =
+        TestFlowFactory.createFakeBrowserRedirectHandler(
+            "com.example.app:/logout?state=test-state");
+    RedirectEndSessionFlow flow =
+        TestFlowFactory.createSuccessRedirectEndSessionFlow("com.example.app:/logout");
+    try {
+      CompletableFuture<Unit> future =
+          flow.start(
+              "example-id-token", "com.example.app:/logout", handler, Collections.emptyMap());
+      future.get(5, TimeUnit.SECONDS);
+    } finally {
+      flow.close();
+    }
+  }
+
+  @Test
+  public void start_WithError_CompletesExceptionally()
+      throws TimeoutException, InterruptedException {
+    BrowserRedirectHandler handler =
+        TestFlowFactory.createFakeBrowserRedirectHandler("com.example.app:/logout");
+    RedirectEndSessionFlow flow = TestFlowFactory.createFailingRedirectEndSessionFlow();
+    try {
+      CompletableFuture<Unit> future =
+          flow.start("example-id-token", "com.example.app:/logout", handler);
+      try {
+        future.get(5, TimeUnit.SECONDS);
+        fail("Should have thrown ExecutionException");
+      } catch (ExecutionException e) {
+        assertNotNull("Cause should not be null", e.getCause());
+        assertTrue(
+            "Should contain error message",
+            e.getCause().getMessage().contains("OIDC Endpoints not available."));
+      }
+    } finally {
+      flow.close();
+    }
+  }
+
+  @Test
+  public void close_IsIdempotent() {
+    RedirectEndSessionFlow flow =
+        TestFlowFactory.createSuccessRedirectEndSessionFlow("com.example.app:/logout");
+    flow.close();
+    flow.close(); // Should not throw
+  }
+}


### PR DESCRIPTION
Implements the redirect-based end-session flow (OpenID Connect RP-Initiated Logout) for KMP targets (Android + JVM). Builds the end-session URL with id_token_hint and random state, validates the redirect URI on resume, and surfaces a ResumeException on state mismatch or error. Java wrapper combines start/resume via BrowserRedirectHandler.

RESOLVES: OKTA-1162037