### PR TITLE
Add KMP oauth2 polish: Android compat extensions, API dump, and build fixes

### DIFF
--- a/oauth2/api/jvm/oauth2.api
+++ b/oauth2/api/jvm/oauth2.api
@@ -1,3 +1,44 @@
+public abstract interface class com/okta/oauth2/kmp/AuthorizationCodeFlow {
+	public static final field Companion Lcom/okta/oauth2/kmp/AuthorizationCodeFlow$Companion;
+	public abstract fun resume-0E7RQCE (Ljava/lang/String;Lcom/okta/oauth2/kmp/AuthorizationCodeFlowContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun start-BWLJW6A (Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun start-BWLJW6A$default (Lcom/okta/oauth2/kmp/AuthorizationCodeFlow;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/okta/oauth2/kmp/AuthorizationCodeFlow$Companion {
+	public final fun invoke (Lcom/okta/authfoundation/client/kmp/OAuth2Client;)Lcom/okta/oauth2/kmp/AuthorizationCodeFlow;
+}
+
+public final class com/okta/oauth2/kmp/AuthorizationCodeFlow$DefaultImpls {
+	public static synthetic fun start-BWLJW6A$default (Lcom/okta/oauth2/kmp/AuthorizationCodeFlow;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/okta/oauth2/kmp/AuthorizationCodeFlow$MissingResultCodeException : java/lang/Exception {
+	public fun <init> ()V
+}
+
+public final class com/okta/oauth2/kmp/AuthorizationCodeFlow$RedirectSchemeMismatchException : java/lang/Exception {
+	public fun <init> ()V
+}
+
+public final class com/okta/oauth2/kmp/AuthorizationCodeFlow$ResumeException : java/lang/Exception {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun getErrorId ()Ljava/lang/String;
+}
+
+public final class com/okta/oauth2/kmp/AuthorizationCodeFlowContext {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;)Lcom/okta/oauth2/kmp/AuthorizationCodeFlowContext;
+	public static synthetic fun copy$default (Lcom/okta/oauth2/kmp/AuthorizationCodeFlowContext;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)Lcom/okta/oauth2/kmp/AuthorizationCodeFlowContext;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRedirectUrl ()Ljava/lang/String;
+	public final fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract interface class com/okta/oauth2/kmp/BrowserRedirectHandler {
 	public abstract fun handleRedirect (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
@@ -48,11 +89,86 @@ public final class com/okta/oauth2/kmp/LocalhostBrowserRedirectHandler : com/okt
 public final class com/okta/oauth2/kmp/LocalhostBrowserRedirectHandler$Companion {
 }
 
+public abstract interface class com/okta/oauth2/kmp/RedirectEndSessionFlow {
+	public static final field Companion Lcom/okta/oauth2/kmp/RedirectEndSessionFlow$Companion;
+	public abstract fun resume-gIAlu-s (Ljava/lang/String;Lcom/okta/oauth2/kmp/RedirectEndSessionFlowContext;)Ljava/lang/Object;
+	public abstract fun start-BWLJW6A (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun start-BWLJW6A$default (Lcom/okta/oauth2/kmp/RedirectEndSessionFlow;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/okta/oauth2/kmp/RedirectEndSessionFlow$Companion {
+	public final fun invoke (Lcom/okta/authfoundation/client/kmp/OAuth2Client;)Lcom/okta/oauth2/kmp/RedirectEndSessionFlow;
+}
+
+public final class com/okta/oauth2/kmp/RedirectEndSessionFlow$DefaultImpls {
+	public static synthetic fun start-BWLJW6A$default (Lcom/okta/oauth2/kmp/RedirectEndSessionFlow;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/okta/oauth2/kmp/RedirectEndSessionFlow$ResumeException : java/lang/Exception {
+}
+
+public final class com/okta/oauth2/kmp/RedirectEndSessionFlowContext {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/okta/oauth2/kmp/RedirectEndSessionFlowContext;
+	public static synthetic fun copy$default (Lcom/okta/oauth2/kmp/RedirectEndSessionFlowContext;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/okta/oauth2/kmp/RedirectEndSessionFlowContext;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRedirectUrl ()Ljava/lang/String;
+	public final fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract interface class com/okta/oauth2/kmp/ResourceOwnerFlow {
+	public static final field Companion Lcom/okta/oauth2/kmp/ResourceOwnerFlow$Companion;
 	public abstract fun start-BWLJW6A (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public final class com/okta/oauth2/kmp/ResourceOwnerFlow$Companion {
+	public final fun invoke (Lcom/okta/authfoundation/client/kmp/OAuth2Client;)Lcom/okta/oauth2/kmp/ResourceOwnerFlow;
+}
+
+public abstract interface class com/okta/oauth2/kmp/SessionTokenFlow {
+	public static final field Companion Lcom/okta/oauth2/kmp/SessionTokenFlow$Companion;
+	public abstract fun start-yxL6bBk (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun start-yxL6bBk$default (Lcom/okta/oauth2/kmp/SessionTokenFlow;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/okta/oauth2/kmp/SessionTokenFlow$Companion {
+	public final fun invoke (Lcom/okta/authfoundation/client/kmp/OAuth2Client;)Lcom/okta/oauth2/kmp/SessionTokenFlow;
+}
+
+public final class com/okta/oauth2/kmp/SessionTokenFlow$DefaultImpls {
+	public static synthetic fun start-yxL6bBk$default (Lcom/okta/oauth2/kmp/SessionTokenFlow;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class com/okta/oauth2/kmp/TokenExchangeFlow {
+	public static final field Companion Lcom/okta/oauth2/kmp/TokenExchangeFlow$Companion;
+	public abstract fun start-yxL6bBk (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun start-yxL6bBk$default (Lcom/okta/oauth2/kmp/TokenExchangeFlow;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/okta/oauth2/kmp/TokenExchangeFlow$Companion {
+	public final fun invoke (Lcom/okta/authfoundation/client/kmp/OAuth2Client;)Lcom/okta/oauth2/kmp/TokenExchangeFlow;
+}
+
+public final class com/okta/oauth2/kmp/TokenExchangeFlow$DefaultImpls {
+	public static synthetic fun start-yxL6bBk$default (Lcom/okta/oauth2/kmp/TokenExchangeFlow;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/okta/oauth2/kmp/jvm/AuthorizationCodeFlow : java/io/Closeable {
+	public fun <init> (Lcom/okta/authfoundation/client/kmp/OAuth2Client;)V
+	public fun <init> (Lcom/okta/oauth2/kmp/AuthorizationCodeFlow;)V
+	public fun close ()V
+	public final fun start (Ljava/lang/String;Lcom/okta/oauth2/kmp/BrowserRedirectHandler;)Ljava/util/concurrent/CompletableFuture;
+	public final fun start (Ljava/lang/String;Lcom/okta/oauth2/kmp/BrowserRedirectHandler;Ljava/util/Map;)Ljava/util/concurrent/CompletableFuture;
+	public final fun start (Ljava/lang/String;Lcom/okta/oauth2/kmp/BrowserRedirectHandler;Ljava/util/Map;Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
+	public static synthetic fun start$default (Lcom/okta/oauth2/kmp/jvm/AuthorizationCodeFlow;Ljava/lang/String;Lcom/okta/oauth2/kmp/BrowserRedirectHandler;Ljava/util/Map;Ljava/lang/String;ILjava/lang/Object;)Ljava/util/concurrent/CompletableFuture;
+}
+
 public final class com/okta/oauth2/kmp/jvm/DeviceAuthorizationFlow : java/io/Closeable {
+	public fun <init> (Lcom/okta/authfoundation/client/kmp/OAuth2Client;)V
 	public fun <init> (Lcom/okta/oauth2/kmp/DeviceAuthorizationFlow;)V
 	public fun close ()V
 	public final fun resume (Lcom/okta/oauth2/kmp/DeviceAuthorizationFlowContext;)Ljava/util/concurrent/CompletableFuture;
@@ -60,9 +176,39 @@ public final class com/okta/oauth2/kmp/jvm/DeviceAuthorizationFlow : java/io/Clo
 	public static synthetic fun start$default (Lcom/okta/oauth2/kmp/jvm/DeviceAuthorizationFlow;Ljava/lang/String;ILjava/lang/Object;)Ljava/util/concurrent/CompletableFuture;
 }
 
+public final class com/okta/oauth2/kmp/jvm/RedirectEndSessionFlow : java/io/Closeable {
+	public fun <init> (Lcom/okta/authfoundation/client/kmp/OAuth2Client;)V
+	public fun <init> (Lcom/okta/oauth2/kmp/RedirectEndSessionFlow;)V
+	public fun close ()V
+	public final fun start (Ljava/lang/String;Ljava/lang/String;Lcom/okta/oauth2/kmp/BrowserRedirectHandler;)Ljava/util/concurrent/CompletableFuture;
+	public final fun start (Ljava/lang/String;Ljava/lang/String;Lcom/okta/oauth2/kmp/BrowserRedirectHandler;Ljava/util/Map;)Ljava/util/concurrent/CompletableFuture;
+	public static synthetic fun start$default (Lcom/okta/oauth2/kmp/jvm/RedirectEndSessionFlow;Ljava/lang/String;Ljava/lang/String;Lcom/okta/oauth2/kmp/BrowserRedirectHandler;Ljava/util/Map;ILjava/lang/Object;)Ljava/util/concurrent/CompletableFuture;
+}
+
 public final class com/okta/oauth2/kmp/jvm/ResourceOwnerFlow : java/io/Closeable {
+	public fun <init> (Lcom/okta/authfoundation/client/kmp/OAuth2Client;)V
 	public fun <init> (Lcom/okta/oauth2/kmp/ResourceOwnerFlow;)V
 	public fun close ()V
 	public final fun start (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
+}
+
+public final class com/okta/oauth2/kmp/jvm/SessionTokenFlow : java/io/Closeable {
+	public fun <init> (Lcom/okta/authfoundation/client/kmp/OAuth2Client;)V
+	public fun <init> (Lcom/okta/oauth2/kmp/SessionTokenFlow;)V
+	public fun close ()V
+	public final fun start (Ljava/lang/String;Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
+	public final fun start (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Ljava/util/concurrent/CompletableFuture;
+	public final fun start (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
+	public static synthetic fun start$default (Lcom/okta/oauth2/kmp/jvm/SessionTokenFlow;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;ILjava/lang/Object;)Ljava/util/concurrent/CompletableFuture;
+}
+
+public final class com/okta/oauth2/kmp/jvm/TokenExchangeFlow : java/io/Closeable {
+	public fun <init> (Lcom/okta/authfoundation/client/kmp/OAuth2Client;)V
+	public fun <init> (Lcom/okta/oauth2/kmp/TokenExchangeFlow;)V
+	public fun close ()V
+	public final fun start (Ljava/lang/String;Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
+	public final fun start (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
+	public final fun start (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
+	public static synthetic fun start$default (Lcom/okta/oauth2/kmp/jvm/TokenExchangeFlow;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ljava/util/concurrent/CompletableFuture;
 }
 

--- a/oauth2/build.gradle.kts
+++ b/oauth2/build.gradle.kts
@@ -127,6 +127,7 @@ kotlin {
         }
 
         getByName("androidHostTest") {
+            resources.srcDir("src/test/resources")
             dependencies {
                 implementation(libs.coroutines.test)
                 implementation(libs.junit)

--- a/oauth2/src/androidMain/kotlin/com/okta/oauth2/kmp/AndroidCompatExtensions.kt
+++ b/oauth2/src/androidMain/kotlin/com/okta/oauth2/kmp/AndroidCompatExtensions.kt
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp
+
+import com.okta.authfoundation.InternalAuthFoundationApi
+import com.okta.authfoundation.client.OAuth2Client
+import com.okta.authfoundation.client.OAuth2ClientBuilder
+import com.okta.authfoundation.client.kmp.OAuth2Client as KmpOAuth2Client
+
+/**
+ * Creates a KMP [DeviceAuthorizationFlow] backed by a new KMP OAuth2Client
+ * configured from this Android [OAuth2Client]'s settings.
+ *
+ * @param client the Android [OAuth2Client] whose configuration is used.
+ * @return a [DeviceAuthorizationFlow] using the KMP HTTP stack.
+ */
+@OptIn(InternalAuthFoundationApi::class)
+fun DeviceAuthorizationFlow(client: OAuth2Client): DeviceAuthorizationFlow {
+    val issuerUrl = client.configuration.discoveryUrl.removeSuffix("/.well-known/openid-configuration")
+    val kmpClient: KmpOAuth2Client =
+        OAuth2ClientBuilder
+            .create(
+                issuerUrl = issuerUrl,
+                clientId = client.configuration.clientId,
+                scope = client.configuration.defaultScope.split(" ")
+            ).getOrThrow()
+    return DeviceAuthorizationFlow(kmpClient)
+}
+
+/**
+ * Creates a KMP [ResourceOwnerFlow] backed by a new KMP OAuth2Client
+ * configured from this Android [OAuth2Client]'s settings.
+ *
+ * @param client the Android [OAuth2Client] whose configuration is used.
+ * @return a [ResourceOwnerFlow] using the KMP HTTP stack.
+ */
+@OptIn(InternalAuthFoundationApi::class)
+fun ResourceOwnerFlow(client: OAuth2Client): ResourceOwnerFlow {
+    val issuerUrl = client.configuration.discoveryUrl.removeSuffix("/.well-known/openid-configuration")
+    val kmpClient: KmpOAuth2Client =
+        OAuth2ClientBuilder
+            .create(
+                issuerUrl = issuerUrl,
+                clientId = client.configuration.clientId,
+                scope = client.configuration.defaultScope.split(" ")
+            ).getOrThrow()
+    return ResourceOwnerFlow(kmpClient)
+}
+
+/**
+ * Creates a KMP [TokenExchangeFlow] backed by a new KMP OAuth2Client
+ * configured from this Android [OAuth2Client]'s settings.
+ *
+ * @param client the Android [OAuth2Client] whose configuration is used.
+ * @return a [TokenExchangeFlow] using the KMP HTTP stack.
+ */
+@OptIn(InternalAuthFoundationApi::class)
+fun TokenExchangeFlow(client: OAuth2Client): TokenExchangeFlow {
+    val issuerUrl = client.configuration.discoveryUrl.removeSuffix("/.well-known/openid-configuration")
+    val kmpClient: KmpOAuth2Client =
+        OAuth2ClientBuilder
+            .create(
+                issuerUrl = issuerUrl,
+                clientId = client.configuration.clientId,
+                scope = client.configuration.defaultScope.split(" ")
+            ).getOrThrow()
+    return TokenExchangeFlow(kmpClient)
+}
+
+/**
+ * Creates a KMP [SessionTokenFlow] backed by a new KMP OAuth2Client
+ * configured from this Android [OAuth2Client]'s settings.
+ *
+ * @param client the Android [OAuth2Client] whose configuration is used.
+ * @return a [SessionTokenFlow] using the KMP HTTP stack.
+ */
+@OptIn(InternalAuthFoundationApi::class)
+fun SessionTokenFlow(client: OAuth2Client): SessionTokenFlow {
+    val issuerUrl = client.configuration.discoveryUrl.removeSuffix("/.well-known/openid-configuration")
+    val kmpClient: KmpOAuth2Client =
+        OAuth2ClientBuilder
+            .create(
+                issuerUrl = issuerUrl,
+                clientId = client.configuration.clientId,
+                scope = client.configuration.defaultScope.split(" ")
+            ).getOrThrow()
+    return SessionTokenFlow(kmpClient)
+}
+
+/**
+ * Creates a KMP [AuthorizationCodeFlow] backed by a new KMP OAuth2Client
+ * configured from this Android [OAuth2Client]'s settings.
+ *
+ * @param client the Android [OAuth2Client] whose configuration is used.
+ * @return a [AuthorizationCodeFlow] using the KMP HTTP stack.
+ */
+@OptIn(InternalAuthFoundationApi::class)
+fun AuthorizationCodeFlow(client: OAuth2Client): AuthorizationCodeFlow {
+    val issuerUrl = client.configuration.discoveryUrl.removeSuffix("/.well-known/openid-configuration")
+    val kmpClient: KmpOAuth2Client =
+        OAuth2ClientBuilder
+            .create(
+                issuerUrl = issuerUrl,
+                clientId = client.configuration.clientId,
+                scope = client.configuration.defaultScope.split(" ")
+            ).getOrThrow()
+    return AuthorizationCodeFlow(kmpClient)
+}
+
+/**
+ * Creates a KMP [RedirectEndSessionFlow] backed by a new KMP OAuth2Client
+ * configured from this Android [OAuth2Client]'s settings.
+ *
+ * @param client the Android [OAuth2Client] whose configuration is used.
+ * @return a [RedirectEndSessionFlow] using the KMP HTTP stack.
+ */
+@OptIn(InternalAuthFoundationApi::class)
+fun RedirectEndSessionFlow(client: OAuth2Client): RedirectEndSessionFlow {
+    val issuerUrl = client.configuration.discoveryUrl.removeSuffix("/.well-known/openid-configuration")
+    val kmpClient: KmpOAuth2Client =
+        OAuth2ClientBuilder
+            .create(
+                issuerUrl = issuerUrl,
+                clientId = client.configuration.clientId,
+                scope = client.configuration.defaultScope.split(" ")
+            ).getOrThrow()
+    return RedirectEndSessionFlow(kmpClient)
+}
+
+/**
+ * Resumes the Authorization Code flow using an Android [android.net.Uri].
+ *
+ * @param uri the redirect [android.net.Uri] received from the browser.
+ * @param flowContext the [AuthorizationCodeFlowContext] returned by [AuthorizationCodeFlow.start].
+ * @return a [Result] containing [com.okta.authfoundation.client.TokenInfo] on success.
+ */
+suspend fun AuthorizationCodeFlow.resume(
+    uri: android.net.Uri,
+    flowContext: AuthorizationCodeFlowContext,
+): Result<com.okta.authfoundation.client.TokenInfo> = resume(uri.toString(), flowContext)
+
+/**
+ * Resumes the Redirect End Session flow using an Android [android.net.Uri].
+ *
+ * @param uri the post-logout redirect [android.net.Uri] received from the browser.
+ * @param flowContext the [RedirectEndSessionFlowContext] returned by [RedirectEndSessionFlow.start].
+ * @return a [Result] containing [Unit] on success.
+ */
+fun RedirectEndSessionFlow.resume(
+    uri: android.net.Uri,
+    flowContext: RedirectEndSessionFlowContext,
+): Result<Unit> = resume(uri.toString(), flowContext)

--- a/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/ResourceOwnerFlow.kt
+++ b/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/ResourceOwnerFlow.kt
@@ -15,7 +15,9 @@
  */
 package com.okta.oauth2.kmp
 
+import com.okta.authfoundation.InternalAuthFoundationApi
 import com.okta.authfoundation.client.TokenInfo
+import com.okta.authfoundation.client.kmp.OAuth2Client
 
 /**
  * An authentication flow that implements the Resource Owner Password Grant.
@@ -50,4 +52,15 @@ interface ResourceOwnerFlow {
         password: String,
         scope: String,
     ): Result<TokenInfo>
+
+    companion object {
+        /**
+         * Creates a [ResourceOwnerFlow] backed by the given [client].
+         *
+         * @param client the [OAuth2Client] used to perform the flow.
+         * @return a [ResourceOwnerFlow] instance.
+         */
+        @OptIn(InternalAuthFoundationApi::class)
+        operator fun invoke(client: OAuth2Client): ResourceOwnerFlow = ResourceOwnerFlowImpl(client)
+    }
 }

--- a/oauth2/src/commonTest/kotlin/com/okta/oauth2/kmp/AuthorizationCodeFlowTest.kt
+++ b/oauth2/src/commonTest/kotlin/com/okta/oauth2/kmp/AuthorizationCodeFlowTest.kt
@@ -48,7 +48,7 @@ class AuthorizationCodeFlowTest {
                     override suspend fun resume(
                         uri: String,
                         flowContext: AuthorizationCodeFlowContext,
-                    ): Result<TokenInfo> = Result.success(FakeAuthCodeTokenInfo())
+                    ): Result<TokenInfo> = Result.success(FakeTokenInfo())
                 }
 
             val result = mockFlow.start("com.example.app:/callback")
@@ -63,7 +63,7 @@ class AuthorizationCodeFlowTest {
     @Test
     fun resume_WhenSuccess_ReturnsTokenInfo() =
         runTest {
-            val fakeToken = FakeAuthCodeTokenInfo()
+            val fakeToken = FakeTokenInfo()
             val mockFlow =
                 object : AuthorizationCodeFlow {
                     override suspend fun start(
@@ -241,18 +241,4 @@ class AuthorizationCodeFlowTest {
             assertTrue(result.isFailure)
             assertTrue(result.exceptionOrNull()?.message?.contains("OIDC Endpoints not available.") == true)
         }
-}
-
-private class FakeAuthCodeTokenInfo : TokenInfo {
-    override val id: String = "test-id"
-    override val clientId: String = "test-client"
-    override val issuerUrl: String = "https://example.okta.com"
-    override val tokenType: String = "Bearer"
-    override val expiresIn: Int = 3600
-    override val accessToken: String = "test-access-token"
-    override val scope: String? = "openid profile"
-    override val refreshToken: String? = "test-refresh-token"
-    override val idToken: String? = null
-    override val deviceSecret: String? = null
-    override val issuedTokenType: String? = null
 }

--- a/oauth2/src/commonTest/kotlin/com/okta/oauth2/kmp/DeviceAuthorizationFlowTest.kt
+++ b/oauth2/src/commonTest/kotlin/com/okta/oauth2/kmp/DeviceAuthorizationFlowTest.kt
@@ -56,7 +56,7 @@ class DeviceAuthorizationFlowTest {
     @Test
     fun resume_WhenSuccess_ReturnsTokenInfo() =
         runTest {
-            val fakeToken = FakeDeviceTokenInfo()
+            val fakeToken = FakeTokenInfo()
             val mockFlow =
                 object : DeviceAuthorizationFlow {
                     override suspend fun start(scope: String): Result<DeviceAuthorizationFlowContext> = Result.failure(NotImplementedError())
@@ -118,18 +118,4 @@ class DeviceAuthorizationFlowTest {
 
             assertTrue(result.isFailure)
         }
-}
-
-private class FakeDeviceTokenInfo : TokenInfo {
-    override val id: String = "test-id"
-    override val clientId: String = "test-client"
-    override val issuerUrl: String = "https://example.okta.com"
-    override val tokenType: String = "Bearer"
-    override val expiresIn: Int = 3600
-    override val accessToken: String = "test-access-token"
-    override val scope: String = "openid profile"
-    override val refreshToken: String? = "test-refresh-token"
-    override val idToken: String? = null
-    override val deviceSecret: String? = null
-    override val issuedTokenType: String? = null
 }

--- a/oauth2/src/commonTest/kotlin/com/okta/oauth2/kmp/FakeTokenInfo.kt
+++ b/oauth2/src/commonTest/kotlin/com/okta/oauth2/kmp/FakeTokenInfo.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp
+
+import com.okta.authfoundation.client.TokenInfo
+
+internal class FakeTokenInfo : TokenInfo {
+    override val id: String = "test-id"
+    override val clientId: String = "test-client"
+    override val issuerUrl: String = "https://example.okta.com"
+    override val tokenType: String = "Bearer"
+    override val expiresIn: Int = 3600
+    override val accessToken: String = "test-access-token"
+    override val scope: String? = "openid profile"
+    override val refreshToken: String? = "test-refresh-token"
+    override val idToken: String? = null
+    override val deviceSecret: String? = null
+    override val issuedTokenType: String? = null
+}

--- a/oauth2/src/commonTest/kotlin/com/okta/oauth2/kmp/ResourceOwnerFlowTest.kt
+++ b/oauth2/src/commonTest/kotlin/com/okta/oauth2/kmp/ResourceOwnerFlowTest.kt
@@ -86,17 +86,3 @@ class ResourceOwnerFlowTest {
             assertTrue(result.exceptionOrNull() is java.io.IOException)
         }
 }
-
-private class FakeTokenInfo : TokenInfo {
-    override val id: String = "test-id"
-    override val clientId: String = "test-client"
-    override val issuerUrl: String = "https://example.okta.com"
-    override val tokenType: String = "Bearer"
-    override val expiresIn: Int = 3600
-    override val accessToken: String = "test-access-token"
-    override val scope: String = "openid profile"
-    override val refreshToken: String? = "test-refresh-token"
-    override val idToken: String? = null
-    override val deviceSecret: String? = null
-    override val issuedTokenType: String? = null
-}

--- a/oauth2/src/commonTest/kotlin/com/okta/oauth2/kmp/SessionTokenFlowTest.kt
+++ b/oauth2/src/commonTest/kotlin/com/okta/oauth2/kmp/SessionTokenFlowTest.kt
@@ -26,7 +26,7 @@ class SessionTokenFlowTest {
     @Test
     fun start_WhenSuccess_ReturnsTokenInfo() =
         runTest {
-            val fakeToken = FakeSessionTokenInfo()
+            val fakeToken = FakeTokenInfo()
             val mockFlow =
                 object : SessionTokenFlow {
                     override suspend fun start(
@@ -97,7 +97,7 @@ class SessionTokenFlowTest {
                         scope: String,
                     ): Result<TokenInfo> {
                         capturedExtraParams = extraRequestParameters
-                        return Result.success(FakeSessionTokenInfo())
+                        return Result.success(FakeTokenInfo())
                     }
                 }
 
@@ -111,18 +111,4 @@ class SessionTokenFlowTest {
             assertNotNull(capturedExtraParams)
             assertEquals("bar", capturedExtraParams["extraOne"])
         }
-}
-
-private class FakeSessionTokenInfo : TokenInfo {
-    override val id: String = "test-id"
-    override val clientId: String = "test-client"
-    override val issuerUrl: String = "https://example.okta.com"
-    override val tokenType: String = "Bearer"
-    override val expiresIn: Int = 3600
-    override val accessToken: String = "test-access-token"
-    override val scope: String? = "openid profile"
-    override val refreshToken: String? = "test-refresh-token"
-    override val idToken: String? = null
-    override val deviceSecret: String? = null
-    override val issuedTokenType: String? = null
 }

--- a/oauth2/src/commonTest/kotlin/com/okta/oauth2/kmp/TokenExchangeFlowTest.kt
+++ b/oauth2/src/commonTest/kotlin/com/okta/oauth2/kmp/TokenExchangeFlowTest.kt
@@ -26,7 +26,7 @@ class TokenExchangeFlowTest {
     @Test
     fun start_WhenSuccess_ReturnsTokenInfo() =
         runTest {
-            val fakeToken = FakeTokenExchangeTokenInfo()
+            val fakeToken = FakeTokenInfo()
             val mockFlow =
                 object : TokenExchangeFlow {
                     override suspend fun start(
@@ -96,7 +96,7 @@ class TokenExchangeFlowTest {
                         scope: String,
                     ): Result<TokenInfo> {
                         capturedAudience = audience
-                        return Result.success(FakeTokenExchangeTokenInfo())
+                        return Result.success(FakeTokenInfo())
                     }
                 }
 
@@ -104,18 +104,4 @@ class TokenExchangeFlowTest {
 
             assertEquals("api://custom", capturedAudience)
         }
-}
-
-private class FakeTokenExchangeTokenInfo : TokenInfo {
-    override val id: String = "test-id"
-    override val clientId: String = "test-client"
-    override val issuerUrl: String = "https://example.okta.com"
-    override val tokenType: String = "Bearer"
-    override val expiresIn: Int = 3600
-    override val accessToken: String = "test-access-token"
-    override val scope: String? = "openid profile"
-    override val refreshToken: String? = "test-refresh-token"
-    override val idToken: String? = null
-    override val deviceSecret: String? = null
-    override val issuedTokenType: String? = null
 }

--- a/oauth2/src/commonTest/kotlin/com/okta/oauth2/kmp/jvm/FakeSuspendFlows.kt
+++ b/oauth2/src/commonTest/kotlin/com/okta/oauth2/kmp/jvm/FakeSuspendFlows.kt
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp.jvm
+
+import com.okta.authfoundation.client.TokenInfo
+import com.okta.oauth2.kmp.AuthorizationCodeFlowContext
+import com.okta.oauth2.kmp.BrowserRedirectHandler
+import com.okta.oauth2.kmp.DeviceAuthorizationFlowContext
+import com.okta.oauth2.kmp.FakeTokenInfo
+import com.okta.oauth2.kmp.RedirectEndSessionFlowContext
+import com.okta.oauth2.kmp.AuthorizationCodeFlow as KotlinAuthorizationCodeFlow
+import com.okta.oauth2.kmp.DeviceAuthorizationFlow as KotlinDeviceAuthorizationFlow
+import com.okta.oauth2.kmp.RedirectEndSessionFlow as KotlinRedirectEndSessionFlow
+import com.okta.oauth2.kmp.ResourceOwnerFlow as KotlinResourceOwnerFlow
+import com.okta.oauth2.kmp.SessionTokenFlow as KotlinSessionTokenFlow
+import com.okta.oauth2.kmp.TokenExchangeFlow as KotlinTokenExchangeFlow
+
+/**
+ * Kotlin bridge providing fake suspend-interface implementations for Java tests.
+ *
+ * Java test files cannot implement Kotlin suspend interfaces directly,
+ * so this Kotlin object provides the anonymous-object delegates that the
+ * Java [TestFlowFactory] passes to each flow's constructor.
+ */
+internal object FakeSuspendFlows {
+    @JvmStatic
+    fun successResourceOwnerDelegate(): KotlinResourceOwnerFlow =
+        object : KotlinResourceOwnerFlow {
+            override suspend fun start(
+                username: String,
+                password: String,
+                scope: String,
+            ): Result<TokenInfo> = Result.success(FakeTokenInfo())
+        }
+
+    @JvmStatic
+    fun failingResourceOwnerDelegate(): KotlinResourceOwnerFlow =
+        object : KotlinResourceOwnerFlow {
+            override suspend fun start(
+                username: String,
+                password: String,
+                scope: String,
+            ): Result<TokenInfo> = Result.failure(IllegalArgumentException("invalid_grant"))
+        }
+
+    @JvmStatic
+    fun successDeviceAuthorizationDelegate(): KotlinDeviceAuthorizationFlow =
+        object : KotlinDeviceAuthorizationFlow {
+            override suspend fun start(scope: String): Result<DeviceAuthorizationFlowContext> =
+                Result.success(
+                    DeviceAuthorizationFlowContext(
+                        verificationUri = "https://example.okta.com/activate",
+                        verificationUriComplete = "https://example.okta.com/activate?user_code=ABCD-1234",
+                        userCode = "ABCD-1234",
+                        expiresIn = 600,
+                        deviceCode = "device-code-xyz",
+                        interval = 5
+                    )
+                )
+
+            override suspend fun resume(flowContext: DeviceAuthorizationFlowContext): Result<TokenInfo> = Result.success(FakeTokenInfo())
+        }
+
+    @JvmStatic
+    fun failingDeviceAuthorizationDelegate(): KotlinDeviceAuthorizationFlow =
+        object : KotlinDeviceAuthorizationFlow {
+            override suspend fun start(scope: String): Result<DeviceAuthorizationFlowContext> = Result.failure(IllegalStateException("OIDC Endpoints not available."))
+
+            override suspend fun resume(flowContext: DeviceAuthorizationFlowContext): Result<TokenInfo> = Result.failure(IllegalStateException("access_denied"))
+        }
+
+    @JvmStatic
+    fun successTokenExchangeDelegate(): KotlinTokenExchangeFlow =
+        object : KotlinTokenExchangeFlow {
+            override suspend fun start(
+                idToken: String,
+                deviceSecret: String,
+                audience: String?,
+                scope: String,
+            ): Result<TokenInfo> = Result.success(FakeTokenInfo())
+        }
+
+    @JvmStatic
+    fun failingTokenExchangeDelegate(): KotlinTokenExchangeFlow =
+        object : KotlinTokenExchangeFlow {
+            override suspend fun start(
+                idToken: String,
+                deviceSecret: String,
+                audience: String?,
+                scope: String,
+            ): Result<TokenInfo> = Result.failure(IllegalStateException("invalid_grant"))
+        }
+
+    @JvmStatic
+    fun successSessionTokenDelegate(): KotlinSessionTokenFlow =
+        object : KotlinSessionTokenFlow {
+            override suspend fun start(
+                sessionToken: String,
+                redirectUrl: String,
+                extraRequestParameters: Map<String, String>,
+                scope: String,
+            ): Result<TokenInfo> = Result.success(FakeTokenInfo())
+        }
+
+    @JvmStatic
+    fun failingSessionTokenDelegate(): KotlinSessionTokenFlow =
+        object : KotlinSessionTokenFlow {
+            override suspend fun start(
+                sessionToken: String,
+                redirectUrl: String,
+                extraRequestParameters: Map<String, String>,
+                scope: String,
+            ): Result<TokenInfo> = Result.failure(IllegalStateException("OIDC Endpoints not available."))
+        }
+
+    @JvmStatic
+    fun successRedirectEndSessionDelegate(redirectUri: String): KotlinRedirectEndSessionFlow =
+        object : KotlinRedirectEndSessionFlow {
+            override suspend fun start(
+                idToken: String,
+                redirectUrl: String,
+                extraRequestParameters: Map<String, String>,
+            ): Result<RedirectEndSessionFlowContext> =
+                Result.success(
+                    RedirectEndSessionFlowContext(
+                        url = "https://example.okta.com/logout?id_token_hint=$idToken",
+                        redirectUrl = redirectUri,
+                        state = "test-state"
+                    )
+                )
+
+            override fun resume(
+                uri: String,
+                flowContext: RedirectEndSessionFlowContext,
+            ): Result<Unit> = Result.success(Unit)
+        }
+
+    @JvmStatic
+    fun failingRedirectEndSessionDelegate(): KotlinRedirectEndSessionFlow =
+        object : KotlinRedirectEndSessionFlow {
+            override suspend fun start(
+                idToken: String,
+                redirectUrl: String,
+                extraRequestParameters: Map<String, String>,
+            ): Result<RedirectEndSessionFlowContext> = Result.failure(IllegalStateException("OIDC Endpoints not available."))
+
+            override fun resume(
+                uri: String,
+                flowContext: RedirectEndSessionFlowContext,
+            ): Result<Unit> = Result.failure(KotlinRedirectEndSessionFlow.ResumeException("access_denied"))
+        }
+
+    @JvmStatic
+    fun fakeBrowserRedirectHandler(redirectUri: String): BrowserRedirectHandler =
+        object : BrowserRedirectHandler {
+            override suspend fun handleRedirect(url: String): String = redirectUri
+        }
+
+    @JvmStatic
+    fun successAuthorizationCodeDelegate(): KotlinAuthorizationCodeFlow =
+        object : KotlinAuthorizationCodeFlow {
+            override suspend fun start(
+                redirectUrl: String,
+                extraRequestParameters: Map<String, String>,
+                scope: String,
+            ): Result<AuthorizationCodeFlowContext> =
+                Result.success(
+                    AuthorizationCodeFlowContext(
+                        url = "https://example.okta.com/authorize?response_type=code",
+                        redirectUrl = redirectUrl,
+                        codeVerifier = "test-code-verifier",
+                        state = "test-state",
+                        nonce = "test-nonce",
+                        maxAge = null
+                    )
+                )
+
+            override suspend fun resume(
+                uri: String,
+                flowContext: AuthorizationCodeFlowContext,
+            ): Result<TokenInfo> = Result.success(FakeTokenInfo())
+        }
+
+    @JvmStatic
+    fun failingAuthorizationCodeDelegate(): KotlinAuthorizationCodeFlow =
+        object : KotlinAuthorizationCodeFlow {
+            override suspend fun start(
+                redirectUrl: String,
+                extraRequestParameters: Map<String, String>,
+                scope: String,
+            ): Result<AuthorizationCodeFlowContext> = Result.failure(IllegalStateException("OIDC Endpoints not available."))
+
+            override suspend fun resume(
+                uri: String,
+                flowContext: AuthorizationCodeFlowContext,
+            ): Result<TokenInfo> = Result.failure(IllegalStateException("OIDC Endpoints not available."))
+        }
+}

--- a/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/jvm/AuthorizationCodeFlow.kt
+++ b/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/jvm/AuthorizationCodeFlow.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.future.future
 import java.io.Closeable
 import java.util.concurrent.CompletableFuture
+import com.okta.authfoundation.client.kmp.OAuth2Client as KmpOAuth2Client
 import com.okta.oauth2.kmp.AuthorizationCodeFlow as KotlinAuthorizationCodeFlow
 
 /**
@@ -35,6 +36,13 @@ import com.okta.oauth2.kmp.AuthorizationCodeFlow as KotlinAuthorizationCodeFlow
  * the redirect callback. Java consumers can use [CompletableFuture] without dealing
  * with Kotlin coroutines.
  *
+ * Typical Java usage:
+ * ```java
+ * AuthorizationCodeFlow flow = new AuthorizationCodeFlow(kmpClient);
+ * TokenInfo token = flow.start(redirectUrl, browserHandler).get();
+ * flow.close();
+ * ```
+ *
  * Must be [closed][close] when no longer needed to release coroutine resources.
  *
  * @param delegate the underlying Kotlin [KotlinAuthorizationCodeFlow] instance.
@@ -42,6 +50,13 @@ import com.okta.oauth2.kmp.AuthorizationCodeFlow as KotlinAuthorizationCodeFlow
 class AuthorizationCodeFlow(
     private val delegate: KotlinAuthorizationCodeFlow,
 ) : Closeable {
+    /**
+     * Creates an [AuthorizationCodeFlow] backed by the given [KmpOAuth2Client].
+     *
+     * @param client the KMP OAuth2 client to use for the Authorization Code flow.
+     */
+    constructor(client: KmpOAuth2Client) : this(KotlinAuthorizationCodeFlow(client))
+
     private val coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
     /**

--- a/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/jvm/DeviceAuthorizationFlow.kt
+++ b/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/jvm/DeviceAuthorizationFlow.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.future.future
 import java.io.Closeable
 import java.util.concurrent.CompletableFuture
+import com.okta.authfoundation.client.kmp.OAuth2Client as KmpOAuth2Client
 import com.okta.oauth2.kmp.DeviceAuthorizationFlow as KotlinDeviceAuthorizationFlow
 
 /**
@@ -32,6 +33,14 @@ import com.okta.oauth2.kmp.DeviceAuthorizationFlow as KotlinDeviceAuthorizationF
  * This class exposes async methods returning [CompletableFuture] so Java consumers
  * can use the Device Authorization flow without dealing with Kotlin coroutines.
  *
+ * Typical Java usage:
+ * ```java
+ * DeviceAuthorizationFlow flow = new DeviceAuthorizationFlow(kmpClient);
+ * DeviceAuthorizationFlowContext ctx = flow.start(scope).get();
+ * TokenInfo token = flow.resume(ctx).get();
+ * flow.close();
+ * ```
+ *
  * Must be [closed][close] when no longer needed to release coroutine resources.
  *
  * @param delegate the underlying Kotlin [KotlinDeviceAuthorizationFlow] instance.
@@ -39,6 +48,13 @@ import com.okta.oauth2.kmp.DeviceAuthorizationFlow as KotlinDeviceAuthorizationF
 class DeviceAuthorizationFlow(
     private val delegate: KotlinDeviceAuthorizationFlow,
 ) : Closeable {
+    /**
+     * Creates a [DeviceAuthorizationFlow] backed by the given [KmpOAuth2Client].
+     *
+     * @param client the KMP OAuth2 client to use for the Device Authorization flow.
+     */
+    constructor(client: KmpOAuth2Client) : this(KotlinDeviceAuthorizationFlow(client))
+
     private val coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
     /**

--- a/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/jvm/RedirectEndSessionFlow.kt
+++ b/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/jvm/RedirectEndSessionFlow.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.future.future
 import java.io.Closeable
 import java.util.concurrent.CompletableFuture
+import com.okta.authfoundation.client.kmp.OAuth2Client as KmpOAuth2Client
 import com.okta.oauth2.kmp.RedirectEndSessionFlow as KotlinRedirectEndSessionFlow
 
 /**
@@ -34,6 +35,13 @@ import com.okta.oauth2.kmp.RedirectEndSessionFlow as KotlinRedirectEndSessionFlo
  * the redirect callback. Java consumers can use [CompletableFuture] without dealing
  * with Kotlin coroutines.
  *
+ * Typical Java usage:
+ * ```java
+ * RedirectEndSessionFlow flow = new RedirectEndSessionFlow(kmpClient);
+ * flow.start(idToken, redirectUrl, browserHandler).get();
+ * flow.close();
+ * ```
+ *
  * Must be [closed][close] when no longer needed to release coroutine resources.
  *
  * @param delegate the underlying Kotlin [KotlinRedirectEndSessionFlow] instance.
@@ -41,6 +49,13 @@ import com.okta.oauth2.kmp.RedirectEndSessionFlow as KotlinRedirectEndSessionFlo
 class RedirectEndSessionFlow(
     private val delegate: KotlinRedirectEndSessionFlow,
 ) : Closeable {
+    /**
+     * Creates a [RedirectEndSessionFlow] backed by the given [KmpOAuth2Client].
+     *
+     * @param client the KMP OAuth2 client to use for the Redirect End Session flow.
+     */
+    constructor(client: KmpOAuth2Client) : this(KotlinRedirectEndSessionFlow(client))
+
     private val coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
     /**

--- a/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/jvm/ResourceOwnerFlow.kt
+++ b/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/jvm/ResourceOwnerFlow.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.future.future
 import java.io.Closeable
 import java.util.concurrent.CompletableFuture
+import com.okta.authfoundation.client.kmp.OAuth2Client as KmpOAuth2Client
 import com.okta.oauth2.kmp.ResourceOwnerFlow as KotlinResourceOwnerFlow
 
 /**
@@ -31,6 +32,13 @@ import com.okta.oauth2.kmp.ResourceOwnerFlow as KotlinResourceOwnerFlow
  * This class exposes async methods returning [CompletableFuture] so Java consumers
  * can use the Resource Owner flow without dealing with Kotlin coroutines.
  *
+ * Typical Java usage:
+ * ```java
+ * ResourceOwnerFlow flow = new ResourceOwnerFlow(kmpClient);
+ * TokenInfo token = flow.start(username, password, scope).get();
+ * flow.close();
+ * ```
+ *
  * Must be [closed][close] when no longer needed to release coroutine resources.
  *
  * @param delegate the underlying Kotlin [KotlinResourceOwnerFlow] instance.
@@ -38,6 +46,13 @@ import com.okta.oauth2.kmp.ResourceOwnerFlow as KotlinResourceOwnerFlow
 class ResourceOwnerFlow(
     private val delegate: KotlinResourceOwnerFlow,
 ) : Closeable {
+    /**
+     * Creates a [ResourceOwnerFlow] backed by the given [KmpOAuth2Client].
+     *
+     * @param client the KMP OAuth2 client to use for the Resource Owner flow.
+     */
+    constructor(client: KmpOAuth2Client) : this(KotlinResourceOwnerFlow(client))
+
     private val coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
     /**

--- a/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/jvm/SessionTokenFlow.kt
+++ b/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/jvm/SessionTokenFlow.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.future.future
 import java.io.Closeable
 import java.util.concurrent.CompletableFuture
+import com.okta.authfoundation.client.kmp.OAuth2Client as KmpOAuth2Client
 import com.okta.oauth2.kmp.SessionTokenFlow as KotlinSessionTokenFlow
 
 /**
@@ -31,6 +32,13 @@ import com.okta.oauth2.kmp.SessionTokenFlow as KotlinSessionTokenFlow
  * This class exposes async methods returning [CompletableFuture] so Java consumers
  * can use the Session Token flow without dealing with Kotlin coroutines.
  *
+ * Typical Java usage:
+ * ```java
+ * SessionTokenFlow flow = new SessionTokenFlow(kmpClient);
+ * TokenInfo token = flow.start(sessionToken, redirectUrl).get();
+ * flow.close();
+ * ```
+ *
  * Must be [closed][close] when no longer needed to release coroutine resources.
  *
  * @param delegate the underlying Kotlin [KotlinSessionTokenFlow] instance.
@@ -38,6 +46,13 @@ import com.okta.oauth2.kmp.SessionTokenFlow as KotlinSessionTokenFlow
 class SessionTokenFlow(
     private val delegate: KotlinSessionTokenFlow,
 ) : Closeable {
+    /**
+     * Creates a [SessionTokenFlow] backed by the given [KmpOAuth2Client].
+     *
+     * @param client the KMP OAuth2 client to use for the Session Token flow.
+     */
+    constructor(client: KmpOAuth2Client) : this(KotlinSessionTokenFlow(client))
+
     private val coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
     /**

--- a/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/jvm/TokenExchangeFlow.kt
+++ b/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/jvm/TokenExchangeFlow.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.future.future
 import java.io.Closeable
 import java.util.concurrent.CompletableFuture
+import com.okta.authfoundation.client.kmp.OAuth2Client as KmpOAuth2Client
 import com.okta.oauth2.kmp.TokenExchangeFlow as KotlinTokenExchangeFlow
 
 /**
@@ -31,6 +32,13 @@ import com.okta.oauth2.kmp.TokenExchangeFlow as KotlinTokenExchangeFlow
  * This class exposes async methods returning [CompletableFuture] so Java consumers
  * can use the Token Exchange flow without dealing with Kotlin coroutines.
  *
+ * Typical Java usage:
+ * ```java
+ * TokenExchangeFlow flow = new TokenExchangeFlow(kmpClient);
+ * TokenInfo token = flow.start(idToken, deviceSecret, null, scope).get();
+ * flow.close();
+ * ```
+ *
  * Must be [closed][close] when no longer needed to release coroutine resources.
  *
  * @param delegate the underlying Kotlin [KotlinTokenExchangeFlow] instance.
@@ -38,6 +46,13 @@ import com.okta.oauth2.kmp.TokenExchangeFlow as KotlinTokenExchangeFlow
 class TokenExchangeFlow(
     private val delegate: KotlinTokenExchangeFlow,
 ) : Closeable {
+    /**
+     * Creates a [TokenExchangeFlow] backed by the given [KmpOAuth2Client].
+     *
+     * @param client the KMP OAuth2 client to use for the Token Exchange flow.
+     */
+    constructor(client: KmpOAuth2Client) : this(KotlinTokenExchangeFlow(client))
+
     private val coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
     /**

--- a/oauth2/src/jvmTest/java/com/okta/oauth2/kmp/jvm/AuthorizationCodeFlowTest.java
+++ b/oauth2/src/jvmTest/java/com/okta/oauth2/kmp/jvm/AuthorizationCodeFlowTest.java
@@ -43,8 +43,7 @@ public class AuthorizationCodeFlowTest {
   @Test
   public void start_ReturnsCompletableFutureWithTokenInfo()
       throws ExecutionException, InterruptedException, TimeoutException {
-    AuthorizationCodeFlow flow = TestFlowFactory.createSuccessAuthorizationCodeFlow();
-    try {
+    try (AuthorizationCodeFlow flow = TestFlowFactory.createSuccessAuthorizationCodeFlow()) {
       CompletableFuture<TokenInfo> future =
           flow.start("com.example.app:/callback", FAKE_REDIRECT_HANDLER);
       assertNotNull("Future should not be null", future);
@@ -53,16 +52,13 @@ public class AuthorizationCodeFlowTest {
       assertNotNull("TokenInfo should not be null", tokenInfo);
       assertEquals("Bearer", tokenInfo.getTokenType());
       assertEquals("test-access-token", tokenInfo.getAccessToken());
-    } finally {
-      flow.close();
     }
   }
 
   @Test
   public void start_WithAllParams_UsesProvidedScope()
       throws ExecutionException, InterruptedException, TimeoutException {
-    AuthorizationCodeFlow flow = TestFlowFactory.createSuccessAuthorizationCodeFlow();
-    try {
+    try (AuthorizationCodeFlow flow = TestFlowFactory.createSuccessAuthorizationCodeFlow()) {
       CompletableFuture<TokenInfo> future =
           flow.start(
               "com.example.app:/callback",
@@ -71,31 +67,25 @@ public class AuthorizationCodeFlowTest {
               "openid profile email");
       TokenInfo tokenInfo = future.get(5, TimeUnit.SECONDS);
       assertNotNull("TokenInfo should not be null", tokenInfo);
-    } finally {
-      flow.close();
     }
   }
 
   @Test
   public void start_WithDefaults_UsesDefaultScopeAndNoExtraParams()
       throws ExecutionException, InterruptedException, TimeoutException {
-    AuthorizationCodeFlow flow = TestFlowFactory.createSuccessAuthorizationCodeFlow();
-    try {
+    try (AuthorizationCodeFlow flow = TestFlowFactory.createSuccessAuthorizationCodeFlow()) {
       // Uses @JvmOverloads defaults — only redirectUrl and browserRedirectHandler required
       CompletableFuture<TokenInfo> future =
           flow.start("com.example.app:/callback", FAKE_REDIRECT_HANDLER);
       TokenInfo tokenInfo = future.get(5, TimeUnit.SECONDS);
       assertNotNull("TokenInfo should not be null", tokenInfo);
-    } finally {
-      flow.close();
     }
   }
 
   @Test
   public void start_WithError_CompletesExceptionally()
       throws TimeoutException, InterruptedException {
-    AuthorizationCodeFlow flow = TestFlowFactory.createFailingAuthorizationCodeFlow();
-    try {
+    try (AuthorizationCodeFlow flow = TestFlowFactory.createFailingAuthorizationCodeFlow()) {
       CompletableFuture<TokenInfo> future =
           flow.start("com.example.app:/callback", FAKE_REDIRECT_HANDLER);
       try {
@@ -107,9 +97,15 @@ public class AuthorizationCodeFlowTest {
             "Should contain error message",
             e.getCause().getMessage().contains("OIDC Endpoints not available."));
       }
-    } finally {
-      flow.close();
     }
+  }
+
+  @Test
+  public void constructor_WithOAuth2Client_CreatesFlow() {
+    com.okta.authfoundation.client.kmp.OAuth2Client kmpClient = TestOAuth2Client.create();
+    AuthorizationCodeFlow flow = new AuthorizationCodeFlow(kmpClient);
+    assertNotNull(flow);
+    flow.close();
   }
 
   @Test

--- a/oauth2/src/jvmTest/java/com/okta/oauth2/kmp/jvm/DeviceAuthorizationFlowTest.java
+++ b/oauth2/src/jvmTest/java/com/okta/oauth2/kmp/jvm/DeviceAuthorizationFlowTest.java
@@ -37,8 +37,7 @@ public class DeviceAuthorizationFlowTest {
   @Test
   public void start_ReturnsCompletableFutureWithContext()
       throws ExecutionException, InterruptedException, TimeoutException {
-    DeviceAuthorizationFlow flow = TestFlowFactory.createSuccessDeviceAuthorizationFlow();
-    try {
+    try (DeviceAuthorizationFlow flow = TestFlowFactory.createSuccessDeviceAuthorizationFlow()) {
       CompletableFuture<DeviceAuthorizationFlowContext> future =
           flow.start("openid profile email offline_access");
       assertNotNull("Future should not be null", future);
@@ -48,16 +47,13 @@ public class DeviceAuthorizationFlowTest {
       assertEquals("https://example.okta.com/activate", ctx.getVerificationUri());
       assertEquals("ABCD-1234", ctx.getUserCode());
       assertEquals(600, ctx.getExpiresIn());
-    } finally {
-      flow.close();
     }
   }
 
   @Test
   public void resume_ReturnsCompletableFutureWithTokenInfo()
       throws ExecutionException, InterruptedException, TimeoutException {
-    DeviceAuthorizationFlow flow = TestFlowFactory.createSuccessDeviceAuthorizationFlow();
-    try {
+    try (DeviceAuthorizationFlow flow = TestFlowFactory.createSuccessDeviceAuthorizationFlow()) {
       DeviceAuthorizationFlowContext ctx = flow.start("openid").get(5, TimeUnit.SECONDS);
       CompletableFuture<TokenInfo> future = flow.resume(ctx);
       assertNotNull("Future should not be null", future);
@@ -66,16 +62,13 @@ public class DeviceAuthorizationFlowTest {
       assertNotNull("TokenInfo should not be null", tokenInfo);
       assertEquals("Bearer", tokenInfo.getTokenType());
       assertEquals("test-access-token", tokenInfo.getAccessToken());
-    } finally {
-      flow.close();
     }
   }
 
   @Test
   public void start_WithError_CompletesExceptionally()
       throws TimeoutException, InterruptedException {
-    DeviceAuthorizationFlow flow = TestFlowFactory.createFailingDeviceAuthorizationFlow();
-    try {
+    try (DeviceAuthorizationFlow flow = TestFlowFactory.createFailingDeviceAuthorizationFlow()) {
       CompletableFuture<DeviceAuthorizationFlowContext> future = flow.start("openid");
       try {
         future.get(5, TimeUnit.SECONDS);
@@ -86,17 +79,16 @@ public class DeviceAuthorizationFlowTest {
             "Should contain error message",
             e.getCause().getMessage().contains("OIDC Endpoints not available."));
       }
-    } finally {
-      flow.close();
     }
   }
 
   @Test
   public void resume_WithError_CompletesExceptionally()
       throws ExecutionException, InterruptedException, TimeoutException {
-    DeviceAuthorizationFlow successStart = TestFlowFactory.createSuccessDeviceAuthorizationFlow();
-    DeviceAuthorizationFlow failingResume = TestFlowFactory.createFailingDeviceAuthorizationFlow();
-    try {
+    try (DeviceAuthorizationFlow successStart =
+            TestFlowFactory.createSuccessDeviceAuthorizationFlow();
+        DeviceAuthorizationFlow failingResume =
+            TestFlowFactory.createFailingDeviceAuthorizationFlow()) {
       // Get a valid context from the success flow
       DeviceAuthorizationFlowContext ctx = successStart.start("openid").get(5, TimeUnit.SECONDS);
 
@@ -110,10 +102,15 @@ public class DeviceAuthorizationFlowTest {
         assertTrue(
             "Should contain error message", e.getCause().getMessage().contains("access_denied"));
       }
-    } finally {
-      successStart.close();
-      failingResume.close();
     }
+  }
+
+  @Test
+  public void constructor_WithOAuth2Client_CreatesFlow() {
+    com.okta.authfoundation.client.kmp.OAuth2Client kmpClient = TestOAuth2Client.create();
+    DeviceAuthorizationFlow flow = new DeviceAuthorizationFlow(kmpClient);
+    assertNotNull(flow);
+    flow.close();
   }
 
   @Test

--- a/oauth2/src/jvmTest/java/com/okta/oauth2/kmp/jvm/RedirectEndSessionFlowTest.java
+++ b/oauth2/src/jvmTest/java/com/okta/oauth2/kmp/jvm/RedirectEndSessionFlowTest.java
@@ -40,15 +40,12 @@ public class RedirectEndSessionFlowTest {
     BrowserRedirectHandler handler =
         TestFlowFactory.createFakeBrowserRedirectHandler(
             "com.example.app:/logout?state=test-state");
-    RedirectEndSessionFlow flow =
-        TestFlowFactory.createSuccessRedirectEndSessionFlow("com.example.app:/logout");
-    try {
+    try (RedirectEndSessionFlow flow =
+        TestFlowFactory.createSuccessRedirectEndSessionFlow("com.example.app:/logout")) {
       CompletableFuture<Unit> future =
           flow.start("example-id-token", "com.example.app:/logout", handler);
       assertNotNull("Future should not be null", future);
       future.get(5, TimeUnit.SECONDS);
-    } finally {
-      flow.close();
     }
   }
 
@@ -58,15 +55,12 @@ public class RedirectEndSessionFlowTest {
     BrowserRedirectHandler handler =
         TestFlowFactory.createFakeBrowserRedirectHandler(
             "com.example.app:/logout?state=test-state");
-    RedirectEndSessionFlow flow =
-        TestFlowFactory.createSuccessRedirectEndSessionFlow("com.example.app:/logout");
-    try {
+    try (RedirectEndSessionFlow flow =
+        TestFlowFactory.createSuccessRedirectEndSessionFlow("com.example.app:/logout")) {
       CompletableFuture<Unit> future =
           flow.start(
               "example-id-token", "com.example.app:/logout", handler, Collections.emptyMap());
       future.get(5, TimeUnit.SECONDS);
-    } finally {
-      flow.close();
     }
   }
 
@@ -75,8 +69,7 @@ public class RedirectEndSessionFlowTest {
       throws TimeoutException, InterruptedException {
     BrowserRedirectHandler handler =
         TestFlowFactory.createFakeBrowserRedirectHandler("com.example.app:/logout");
-    RedirectEndSessionFlow flow = TestFlowFactory.createFailingRedirectEndSessionFlow();
-    try {
+    try (RedirectEndSessionFlow flow = TestFlowFactory.createFailingRedirectEndSessionFlow()) {
       CompletableFuture<Unit> future =
           flow.start("example-id-token", "com.example.app:/logout", handler);
       try {
@@ -88,9 +81,15 @@ public class RedirectEndSessionFlowTest {
             "Should contain error message",
             e.getCause().getMessage().contains("OIDC Endpoints not available."));
       }
-    } finally {
-      flow.close();
     }
+  }
+
+  @Test
+  public void constructor_WithOAuth2Client_CreatesFlow() {
+    com.okta.authfoundation.client.kmp.OAuth2Client kmpClient = TestOAuth2Client.create();
+    RedirectEndSessionFlow flow = new RedirectEndSessionFlow(kmpClient);
+    assertNotNull(flow);
+    flow.close();
   }
 
   @Test

--- a/oauth2/src/jvmTest/java/com/okta/oauth2/kmp/jvm/ResourceOwnerFlowTest.java
+++ b/oauth2/src/jvmTest/java/com/okta/oauth2/kmp/jvm/ResourceOwnerFlowTest.java
@@ -36,8 +36,7 @@ public class ResourceOwnerFlowTest {
   @Test
   public void start_ReturnsCompletableFutureWithTokenInfo()
       throws ExecutionException, InterruptedException, TimeoutException {
-    ResourceOwnerFlow flow = TestFlowFactory.createSuccessResourceOwnerFlow();
-    try {
+    try (ResourceOwnerFlow flow = TestFlowFactory.createSuccessResourceOwnerFlow()) {
       CompletableFuture<TokenInfo> future = flow.start("user@example.com", "password", "openid");
       assertNotNull("Future should not be null", future);
 
@@ -45,16 +44,13 @@ public class ResourceOwnerFlowTest {
       assertNotNull("TokenInfo should not be null", tokenInfo);
       assertEquals("Bearer", tokenInfo.getTokenType());
       assertEquals("test-access-token", tokenInfo.getAccessToken());
-    } finally {
-      flow.close();
     }
   }
 
   @Test
   public void start_WithError_CompletesExceptionally()
       throws TimeoutException, InterruptedException {
-    ResourceOwnerFlow flow = TestFlowFactory.createFailingResourceOwnerFlow();
-    try {
+    try (ResourceOwnerFlow flow = TestFlowFactory.createFailingResourceOwnerFlow()) {
       CompletableFuture<TokenInfo> future = flow.start("user@example.com", "wrong", "openid");
       try {
         future.get(5, TimeUnit.SECONDS);
@@ -64,9 +60,15 @@ public class ResourceOwnerFlowTest {
         assertTrue(
             "Should contain error message", e.getCause().getMessage().contains("invalid_grant"));
       }
-    } finally {
-      flow.close();
     }
+  }
+
+  @Test
+  public void constructor_WithOAuth2Client_CreatesFlow() {
+    com.okta.authfoundation.client.kmp.OAuth2Client kmpClient = TestOAuth2Client.create();
+    ResourceOwnerFlow flow = new ResourceOwnerFlow(kmpClient);
+    assertNotNull(flow);
+    flow.close();
   }
 
   @Test

--- a/oauth2/src/jvmTest/java/com/okta/oauth2/kmp/jvm/SessionTokenFlowTest.java
+++ b/oauth2/src/jvmTest/java/com/okta/oauth2/kmp/jvm/SessionTokenFlowTest.java
@@ -37,8 +37,7 @@ public class SessionTokenFlowTest {
   @Test
   public void start_ReturnsCompletableFutureWithTokenInfo()
       throws ExecutionException, InterruptedException, TimeoutException {
-    SessionTokenFlow flow = TestFlowFactory.createSuccessSessionTokenFlow();
-    try {
+    try (SessionTokenFlow flow = TestFlowFactory.createSuccessSessionTokenFlow()) {
       CompletableFuture<TokenInfo> future =
           flow.start("example-session-token", "com.example.app:/callback");
       assertNotNull("Future should not be null", future);
@@ -47,16 +46,13 @@ public class SessionTokenFlowTest {
       assertNotNull("TokenInfo should not be null", tokenInfo);
       assertEquals("Bearer", tokenInfo.getTokenType());
       assertEquals("test-access-token", tokenInfo.getAccessToken());
-    } finally {
-      flow.close();
     }
   }
 
   @Test
   public void start_WithAllParams_ReturnsTokenInfo()
       throws ExecutionException, InterruptedException, TimeoutException {
-    SessionTokenFlow flow = TestFlowFactory.createSuccessSessionTokenFlow();
-    try {
+    try (SessionTokenFlow flow = TestFlowFactory.createSuccessSessionTokenFlow()) {
       CompletableFuture<TokenInfo> future =
           flow.start(
               "example-session-token",
@@ -65,16 +61,13 @@ public class SessionTokenFlowTest {
               "openid profile email");
       TokenInfo tokenInfo = future.get(5, TimeUnit.SECONDS);
       assertNotNull("TokenInfo should not be null", tokenInfo);
-    } finally {
-      flow.close();
     }
   }
 
   @Test
   public void start_WithError_CompletesExceptionally()
       throws TimeoutException, InterruptedException {
-    SessionTokenFlow flow = TestFlowFactory.createFailingSessionTokenFlow();
-    try {
+    try (SessionTokenFlow flow = TestFlowFactory.createFailingSessionTokenFlow()) {
       CompletableFuture<TokenInfo> future = flow.start("bad-token", "com.example.app:/callback");
       try {
         future.get(5, TimeUnit.SECONDS);
@@ -85,9 +78,15 @@ public class SessionTokenFlowTest {
             "Should contain error message",
             e.getCause().getMessage().contains("OIDC Endpoints not available."));
       }
-    } finally {
-      flow.close();
     }
+  }
+
+  @Test
+  public void constructor_WithOAuth2Client_CreatesFlow() {
+    com.okta.authfoundation.client.kmp.OAuth2Client kmpClient = TestOAuth2Client.create();
+    SessionTokenFlow flow = new SessionTokenFlow(kmpClient);
+    assertNotNull(flow);
+    flow.close();
   }
 
   @Test

--- a/oauth2/src/jvmTest/java/com/okta/oauth2/kmp/jvm/TestFlowFactory.java
+++ b/oauth2/src/jvmTest/java/com/okta/oauth2/kmp/jvm/TestFlowFactory.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp.jvm;
+
+import com.okta.oauth2.kmp.BrowserRedirectHandler;
+
+/**
+ * Factory for creating pre-built flow instances for Java wrapper tests.
+ *
+ * <p>Suspend interface delegates are provided by {@link FakeSuspendFlows}, a Kotlin bridge object.
+ * Java test files cannot implement Kotlin suspend interfaces directly.
+ */
+public final class TestFlowFactory {
+
+  private TestFlowFactory() {}
+
+  /** Creates a {@link ResourceOwnerFlow} that always succeeds. */
+  public static ResourceOwnerFlow createSuccessResourceOwnerFlow() {
+    return new ResourceOwnerFlow(FakeSuspendFlows.successResourceOwnerDelegate());
+  }
+
+  /** Creates a {@link ResourceOwnerFlow} that always fails with {@code invalid_grant}. */
+  public static ResourceOwnerFlow createFailingResourceOwnerFlow() {
+    return new ResourceOwnerFlow(FakeSuspendFlows.failingResourceOwnerDelegate());
+  }
+
+  /** Creates a {@link DeviceAuthorizationFlow} that always succeeds. */
+  public static DeviceAuthorizationFlow createSuccessDeviceAuthorizationFlow() {
+    return new DeviceAuthorizationFlow(FakeSuspendFlows.successDeviceAuthorizationDelegate());
+  }
+
+  /** Creates a {@link DeviceAuthorizationFlow} that always fails. */
+  public static DeviceAuthorizationFlow createFailingDeviceAuthorizationFlow() {
+    return new DeviceAuthorizationFlow(FakeSuspendFlows.failingDeviceAuthorizationDelegate());
+  }
+
+  /** Creates a {@link TokenExchangeFlow} that always succeeds. */
+  public static TokenExchangeFlow createSuccessTokenExchangeFlow() {
+    return new TokenExchangeFlow(FakeSuspendFlows.successTokenExchangeDelegate());
+  }
+
+  /** Creates a {@link TokenExchangeFlow} that always fails with {@code invalid_grant}. */
+  public static TokenExchangeFlow createFailingTokenExchangeFlow() {
+    return new TokenExchangeFlow(FakeSuspendFlows.failingTokenExchangeDelegate());
+  }
+
+  /** Creates a {@link SessionTokenFlow} that always succeeds. */
+  public static SessionTokenFlow createSuccessSessionTokenFlow() {
+    return new SessionTokenFlow(FakeSuspendFlows.successSessionTokenDelegate());
+  }
+
+  /** Creates a {@link SessionTokenFlow} that always fails. */
+  public static SessionTokenFlow createFailingSessionTokenFlow() {
+    return new SessionTokenFlow(FakeSuspendFlows.failingSessionTokenDelegate());
+  }
+
+  /**
+   * Creates a {@link RedirectEndSessionFlow} that always succeeds.
+   *
+   * @param redirectUri the post-logout redirect URI returned in the context.
+   */
+  public static RedirectEndSessionFlow createSuccessRedirectEndSessionFlow(String redirectUri) {
+    return new RedirectEndSessionFlow(
+        FakeSuspendFlows.successRedirectEndSessionDelegate(redirectUri));
+  }
+
+  /** Creates a {@link RedirectEndSessionFlow} that always fails. */
+  public static RedirectEndSessionFlow createFailingRedirectEndSessionFlow() {
+    return new RedirectEndSessionFlow(FakeSuspendFlows.failingRedirectEndSessionDelegate());
+  }
+
+  /**
+   * Creates a fake {@link BrowserRedirectHandler} that immediately returns {@code redirectUri}.
+   *
+   * @param redirectUri the URI returned by {@code handleRedirect}.
+   */
+  public static BrowserRedirectHandler createFakeBrowserRedirectHandler(String redirectUri) {
+    return FakeSuspendFlows.fakeBrowserRedirectHandler(redirectUri);
+  }
+
+  /** Creates an {@link AuthorizationCodeFlow} that always succeeds. */
+  public static AuthorizationCodeFlow createSuccessAuthorizationCodeFlow() {
+    return new AuthorizationCodeFlow(FakeSuspendFlows.successAuthorizationCodeDelegate());
+  }
+
+  /** Creates an {@link AuthorizationCodeFlow} that always fails. */
+  public static AuthorizationCodeFlow createFailingAuthorizationCodeFlow() {
+    return new AuthorizationCodeFlow(FakeSuspendFlows.failingAuthorizationCodeDelegate());
+  }
+}

--- a/oauth2/src/jvmTest/java/com/okta/oauth2/kmp/jvm/TestOAuth2Client.java
+++ b/oauth2/src/jvmTest/java/com/okta/oauth2/kmp/jvm/TestOAuth2Client.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp.jvm;
+
+import com.okta.authfoundation.client.jvm.OAuth2ClientBuilder;
+import com.okta.authfoundation.client.kmp.OAuth2Client;
+import java.util.Collections;
+
+/**
+ * Test helper providing a minimal {@link OAuth2Client} instance for Java tests.
+ *
+ * <p>Construction uses valid parameters (HTTPS issuer, non-blank clientId, non-empty scope) that
+ * satisfy {@link OAuth2ClientBuilder} validation and succeed without network calls (endpoint
+ * discovery is lazy).
+ */
+class TestOAuth2Client {
+
+  private TestOAuth2Client() {}
+
+  static OAuth2Client create() {
+    return new OAuth2ClientBuilder(
+            "https://example.okta.com", "test-client", Collections.singletonList("openid"))
+        .build()
+        .getOrThrow();
+  }
+}

--- a/oauth2/src/jvmTest/java/com/okta/oauth2/kmp/jvm/TokenExchangeFlowTest.java
+++ b/oauth2/src/jvmTest/java/com/okta/oauth2/kmp/jvm/TokenExchangeFlowTest.java
@@ -36,8 +36,7 @@ public class TokenExchangeFlowTest {
   @Test
   public void start_ReturnsCompletableFutureWithTokenInfo()
       throws ExecutionException, InterruptedException, TimeoutException {
-    TokenExchangeFlow flow = TestFlowFactory.createSuccessTokenExchangeFlow();
-    try {
+    try (TokenExchangeFlow flow = TestFlowFactory.createSuccessTokenExchangeFlow()) {
       CompletableFuture<TokenInfo> future =
           flow.start("id-token", "device-secret", null, "openid profile email offline_access");
       assertNotNull("Future should not be null", future);
@@ -46,30 +45,24 @@ public class TokenExchangeFlowTest {
       assertNotNull("TokenInfo should not be null", tokenInfo);
       assertEquals("Bearer", tokenInfo.getTokenType());
       assertEquals("test-access-token", tokenInfo.getAccessToken());
-    } finally {
-      flow.close();
     }
   }
 
   @Test
   public void start_WithDefaults_UsesDefaultScope()
       throws ExecutionException, InterruptedException, TimeoutException {
-    TokenExchangeFlow flow = TestFlowFactory.createSuccessTokenExchangeFlow();
-    try {
+    try (TokenExchangeFlow flow = TestFlowFactory.createSuccessTokenExchangeFlow()) {
       // Uses @JvmOverloads defaults — only required params
       CompletableFuture<TokenInfo> future = flow.start("id-token", "device-secret");
       TokenInfo tokenInfo = future.get(5, TimeUnit.SECONDS);
       assertNotNull("TokenInfo should not be null", tokenInfo);
-    } finally {
-      flow.close();
     }
   }
 
   @Test
   public void start_WithError_CompletesExceptionally()
       throws TimeoutException, InterruptedException {
-    TokenExchangeFlow flow = TestFlowFactory.createFailingTokenExchangeFlow();
-    try {
+    try (TokenExchangeFlow flow = TestFlowFactory.createFailingTokenExchangeFlow()) {
       CompletableFuture<TokenInfo> future = flow.start("id-token", "device-secret");
       try {
         future.get(5, TimeUnit.SECONDS);
@@ -79,9 +72,15 @@ public class TokenExchangeFlowTest {
         assertTrue(
             "Should contain error message", e.getCause().getMessage().contains("invalid_grant"));
       }
-    } finally {
-      flow.close();
     }
+  }
+
+  @Test
+  public void constructor_WithOAuth2Client_CreatesFlow() {
+    com.okta.authfoundation.client.kmp.OAuth2Client kmpClient = TestOAuth2Client.create();
+    TokenExchangeFlow flow = new TokenExchangeFlow(kmpClient);
+    assertNotNull(flow);
+    flow.close();
   }
 
   @Test


### PR DESCRIPTION
- AndroidCompatExtensions: factory functions bridging Android OAuth2Client to all 6 KMP flow interfaces; Android Uri overloads for AuthorizationCodeFlow and RedirectEndSessionFlow resume methods
- ResourceOwnerFlow: add companion object with invoke operator so Android CompatExtension can construct it uniformly alongside the other flows
- build.gradle.kts: include src/test/resources in androidHostTest source set so existing Android host tests find their mock HTTP responses after KMP migration
- oauth2.api: regenerated JVM API dump reflecting all new public KMP classes
- TestFlowFactory: updated with helpers for all new flow types used by Java tests