### PR TITLE
Fix kotlinx.serialization.MissingFieldException

### DIFF
--- a/okta-idx-kotlin/src/main/java/com/okta/idx/kotlin/dto/v1/Responses.kt
+++ b/okta-idx-kotlin/src/main/java/com/okta/idx/kotlin/dto/v1/Responses.kt
@@ -196,7 +196,7 @@ internal data class Message(
 ) {
     @Serializable
     internal data class Localization(
-        val key: String,
+        val key: String? = null,
     )
 }
 

--- a/okta-idx-kotlin/src/test/java/com/okta/idx/kotlin/dto/IdxResponseTest.kt
+++ b/okta-idx-kotlin/src/test/java/com/okta/idx/kotlin/dto/IdxResponseTest.kt
@@ -151,6 +151,81 @@ class IdxResponseTest {
     }
 
     @Test
+    fun testFieldError_MissingI18nKey_DoesNotThrow() {
+        // Regression test for https://github.com/okta/okta-mobile-kotlin/issues/375
+        // The server may omit the 'key' field from a Message.Localization object.
+        // Previously this caused a MissingFieldException; now it should deserialize gracefully.
+        val idxResponse = getIdxResponse("field_error_missing_i18n_key.json")
+
+        val emailField =
+            idxResponse.remediations
+                .first()
+                .form.visibleFields
+                .first()
+                .form!!
+                .visibleFields
+                .first()
+        assertThat(emailField.messages).hasSize(3)
+    }
+
+    @Test
+    fun testFieldError_I18nKeyPresent_MappedToLocalizationKey() {
+        val idxResponse = getIdxResponse("field_error_missing_i18n_key.json")
+
+        val emailField =
+            idxResponse.remediations
+                .first()
+                .form.visibleFields
+                .first()
+                .form!!
+                .visibleFields
+                .first()
+        val message = emailField.messages[0]
+
+        assertThat(message.message).isEqualTo("Message with key present")
+        assertThat(message.localizationKey).isEqualTo("registration.error.invalidLoginEmail")
+        assertThat(message.type).isEqualTo(IdxMessage.Severity.ERROR)
+    }
+
+    @Test
+    fun testFieldError_I18nObjectPresentButKeyAbsent_LocalizationKeyIsNull() {
+        val idxResponse = getIdxResponse("field_error_missing_i18n_key.json")
+
+        val emailField =
+            idxResponse.remediations
+                .first()
+                .form.visibleFields
+                .first()
+                .form!!
+                .visibleFields
+                .first()
+        val message = emailField.messages[1]
+
+        assertThat(message.message).isEqualTo("Message with i18n object but key absent")
+        assertThat(message.localizationKey).isNull()
+        assertThat(message.type).isEqualTo(IdxMessage.Severity.ERROR)
+    }
+
+    @Test
+    fun testFieldError_NoI18nObject_LocalizationKeyIsNull() {
+        val idxResponse = getIdxResponse("field_error_missing_i18n_key.json")
+
+        val emailField =
+            idxResponse.remediations
+                .first()
+                .form.visibleFields
+                .first()
+                .form!!
+                .visibleFields
+                .first()
+        val message = emailField.messages[2]
+
+        assertThat(message.message).isEqualTo("Message with no i18n at all")
+        assertThat(message.localizationKey).isNull()
+        assertThat(message.type).isEqualTo(IdxMessage.Severity.ERROR)
+    }
+
+    @Test
     fun testTopLevelError() {
         val idxResponse = getIdxResponse("top_level_error.json")
 

--- a/okta-idx-kotlin/src/test/resources/dto/field_error_missing_i18n_key.json
+++ b/okta-idx-kotlin/src/test/resources/dto/field_error_missing_i18n_key.json
@@ -1,0 +1,79 @@
+{
+  "version": "1.0.0",
+  "stateHandle": "02MBcg1YCpB3SxK93qaYSUVSKjCwLwg3Eq4x7eyaej",
+  "expiresAt": "2021-09-28T18:02:00.000Z",
+  "intent": "LOGIN",
+  "remediation": {
+    "type": "array",
+    "value": [
+      {
+        "rel": ["create-form"],
+        "name": "enroll-profile",
+        "href": "https://foo.okta.com/idp/idx/enroll/new",
+        "method": "POST",
+        "produces": "application/ion+json; okta-version=1.0.0",
+        "value": [
+          {
+            "name": "userProfile",
+            "form": {
+              "value": [
+                {
+                  "name": "email",
+                  "label": "Email",
+                  "required": true,
+                  "value": "not-an-email",
+                  "messages": {
+                    "type": "array",
+                    "value": [
+                      {
+                        "message": "Message with key present",
+                        "i18n": {
+                          "key": "registration.error.invalidLoginEmail"
+                        },
+                        "class": "ERROR"
+                      },
+                      {
+                        "message": "Message with i18n object but key absent",
+                        "i18n": {},
+                        "class": "ERROR"
+                      },
+                      {
+                        "message": "Message with no i18n at all",
+                        "class": "ERROR"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "name": "stateHandle",
+                  "required": true,
+                  "value": "02MBcg1YCpB3SxK93qaYSUVSKjCwLwg3Eq4x7eyaej",
+                  "visible": false,
+                  "mutable": false
+                }
+              ]
+            }
+          }
+        ],
+        "accepts": "application/json; okta-version=1.0.0"
+      }
+    ]
+  },
+  "cancel": {
+    "rel": ["create-form"],
+    "name": "cancel",
+    "href": "https://foo.okta.com/idp/idx/cancel",
+    "method": "POST",
+    "produces": "application/ion+json; okta-version=1.0.0",
+    "value": [
+      {
+        "name": "stateHandle",
+        "required": true,
+        "value": "02MBcg1YCpB3SxK93qaYSUVSKjCwLwg3Eq4x7eyaej",
+        "visible": false,
+        "mutable": false
+      }
+    ],
+    "accepts": "application/json; okta-version=1.0.0"
+  }
+}


### PR DESCRIPTION
A server response is missing key value from a Message.Localization (i18n) object causes a crash because the serialization class declares it as non null. fix is to make the key optional. The SDK does not use this but may be a breaking change for consumers, they need to do a null check.

RESOLVES: OKTA-1201178