### PR TITLE
feat: EC key JWT validation, refreshToken extra params, custom endpoint overrides

### DIFF
--- a/auth-foundation/api/jvm/auth-foundation.api
+++ b/auth-foundation/api/jvm/auth-foundation.api
@@ -257,6 +257,7 @@ public final class com/okta/authfoundation/client/OAuth2ClientBuilder {
 	public final fun getClock ()Lcom/okta/authfoundation/client/OidcClock;
 	public final fun getComputeDispatcher ()Lkotlin/coroutines/CoroutineContext;
 	public final fun getDeviceSecretValidator ()Lcom/okta/authfoundation/client/kmp/DeviceSecretValidator;
+	public final fun getEndpointOverrides ()Lcom/okta/authfoundation/client/OAuth2EndpointOverrides;
 	public final fun getIdTokenValidator ()Lcom/okta/authfoundation/client/kmp/IdTokenValidator;
 	public final fun getIoDispatcher ()Lkotlin/coroutines/CoroutineContext;
 	public final fun getJson ()Lkotlinx/serialization/json/Json;
@@ -269,6 +270,7 @@ public final class com/okta/authfoundation/client/OAuth2ClientBuilder {
 	public final fun setClock (Lcom/okta/authfoundation/client/OidcClock;)V
 	public final fun setComputeDispatcher (Lkotlin/coroutines/CoroutineContext;)V
 	public final fun setDeviceSecretValidator (Lcom/okta/authfoundation/client/kmp/DeviceSecretValidator;)V
+	public final fun setEndpointOverrides (Lcom/okta/authfoundation/client/OAuth2EndpointOverrides;)V
 	public final fun setIdTokenValidator (Lcom/okta/authfoundation/client/kmp/IdTokenValidator;)V
 	public final fun setIoDispatcher (Lkotlin/coroutines/CoroutineContext;)V
 	public final fun setJson (Lkotlinx/serialization/json/Json;)V
@@ -290,6 +292,7 @@ public final class com/okta/authfoundation/client/OAuth2ClientConfiguration {
 	public final fun getClock ()Lcom/okta/authfoundation/client/OidcClock;
 	public final fun getDefaultScope ()Ljava/lang/String;
 	public final fun getDeviceSecretValidator ()Lcom/okta/authfoundation/client/kmp/DeviceSecretValidator;
+	public final fun getEndpointOverrides ()Lcom/okta/authfoundation/client/OAuth2EndpointOverrides;
 	public final fun getIdTokenValidator ()Lcom/okta/authfoundation/client/kmp/IdTokenValidator;
 	public final fun getIssuerUrl ()Ljava/lang/String;
 	public final fun getJson ()Lkotlinx/serialization/json/Json;
@@ -321,6 +324,20 @@ public final class com/okta/authfoundation/client/OAuth2ClientResult$Error$RateL
 public final class com/okta/authfoundation/client/OAuth2ClientResult$Success : com/okta/authfoundation/client/OAuth2ClientResult {
 	public fun <init> (Ljava/lang/Object;)V
 	public final fun getResult ()Ljava/lang/Object;
+}
+
+public final class com/okta/authfoundation/client/OAuth2EndpointOverrides {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAuthorizationEndpoint ()Ljava/lang/String;
+	public final fun getDeviceAuthorizationEndpoint ()Ljava/lang/String;
+	public final fun getEndSessionEndpoint ()Ljava/lang/String;
+	public final fun getIntrospectionEndpoint ()Ljava/lang/String;
+	public final fun getJwksUri ()Ljava/lang/String;
+	public final fun getRevocationEndpoint ()Ljava/lang/String;
+	public final fun getTokenEndpoint ()Ljava/lang/String;
+	public final fun getUserInfoEndpoint ()Ljava/lang/String;
 }
 
 public abstract interface class com/okta/authfoundation/client/OidcClock {
@@ -394,6 +411,7 @@ public final class com/okta/authfoundation/client/events/TokenRevokedEvent : com
 }
 
 public final class com/okta/authfoundation/client/internal/OAuth2Endpoints {
+	public static final field Companion Lcom/okta/authfoundation/client/internal/OAuth2Endpoints$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public final fun getAuthorizationEndpoint ()Ljava/lang/String;
 	public final fun getDeviceAuthorizationEndpoint ()Ljava/lang/String;
@@ -404,6 +422,11 @@ public final class com/okta/authfoundation/client/internal/OAuth2Endpoints {
 	public final fun getRevocationEndpoint ()Ljava/lang/String;
 	public final fun getTokenEndpoint ()Ljava/lang/String;
 	public final fun getUserInfoEndpoint ()Ljava/lang/String;
+	public final fun merge (Lcom/okta/authfoundation/client/OAuth2EndpointOverrides;)Lcom/okta/authfoundation/client/internal/OAuth2Endpoints;
+}
+
+public final class com/okta/authfoundation/client/internal/OAuth2Endpoints$Companion {
+	public final fun allFieldsNonNull (Lcom/okta/authfoundation/client/OAuth2EndpointOverrides;)Z
 }
 
 public final class com/okta/authfoundation/client/jvm/AuthFoundationResult {
@@ -433,6 +456,7 @@ public final class com/okta/authfoundation/client/jvm/OAuth2ClientBuilder {
 	public final fun setClientSecret (Ljava/lang/String;)Lcom/okta/authfoundation/client/jvm/OAuth2ClientBuilder;
 	public final fun setClock (Lcom/okta/authfoundation/client/OidcClock;)Lcom/okta/authfoundation/client/jvm/OAuth2ClientBuilder;
 	public final fun setComputeDispatcher (Lkotlin/coroutines/CoroutineContext;)Lcom/okta/authfoundation/client/jvm/OAuth2ClientBuilder;
+	public final fun setEndpointOverrides (Lcom/okta/authfoundation/client/OAuth2EndpointOverrides;)Lcom/okta/authfoundation/client/jvm/OAuth2ClientBuilder;
 	public final fun setIoDispatcher (Lkotlin/coroutines/CoroutineContext;)Lcom/okta/authfoundation/client/jvm/OAuth2ClientBuilder;
 }
 
@@ -511,6 +535,7 @@ public final class com/okta/authfoundation/client/kmp/OAuth2Client {
 	public final fun getUserInfo-gIAlu-s (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun introspectToken-0E7RQCE (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun jwks-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun refreshToken-0E7RQCE (Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun refreshToken-gIAlu-s (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun revokeToken-gIAlu-s (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun tokenRequest-BWLJW6A (Ljava/util/Map;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -670,10 +695,15 @@ public abstract interface class com/okta/authfoundation/credential/kmp/Credentia
 	public abstract fun introspectToken-gIAlu-s (Lcom/okta/authfoundation/credential/TokenType;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun refreshIfExpired-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun refreshToken-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun refreshToken-gIAlu-s (Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun revokeAllTokens-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun revokeToken-gIAlu-s (Lcom/okta/authfoundation/credential/RevokeTokenType;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun scope ()Ljava/lang/String;
 	public abstract fun setTagsAsync-gIAlu-s (Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/okta/authfoundation/credential/kmp/Credential$DefaultImpls {
+	public static fun refreshToken-gIAlu-s (Lcom/okta/authfoundation/credential/kmp/Credential;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class com/okta/authfoundation/credential/kmp/CredentialImpl : com/okta/authfoundation/credential/kmp/Credential {
@@ -691,6 +721,7 @@ public final class com/okta/authfoundation/credential/kmp/CredentialImpl : com/o
 	public fun introspectToken-gIAlu-s (Lcom/okta/authfoundation/credential/TokenType;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun refreshIfExpired-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun refreshToken-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun refreshToken-gIAlu-s (Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun revokeAllTokens-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun revokeToken-gIAlu-s (Lcom/okta/authfoundation/credential/RevokeTokenType;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun scope ()Ljava/lang/String;

--- a/auth-foundation/src/androidHostTest/kotlin/com/okta/authfoundation/jwt/EcSignatureVerifierTest.kt
+++ b/auth-foundation/src/androidHostTest/kotlin/com/okta/authfoundation/jwt/EcSignatureVerifierTest.kt
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.jwt
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import java.security.Signature
+import java.security.interfaces.ECPublicKey
+
+class EcSignatureVerifierTest {
+    private val testData = "header.payload".toByteArray()
+
+    // Signs [data] with the given private key and returns the signature in P1363 format.
+    private fun signP1363(
+        data: ByteArray,
+        keyPair: java.security.KeyPair,
+        jcaAlg: String,
+    ): ByteArray {
+        val ecPublicKey = keyPair.public as ECPublicKey
+        val coordByteLen = (ecPublicKey.params.order.bitLength() + 7) / 8
+        val derSig =
+            Signature.getInstance(jcaAlg).run {
+                initSign(keyPair.private)
+                update(data)
+                sign()
+            }
+        return derToP1363(derSig, coordByteLen)
+    }
+
+    @Test fun es256_ValidSignature_ReturnsTrue() {
+        val keyPair = TestKeyFactory.createEcKeyPair("P-256")
+        val ecPublicKey = keyPair.public as ECPublicKey
+        val coordByteLen = (ecPublicKey.params.order.bitLength() + 7) / 8
+        val x =
+            ecPublicKey.w.affineX
+                .toByteArray()
+                .toCoordBytes(coordByteLen)
+        val y =
+            ecPublicKey.w.affineY
+                .toByteArray()
+                .toCoordBytes(coordByteLen)
+        val sig = signP1363(testData, keyPair, "SHA256withECDSA")
+
+        assertThat(verifyEcSignature(x, y, "P-256", testData, sig)).isTrue()
+    }
+
+    @Test fun es256_WrongKey_ReturnsFalse() {
+        val signingKeyPair = TestKeyFactory.createEcKeyPair("P-256")
+        val wrongKeyPair = TestKeyFactory.createEcKeyPair("P-256")
+        val wrongPublicKey = wrongKeyPair.public as ECPublicKey
+        val coordByteLen = (wrongPublicKey.params.order.bitLength() + 7) / 8
+        val x =
+            wrongPublicKey.w.affineX
+                .toByteArray()
+                .toCoordBytes(coordByteLen)
+        val y =
+            wrongPublicKey.w.affineY
+                .toByteArray()
+                .toCoordBytes(coordByteLen)
+        val sig = signP1363(testData, signingKeyPair, "SHA256withECDSA")
+
+        assertThat(verifyEcSignature(x, y, "P-256", testData, sig)).isFalse()
+    }
+
+    @Test fun es384_ValidSignature_ReturnsTrue() {
+        val keyPair = TestKeyFactory.createEcKeyPair("P-384")
+        val ecPublicKey = keyPair.public as ECPublicKey
+        val coordByteLen = (ecPublicKey.params.order.bitLength() + 7) / 8
+        val x =
+            ecPublicKey.w.affineX
+                .toByteArray()
+                .toCoordBytes(coordByteLen)
+        val y =
+            ecPublicKey.w.affineY
+                .toByteArray()
+                .toCoordBytes(coordByteLen)
+        val sig = signP1363(testData, keyPair, "SHA384withECDSA")
+
+        assertThat(verifyEcSignature(x, y, "P-384", testData, sig)).isTrue()
+    }
+
+    @Test fun es384_WrongKey_ReturnsFalse() {
+        val signingKeyPair = TestKeyFactory.createEcKeyPair("P-384")
+        val wrongKeyPair = TestKeyFactory.createEcKeyPair("P-384")
+        val wrongPublicKey = wrongKeyPair.public as ECPublicKey
+        val coordByteLen = (wrongPublicKey.params.order.bitLength() + 7) / 8
+        val x =
+            wrongPublicKey.w.affineX
+                .toByteArray()
+                .toCoordBytes(coordByteLen)
+        val y =
+            wrongPublicKey.w.affineY
+                .toByteArray()
+                .toCoordBytes(coordByteLen)
+        val sig = signP1363(testData, signingKeyPair, "SHA384withECDSA")
+
+        assertThat(verifyEcSignature(x, y, "P-384", testData, sig)).isFalse()
+    }
+
+    @Test fun es512_ValidSignature_ReturnsTrue() {
+        val keyPair = TestKeyFactory.createEcKeyPair("P-521")
+        val ecPublicKey = keyPair.public as ECPublicKey
+        val coordByteLen = (ecPublicKey.params.order.bitLength() + 7) / 8
+        val x =
+            ecPublicKey.w.affineX
+                .toByteArray()
+                .toCoordBytes(coordByteLen)
+        val y =
+            ecPublicKey.w.affineY
+                .toByteArray()
+                .toCoordBytes(coordByteLen)
+        val sig = signP1363(testData, keyPair, "SHA512withECDSA")
+
+        assertThat(verifyEcSignature(x, y, "P-521", testData, sig)).isTrue()
+    }
+
+    @Test fun es512_WrongKey_ReturnsFalse() {
+        val signingKeyPair = TestKeyFactory.createEcKeyPair("P-521")
+        val wrongKeyPair = TestKeyFactory.createEcKeyPair("P-521")
+        val wrongPublicKey = wrongKeyPair.public as ECPublicKey
+        val coordByteLen = (wrongPublicKey.params.order.bitLength() + 7) / 8
+        val x =
+            wrongPublicKey.w.affineX
+                .toByteArray()
+                .toCoordBytes(coordByteLen)
+        val y =
+            wrongPublicKey.w.affineY
+                .toByteArray()
+                .toCoordBytes(coordByteLen)
+        val sig = signP1363(testData, signingKeyPair, "SHA512withECDSA")
+
+        assertThat(verifyEcSignature(x, y, "P-521", testData, sig)).isFalse()
+    }
+
+    @Test fun ec_MissingXCoord_ReturnsFalse() {
+        val keyPair = TestKeyFactory.createEcKeyPair("P-256")
+        val ecPublicKey = keyPair.public as ECPublicKey
+        val coordByteLen = (ecPublicKey.params.order.bitLength() + 7) / 8
+        val y =
+            ecPublicKey.w.affineY
+                .toByteArray()
+                .toCoordBytes(coordByteLen)
+        val sig = signP1363(testData, keyPair, "SHA256withECDSA")
+
+        // Pass all-zero x (not the real key)
+        assertThat(verifyEcSignature(ByteArray(coordByteLen), y, "P-256", testData, sig)).isFalse()
+    }
+
+    @Test fun ec_MissingYCoord_ReturnsFalse() {
+        val keyPair = TestKeyFactory.createEcKeyPair("P-256")
+        val ecPublicKey = keyPair.public as ECPublicKey
+        val coordByteLen = (ecPublicKey.params.order.bitLength() + 7) / 8
+        val x =
+            ecPublicKey.w.affineX
+                .toByteArray()
+                .toCoordBytes(coordByteLen)
+        val sig = signP1363(testData, keyPair, "SHA256withECDSA")
+
+        // Pass all-zero y (invalid point)
+        assertThat(verifyEcSignature(x, ByteArray(coordByteLen), "P-256", testData, sig)).isFalse()
+    }
+
+    @Test fun ec_UnsupportedCurve_ReturnsFalse() {
+        val keyPair = TestKeyFactory.createEcKeyPair("P-256")
+        val ecPublicKey = keyPair.public as ECPublicKey
+        val coordByteLen = (ecPublicKey.params.order.bitLength() + 7) / 8
+        val x =
+            ecPublicKey.w.affineX
+                .toByteArray()
+                .toCoordBytes(coordByteLen)
+        val y =
+            ecPublicKey.w.affineY
+                .toByteArray()
+                .toCoordBytes(coordByteLen)
+        val sig = signP1363(testData, keyPair, "SHA256withECDSA")
+
+        assertThat(verifyEcSignature(x, y, "P-224", testData, sig)).isFalse()
+    }
+
+    @Test fun ec_InvalidBase64Signature_ReturnsFalse() {
+        val keyPair = TestKeyFactory.createEcKeyPair("P-256")
+        val ecPublicKey = keyPair.public as ECPublicKey
+        val coordByteLen = (ecPublicKey.params.order.bitLength() + 7) / 8
+        val x =
+            ecPublicKey.w.affineX
+                .toByteArray()
+                .toCoordBytes(coordByteLen)
+        val y =
+            ecPublicKey.w.affineY
+                .toByteArray()
+                .toCoordBytes(coordByteLen)
+
+        assertThat(verifyEcSignature(x, y, "P-256", testData, ByteArray(4) { 0xFF.toByte() })).isFalse()
+    }
+}
+
+/** Strips/pads a BigInteger byte array to [coordByteLen] bytes for use as EC coordinate. */
+private fun ByteArray.toCoordBytes(coordByteLen: Int): ByteArray =
+    when {
+        size == coordByteLen -> this
+        size > coordByteLen -> copyOfRange(size - coordByteLen, size)
+        else -> ByteArray(coordByteLen - size) + this
+    }
+
+/**
+ * Converts a DER-encoded ECDSA signature to P1363 (raw r‖s) format.
+ *
+ * Used in tests to produce P1363 input from JCA's DER output.
+ */
+private fun derToP1363(
+    der: ByteArray,
+    coordByteLen: Int,
+): ByteArray {
+    // DER: 0x30 <len> [0x81 <len>] 0x02 <r_len> <r_bytes> 0x02 <s_len> <s_bytes>
+    var pos = 1 // skip 0x30
+    // Sequence length: short or long form
+    val lenByte = der[pos++].toInt() and 0xFF
+    if (lenByte and 0x80 != 0) {
+        // Long form: skip the length bytes (0x81 <byte> for one-byte length)
+        pos += lenByte and 0x7F
+    }
+    // Read r integer
+    pos++ // skip 0x02 tag
+    val rLen = der[pos++].toInt() and 0xFF
+    val rBytes = der.copyOfRange(pos, pos + rLen)
+    pos += rLen
+    // Read s integer
+    pos++ // skip 0x02 tag
+    val sLen = der[pos++].toInt() and 0xFF
+    val sBytes = der.copyOfRange(pos, pos + sLen)
+
+    // Pad each component to coordByteLen (strip leading 0x00 sign byte if present)
+    val p1363 = ByteArray(coordByteLen * 2)
+    rBytes.toCoordBytes(coordByteLen).copyInto(p1363, 0)
+    sBytes.toCoordBytes(coordByteLen).copyInto(p1363, coordByteLen)
+    return p1363
+}

--- a/auth-foundation/src/androidHostTest/kotlin/com/okta/authfoundation/jwt/JwksFactory.kt
+++ b/auth-foundation/src/androidHostTest/kotlin/com/okta/authfoundation/jwt/JwksFactory.kt
@@ -16,6 +16,8 @@
 package com.okta.authfoundation.jwt
 
 import okio.ByteString.Companion.toByteString
+import java.security.KeyPair
+import java.security.interfaces.ECPublicKey
 import java.security.interfaces.RSAPublicKey
 
 fun createJwks(
@@ -46,3 +48,56 @@ fun createJwks(
                 )
             )
     )
+
+/**
+ * Creates a [Jwks] containing a single EC key backed by [keyPair].
+ *
+ * The x and y coordinates are extracted from the public key and base64url-encoded per RFC 7517.
+ *
+ * @param keyPair the EC key pair (public key must be an [ECPublicKey]).
+ * @param crv the JWK curve name: `"P-256"`, `"P-384"`, or `"P-521"`.
+ * @param keyId the key ID to embed in the JWKS entry.
+ */
+fun createEcJwks(
+    keyPair: KeyPair,
+    crv: String,
+    keyId: String = "ec-test-key",
+): Jwks {
+    val ecPublicKey = keyPair.public as ECPublicKey
+    val coordByteLen = (ecPublicKey.params.order.bitLength() + 7) / 8
+    val x =
+        ecPublicKey.w.affineX
+            .toByteArray()
+            .toCoordBytes(coordByteLen)
+    val y =
+        ecPublicKey.w.affineY
+            .toByteArray()
+            .toCoordBytes(coordByteLen)
+    return Jwks(
+        keys =
+            listOf(
+                Jwks.Key(
+                    keyId = keyId,
+                    use = "sig",
+                    keyType = "EC",
+                    algorithm = null,
+                    exponent = null,
+                    modulus = null,
+                    x = x.toByteString().base64Url(),
+                    y = y.toByteString().base64Url(),
+                    crv = crv
+                )
+            )
+    )
+}
+
+/**
+ * Converts a [BigInteger.toByteArray] result to a fixed-length unsigned coordinate byte array.
+ * BigInteger may prepend a 0x00 sign byte; this strips or pads to exactly [coordByteLen] bytes.
+ */
+private fun ByteArray.toCoordBytes(coordByteLen: Int): ByteArray =
+    when {
+        size == coordByteLen -> this
+        size > coordByteLen -> copyOfRange(size - coordByteLen, size)
+        else -> ByteArray(coordByteLen - size) + this
+    }

--- a/auth-foundation/src/androidHostTest/kotlin/com/okta/authfoundation/jwt/JwksTest.kt
+++ b/auth-foundation/src/androidHostTest/kotlin/com/okta/authfoundation/jwt/JwksTest.kt
@@ -89,4 +89,82 @@ class JwksTest {
             "yUPh0wNqXh1CMSxzud4uHkfBKkNX7powR4cRS_i0VxkbiicbNZ0IQhw-enDhZieRti4NhygOJfN8DPmtHsWJxt_pCsibc--bNgylcESpn9K4OxtiQrjUvtRM4WX3PWsKUREDZ0Vp-WAXC2nibvqRP_Ky38DkZMinzvCLabr0IOzyGc9AJrUHib61X6FucSoLM_YrKi2hd2UUHqeGiZrmUcHCrgrxcJIBTSbJq47hZrFzFN5RDq0Ium-lm8DU3bfoSlyc7minHlCWcOd90LtjonIHYqUVlpRYUzj_n4AM7DPKI6DDxC0-hio37qxfdmV_5Zvo6fpxIe8EUbI-oUoS3Q"
         )
     }
+
+    @Test fun ecKey_XYCrvParsedCorrectly() {
+        val json =
+            """
+            {
+                "keys": [
+                    {
+                        "kty": "EC",
+                        "kid": "ec-key-1",
+                        "use": "sig",
+                        "crv": "P-256",
+                        "x": "f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",
+                        "y": "x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0"
+                    }
+                ]
+            }
+            """.trimIndent()
+        val jwks =
+            oktaRule.configuration.json
+                .decodeFromString(SerializableJwks.serializer(), json)
+                .toJwks()
+        assertThat(jwks.keys).hasSize(1)
+        val key = jwks.keys.first()
+        assertThat(key.keyType).isEqualTo("EC")
+        assertThat(key.crv).isEqualTo("P-256")
+        assertThat(key.x).isEqualTo("f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU")
+        assertThat(key.y).isEqualTo("x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0")
+        assertThat(key.exponent).isNull()
+        assertThat(key.modulus).isNull()
+    }
+
+    @Test fun ecKey_MissingXField_ParsesNull() {
+        val json =
+            """
+            {
+                "keys": [
+                    {
+                        "kty": "EC",
+                        "kid": "ec-key-no-x",
+                        "use": "sig",
+                        "crv": "P-256",
+                        "y": "x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0"
+                    }
+                ]
+            }
+            """.trimIndent()
+        val jwks =
+            oktaRule.configuration.json
+                .decodeFromString(SerializableJwks.serializer(), json)
+                .toJwks()
+        val key = jwks.keys.first()
+        assertThat(key.x).isNull()
+        assertThat(key.y).isEqualTo("x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0")
+    }
+
+    @Test fun ecKey_MissingCrvField_ParsesNull() {
+        val json =
+            """
+            {
+                "keys": [
+                    {
+                        "kty": "EC",
+                        "kid": "ec-key-no-crv",
+                        "use": "sig",
+                        "x": "f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",
+                        "y": "x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0"
+                    }
+                ]
+            }
+            """.trimIndent()
+        val jwks =
+            oktaRule.configuration.json
+                .decodeFromString(SerializableJwks.serializer(), json)
+                .toJwks()
+        val key = jwks.keys.first()
+        assertThat(key.crv).isNull()
+        assertThat(key.x).isEqualTo("f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU")
+    }
 }

--- a/auth-foundation/src/androidHostTest/kotlin/com/okta/authfoundation/jwt/JwtTest.kt
+++ b/auth-foundation/src/androidHostTest/kotlin/com/okta/authfoundation/jwt/JwtTest.kt
@@ -19,8 +19,12 @@ import com.google.common.truth.Truth.assertThat
 import com.okta.authfoundation.jwt.JwtBuilder.Companion.createJwtBuilder
 import com.okta.testhelpers.OktaRule
 import kotlinx.coroutines.runBlocking
+import okio.ByteString.Companion.toByteString
 import org.junit.Rule
 import org.junit.Test
+import java.security.KeyPair
+import java.security.Signature
+import java.security.interfaces.ECPublicKey
 
 class JwtTest {
     @get:Rule val oktaRule = OktaRule()
@@ -109,4 +113,112 @@ class JwtTest {
             val jwt = oktaRule.createOAuth2Client().createJwtBuilder().createJwt(claims = IdTokenClaims())
             assertThat(jwt).isNotEqualTo("Different!")
         }
+
+    // ── EC dispatch tests ──────────────────────────────────────────────────────
+
+    @Test fun hasValidSignature_EcKey_Es256_ReturnsTrue(): Unit =
+        runBlocking {
+            val keyPair = TestKeyFactory.createEcKeyPair("P-256")
+            val jwks = createEcJwks(keyPair, crv = "P-256", keyId = "ec-test-key")
+            val jwt =
+                createEcJwt(
+                    keyPair = keyPair,
+                    keyId = "ec-test-key",
+                    algorithm = "ES256",
+                    jcaAlg = "SHA256withECDSA",
+                    parser = JwtParser(oktaRule.configuration.json, oktaRule.configuration.computeDispatcher)
+                )
+            assertThat(jwt.hasValidSignature(jwks)).isTrue()
+        }
+
+    @Test fun hasValidSignature_EcKey_WrongKeyId_ReturnsFalse(): Unit =
+        runBlocking {
+            val keyPair = TestKeyFactory.createEcKeyPair("P-256")
+            // JWKS has "other-key-id" but JWT header says "ec-test-key"
+            val jwks = createEcJwks(keyPair, crv = "P-256", keyId = "other-key-id")
+            val jwt =
+                createEcJwt(
+                    keyPair = keyPair,
+                    keyId = "ec-test-key",
+                    algorithm = "ES256",
+                    jcaAlg = "SHA256withECDSA",
+                    parser = JwtParser(oktaRule.configuration.json, oktaRule.configuration.computeDispatcher)
+                )
+            assertThat(jwt.hasValidSignature(jwks)).isFalse()
+        }
+
+    @Test fun hasValidSignature_MixedJwks_RsaKeyStillWorks(): Unit =
+        runBlocking {
+            // A JWKS containing both an RSA key and an EC key — RSA JWT should still verify correctly.
+            val rsaJwks = createJwks()
+            val ecKeyPair = TestKeyFactory.createEcKeyPair("P-256")
+            val ecJwks = createEcJwks(ecKeyPair, crv = "P-256", keyId = "ec-key")
+            val mixedJwks = Jwks(keys = rsaJwks.keys + ecJwks.keys)
+
+            val rsaJwt = oktaRule.createOAuth2Client().createJwtBuilder().createJwt(claims = IdTokenClaims())
+            assertThat(rsaJwt.hasValidSignature(mixedJwks)).isTrue()
+        }
 }
+
+// ── EC JWT test helper ─────────────────────────────────────────────────────────
+
+private fun createEcJwt(
+    keyPair: KeyPair,
+    keyId: String,
+    algorithm: String,
+    jcaAlg: String,
+    parser: JwtParser,
+): Jwt {
+    val ecPublicKey = keyPair.public as ECPublicKey
+    val coordByteLen = (ecPublicKey.params.order.bitLength() + 7) / 8
+
+    fun String.toBase64(): String = toByteArray(Charsets.US_ASCII).toByteString().base64Url().trimEnd('=')
+
+    val header = """{"alg":"$algorithm","kid":"$keyId","typ":"JWT"}""".toBase64()
+    val claims = """{"sub":"test","iss":"https://example.okta.com","aud":"client","iat":1700000000,"exp":9999999999}""".toBase64()
+    val signingInput = "$header.$claims"
+
+    val derSig =
+        Signature.getInstance(jcaAlg).run {
+            initSign(keyPair.private)
+            update(signingInput.toByteArray(Charsets.US_ASCII))
+            sign()
+        }
+
+    // Convert DER → P1363 for JWT (IETF JWS spec requires P1363/raw format)
+    val p1363Sig = derToP1363(derSig, coordByteLen)
+    val sigEncoded = p1363Sig.toByteString().base64Url().trimEnd('=')
+
+    return parser.parse("$signingInput.$sigEncoded")
+}
+
+/** Converts a DER ECDSA signature to P1363 (raw r‖s) format for JWT encoding. */
+private fun derToP1363(
+    der: ByteArray,
+    coordByteLen: Int,
+): ByteArray {
+    var pos = 1 // skip 0x30
+    val lenByte = der[pos++].toInt() and 0xFF
+    if (lenByte and 0x80 != 0) pos += lenByte and 0x7F
+
+    pos++ // skip 0x02
+    val rLen = der[pos++].toInt() and 0xFF
+    val rBytes = der.copyOfRange(pos, pos + rLen)
+    pos += rLen
+
+    pos++ // skip 0x02
+    val sLen = der[pos++].toInt() and 0xFF
+    val sBytes = der.copyOfRange(pos, pos + sLen)
+
+    val p1363 = ByteArray(coordByteLen * 2)
+    rBytes.toCoordBytes(coordByteLen).copyInto(p1363, 0)
+    sBytes.toCoordBytes(coordByteLen).copyInto(p1363, coordByteLen)
+    return p1363
+}
+
+private fun ByteArray.toCoordBytes(coordByteLen: Int): ByteArray =
+    when {
+        size == coordByteLen -> this
+        size > coordByteLen -> copyOfRange(size - coordByteLen, size)
+        else -> ByteArray(coordByteLen - size) + this
+    }

--- a/auth-foundation/src/androidHostTest/kotlin/com/okta/authfoundation/jwt/TestKeyFactory.kt
+++ b/auth-foundation/src/androidHostTest/kotlin/com/okta/authfoundation/jwt/TestKeyFactory.kt
@@ -17,8 +17,11 @@ package com.okta.authfoundation.jwt
 
 import okio.ByteString.Companion.decodeBase64
 import java.security.KeyFactory
+import java.security.KeyPair
+import java.security.KeyPairGenerator
 import java.security.PrivateKey
 import java.security.PublicKey
+import java.security.spec.ECGenParameterSpec
 import java.security.spec.PKCS8EncodedKeySpec
 import java.security.spec.X509EncodedKeySpec
 
@@ -94,5 +97,25 @@ object TestKeyFactory {
         val keySpec = X509EncodedKeySpec(publicKeyBytes)
         val keyFactory = KeyFactory.getInstance("RSA")
         return keyFactory.generatePublic(keySpec)
+    }
+
+    /**
+     * Generates a fresh EC key pair for the given named curve.
+     *
+     * @param curve the JWK curve name: `"P-256"`, `"P-384"`, or `"P-521"`.
+     */
+    fun createEcKeyPair(curve: String = "P-256"): KeyPair {
+        val ecCurveName =
+            when (curve) {
+                "P-256" -> "secp256r1"
+                "P-384" -> "secp384r1"
+                "P-521" -> "secp521r1"
+                else -> curve
+            }
+        return KeyPairGenerator
+            .getInstance("EC")
+            .apply {
+                initialize(ECGenParameterSpec(ecCurveName))
+            }.generateKeyPair()
     }
 }

--- a/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/client/EndpointsFactory.kt
+++ b/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/client/EndpointsFactory.kt
@@ -33,9 +33,16 @@ internal object EndpointsFactory {
     private var cacheInstance: Cache? = null
 
     suspend fun get(configuration: OidcConfiguration): OAuth2ClientResult<OidcEndpoints> {
+        val overrides = configuration.endpointOverrides
+
+        // If all override fields are provided, skip discovery entirely.
+        if (overrides != null && overrides.allFieldsNonNull()) {
+            return OAuth2ClientResult.Success(overrides.asOidcEndpoints())
+        }
+
         val cache = getOrCreateCache(configuration.cacheFactory)
         val cacheKey = PREFIX + configuration.discoveryUrl
-        val endpoints =
+        val cached =
             withContext(configuration.computeDispatcher) {
                 val result = cache.get(cacheKey) ?: return@withContext null
                 return@withContext try {
@@ -49,23 +56,35 @@ internal object EndpointsFactory {
                     null
                 }
             }
-        if (endpoints != null) {
-            return endpoints
-        }
-        val request =
-            Request
-                .Builder()
-                .url(configuration.discoveryUrl.toHttpUrl())
-                .build()
-        return configuration.internalPerformRequest(request, { it.isSuccessful }) { responseBody ->
-            @OptIn(ExperimentalSerializationApi::class)
-            val serializableOidcEndpoints =
-                configuration.json.decodeFromBufferedSource(
-                    SerializableOidcEndpoints.serializer(),
-                    responseBody.peek()
-                )
-            cache.set(cacheKey, responseBody.readUtf8())
-            serializableOidcEndpoints.asOidcEndpoints()
+        val discovered =
+            if (cached != null) {
+                cached
+            } else {
+                val request =
+                    Request
+                        .Builder()
+                        .url(configuration.discoveryUrl.toHttpUrl())
+                        .build()
+                configuration.internalPerformRequest(request, { it.isSuccessful }) { responseBody ->
+                    @OptIn(ExperimentalSerializationApi::class)
+                    val serializableOidcEndpoints =
+                        configuration.json.decodeFromBufferedSource(
+                            SerializableOidcEndpoints.serializer(),
+                            responseBody.peek()
+                        )
+                    cache.set(cacheKey, responseBody.readUtf8())
+                    serializableOidcEndpoints.asOidcEndpoints()
+                }
+            }
+
+        // Merge partial overrides on top of the discovered endpoints.
+        return if (overrides == null) {
+            discovered
+        } else {
+            when (discovered) {
+                is OAuth2ClientResult.Success -> OAuth2ClientResult.Success(discovered.result.merge(overrides))
+                is OAuth2ClientResult.Error -> discovered
+            }
         }
     }
 
@@ -82,4 +101,40 @@ internal object EndpointsFactory {
     internal fun reset() {
         cacheInstance = null
     }
+
+    private fun OAuth2EndpointOverrides.allFieldsNonNull(): Boolean =
+        authorizationEndpoint != null &&
+            tokenEndpoint != null &&
+            userInfoEndpoint != null &&
+            jwksUri != null &&
+            introspectionEndpoint != null &&
+            revocationEndpoint != null &&
+            endSessionEndpoint != null &&
+            deviceAuthorizationEndpoint != null
+
+    private fun OAuth2EndpointOverrides.asOidcEndpoints(): OidcEndpoints =
+        OidcEndpoints(
+            issuer = authorizationEndpoint!!.toHttpUrl(), // use authorizationEndpoint as a proxy issuer
+            authorizationEndpoint = authorizationEndpoint.toHttpUrl(),
+            tokenEndpoint = tokenEndpoint!!.toHttpUrl(),
+            userInfoEndpoint = userInfoEndpoint!!.toHttpUrl(),
+            jwksUri = jwksUri!!.toHttpUrl(),
+            introspectionEndpoint = introspectionEndpoint!!.toHttpUrl(),
+            revocationEndpoint = revocationEndpoint!!.toHttpUrl(),
+            endSessionEndpoint = endSessionEndpoint!!.toHttpUrl(),
+            deviceAuthorizationEndpoint = deviceAuthorizationEndpoint!!.toHttpUrl()
+        )
+
+    private fun OidcEndpoints.merge(overrides: OAuth2EndpointOverrides): OidcEndpoints =
+        OidcEndpoints(
+            issuer = issuer,
+            authorizationEndpoint = overrides.authorizationEndpoint?.toHttpUrl() ?: authorizationEndpoint,
+            tokenEndpoint = overrides.tokenEndpoint?.toHttpUrl() ?: tokenEndpoint,
+            userInfoEndpoint = overrides.userInfoEndpoint?.toHttpUrl() ?: userInfoEndpoint,
+            jwksUri = overrides.jwksUri?.toHttpUrl() ?: jwksUri,
+            introspectionEndpoint = overrides.introspectionEndpoint?.toHttpUrl() ?: introspectionEndpoint,
+            revocationEndpoint = overrides.revocationEndpoint?.toHttpUrl() ?: revocationEndpoint,
+            endSessionEndpoint = overrides.endSessionEndpoint?.toHttpUrl() ?: endSessionEndpoint,
+            deviceAuthorizationEndpoint = overrides.deviceAuthorizationEndpoint?.toHttpUrl() ?: deviceAuthorizationEndpoint
+        )
 }

--- a/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/client/OAuth2Client.kt
+++ b/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/client/OAuth2Client.kt
@@ -123,8 +123,23 @@ class OAuth2Client private constructor(
      * Attempt to refresh the token.
      *
      * @param token the [Token] to refresh.
+     * @see refreshToken for an overload that accepts additional request parameters.
      */
-    suspend fun refreshToken(token: Token): OAuth2ClientResult<Token> {
+    suspend fun refreshToken(token: Token): OAuth2ClientResult<Token> = refreshToken(token, emptyMap())
+
+    /**
+     * Attempt to refresh the token, forwarding additional form body parameters to the token endpoint.
+     *
+     * Reserved keys (`grant_type`, `client_id`, `refresh_token`) are silently filtered out of
+     * [extraRequestParameters] and cannot be overridden.
+     *
+     * @param token the [Token] to refresh.
+     * @param extraRequestParameters additional form parameters to include in the token request.
+     */
+    suspend fun refreshToken(
+        token: Token,
+        extraRequestParameters: Map<String, String>,
+    ): OAuth2ClientResult<Token> {
         val endpoints = endpointsOrNull() ?: return endpointNotAvailableError()
 
         val refreshToken =
@@ -132,13 +147,18 @@ class OAuth2Client private constructor(
                 return OAuth2ClientResult.Error(throwable as Exception)
             }
 
+        val reserved = setOf("grant_type", "client_id", "refresh_token")
         val formBody =
             FormBody
                 .Builder()
                 .add("client_id", configuration.clientId)
                 .add("grant_type", "refresh_token")
                 .add("refresh_token", refreshToken)
-                .build()
+                .apply {
+                    extraRequestParameters.forEach { (key, value) ->
+                        if (key !in reserved) add(key, value)
+                    }
+                }.build()
 
         val request =
             Request

--- a/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/client/OidcConfiguration.kt
+++ b/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/client/OidcConfiguration.kt
@@ -62,6 +62,13 @@ class OidcConfiguration private constructor(
     /** The factory for creating a new instance of [Cache]. [Cache] is used to optimize network calls by the SDK. */
     @property:InternalAuthFoundationApi
     val cacheFactory: suspend () -> Cache = AuthFoundationDefaults.cacheFactory,
+    /**
+     * Optional per-endpoint URL overrides. Non-null fields take precedence over discovery values.
+     * When all fields are non-null the discovery document fetch is skipped entirely.
+     * See [OAuth2EndpointOverrides] for details and URL validation rules.
+     */
+    @Transient @property:InternalAuthFoundationApi
+    val endpointOverrides: OAuth2EndpointOverrides? = null,
 ) {
     /**
      * Used to create an OidcConfiguration.
@@ -87,7 +94,39 @@ class OidcConfiguration private constructor(
         idTokenValidator = AuthFoundationDefaults.idTokenValidator,
         accessTokenValidator = AuthFoundationDefaults.accessTokenValidator,
         deviceSecretValidator = AuthFoundationDefaults.deviceSecretValidator,
-        cacheFactory = AuthFoundationDefaults.cacheFactory
+        cacheFactory = AuthFoundationDefaults.cacheFactory,
+        endpointOverrides = null
+    )
+
+    /**
+     * Used to create an OidcConfiguration with custom endpoint overrides.
+     *
+     * @param clientId the application's client ID.
+     * @param defaultScope the default access scopes required by the client.
+     * @param issuer the Authorization Server URL, e.g. `https://your_okta_domain.okta.com/oauth2/default`.
+     * @param endpointOverrides optional per-endpoint URL overrides; see [OAuth2EndpointOverrides].
+     *
+     * See [AuthFoundationDefaults] for further customization options.
+     */
+    constructor(
+        clientId: String,
+        defaultScope: String,
+        issuer: String,
+        endpointOverrides: OAuth2EndpointOverrides?,
+    ) : this(
+        clientId = clientId,
+        defaultScope = defaultScope,
+        discoveryUrl = "$issuer/.well-known/openid-configuration",
+        okHttpClientFactory = AuthFoundationDefaults.okHttpClientFactory,
+        ioDispatcher = AuthFoundationDefaults.ioDispatcher,
+        computeDispatcher = AuthFoundationDefaults.computeDispatcher,
+        clock = AuthFoundationDefaults.clock,
+        eventCoordinator = AuthFoundationDefaults.eventCoordinator,
+        idTokenValidator = AuthFoundationDefaults.idTokenValidator,
+        accessTokenValidator = AuthFoundationDefaults.accessTokenValidator,
+        deviceSecretValidator = AuthFoundationDefaults.deviceSecretValidator,
+        cacheFactory = AuthFoundationDefaults.cacheFactory,
+        endpointOverrides = endpointOverrides
     )
 
     /** The Call.Factory which makes calls to the okta server. */

--- a/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/credential/Credential.kt
+++ b/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/credential/Credential.kt
@@ -452,8 +452,29 @@ class Credential internal constructor(
 
     /**
      * Attempt to refresh the [Token] associated with this [Credential].
+     *
+     * Uses a shared orchestrator for deduplication — concurrent calls for the same credential
+     * will coalesce into a single network request.
+     *
+     * @see refreshToken for an overload that accepts additional request parameters.
      */
     suspend fun refreshToken(): OAuth2ClientResult<Token> = refreshCoalescingOrchestrator.get()
+
+    /**
+     * Attempt to refresh the [Token] associated with this [Credential], forwarding additional
+     * form body parameters to the token endpoint.
+     *
+     * When [extraRequestParameters] is empty, delegates to [refreshToken] (uses the orchestrator).
+     * When non-empty, calls the token endpoint directly — bypassing the coalescing orchestrator.
+     *
+     * Reserved keys (`grant_type`, `client_id`, `refresh_token`) are silently filtered out.
+     *
+     * @param extraRequestParameters additional form parameters to forward to the token endpoint.
+     */
+    suspend fun refreshToken(extraRequestParameters: Map<String, String>): OAuth2ClientResult<Token> {
+        if (extraRequestParameters.isEmpty()) return refreshToken()
+        return client.refreshToken(token, extraRequestParameters)
+    }
 
     private suspend fun performRealRefresh(): OAuth2ClientResult<Token> = client.refreshToken(token)
 

--- a/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/jwt/EcSignatureVerifier.kt
+++ b/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/jwt/EcSignatureVerifier.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.jwt
+
+import com.okta.authfoundation.api.log.LogLevel
+import com.okta.authfoundation.api.log.getDefaultAuthFoundationLogger
+import java.math.BigInteger
+import java.security.AlgorithmParameters
+import java.security.KeyFactory
+import java.security.Signature
+import java.security.spec.ECGenParameterSpec
+import java.security.spec.ECParameterSpec
+import java.security.spec.ECPoint
+import java.security.spec.ECPublicKeySpec
+
+private val logger = getDefaultAuthFoundationLogger()
+
+internal actual fun verifyEcSignature(
+    x: ByteArray,
+    y: ByteArray,
+    crv: String,
+    data: ByteArray,
+    signature: ByteArray,
+): Boolean =
+    try {
+        val curveName =
+            when (crv) {
+                "P-256" -> "secp256r1"
+                "P-384" -> "secp384r1"
+                "P-521" -> "secp521r1"
+                else -> return false
+            }
+        val jcaAlg =
+            when (crv) {
+                "P-256" -> "SHA256withECDSAinP1363Format"
+                "P-384" -> "SHA384withECDSAinP1363Format"
+                "P-521" -> "SHA512withECDSAinP1363Format"
+                else -> return false
+            }
+
+        val ecPoint = ECPoint(BigInteger(1, x), BigInteger(1, y))
+        val ecParams =
+            AlgorithmParameters.getInstance("EC").run {
+                init(ECGenParameterSpec(curveName))
+                getParameterSpec(ECParameterSpec::class.java)
+            }
+        val publicKey = KeyFactory.getInstance("EC").generatePublic(ECPublicKeySpec(ecPoint, ecParams))
+
+        Signature.getInstance(jcaAlg).run {
+            initVerify(publicKey)
+            update(data)
+            verify(signature)
+        }
+    } catch (e: Exception) {
+        logger.write("EC signature verification failed", tr = e, logLevel = LogLevel.WARN)
+        false
+    }

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/OAuth2ClientBuilder.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/OAuth2ClientBuilder.kt
@@ -90,6 +90,24 @@ class OAuth2ClientBuilder private constructor(
     /** Device secret validator. When set, device secrets are validated via `ds_hash` claim. */
     var deviceSecretValidator: DeviceSecretValidator = DefaultDeviceSecretValidator()
 
+    /**
+     * Optional per-endpoint URL overrides.
+     *
+     * When set, each non-null field replaces the corresponding URL from the OpenID Connect
+     * discovery document. When all 8 fields are non-null, the discovery HTTP call is skipped
+     * entirely. All non-null override values must be valid HTTPS URLs.
+     *
+     * Example:
+     * ```kotlin
+     * endpointOverrides = OAuth2EndpointOverrides(
+     *     tokenEndpoint = "https://proxy.example.com/token"
+     * )
+     * ```
+     *
+     * @see OAuth2EndpointOverrides
+     */
+    var endpointOverrides: OAuth2EndpointOverrides? = null
+
     companion object {
         /**
          * Creates a [OAuth2Client] with the given parameters and optional customization.
@@ -120,6 +138,31 @@ class OAuth2ClientBuilder private constructor(
 
                 val builder = OAuth2ClientBuilder(issuerUrl, clientId, scope.joinToString(" "))
                 buildAction?.invoke(builder)
+
+                // Validate endpoint override URLs
+                builder.endpointOverrides?.let { overrides ->
+                    fun validateOverrideUrl(
+                        value: String?,
+                        fieldName: String,
+                    ) {
+                        if (value == null) return
+                        require(
+                            runCatching {
+                                val url = Url(value)
+                                url.protocol == URLProtocol.HTTPS && url.host.isNotBlank()
+                            }.getOrDefault(false)
+                        ) { "endpointOverrides.$fieldName must be a valid https URL." }
+                    }
+                    validateOverrideUrl(overrides.authorizationEndpoint, "authorizationEndpoint")
+                    validateOverrideUrl(overrides.tokenEndpoint, "tokenEndpoint")
+                    validateOverrideUrl(overrides.userInfoEndpoint, "userInfoEndpoint")
+                    validateOverrideUrl(overrides.jwksUri, "jwksUri")
+                    validateOverrideUrl(overrides.introspectionEndpoint, "introspectionEndpoint")
+                    validateOverrideUrl(overrides.revocationEndpoint, "revocationEndpoint")
+                    validateOverrideUrl(overrides.endSessionEndpoint, "endSessionEndpoint")
+                    validateOverrideUrl(overrides.deviceAuthorizationEndpoint, "deviceAuthorizationEndpoint")
+                }
+
                 val config = builder.build()
                 val discovery = EndpointDiscovery(config)
                 @OptIn(InternalAuthFoundationApi::class)
@@ -147,6 +190,7 @@ class OAuth2ClientBuilder private constructor(
             acrValues = acrValues,
             idTokenValidator = idTokenValidator,
             accessTokenValidator = accessTokenValidator,
-            deviceSecretValidator = deviceSecretValidator
+            deviceSecretValidator = deviceSecretValidator,
+            endpointOverrides = endpointOverrides
         )
 }

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/OAuth2ClientConfiguration.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/OAuth2ClientConfiguration.kt
@@ -57,4 +57,6 @@ class OAuth2ClientConfiguration internal constructor(
     val accessTokenValidator: AccessTokenValidator = DefaultAccessTokenValidator(),
     /** Validator for device secrets. Validates `ds_hash` claim against the device secret hash. */
     val deviceSecretValidator: DeviceSecretValidator = DefaultDeviceSecretValidator(),
+    /** Optional per-endpoint URL overrides. Non-null fields win over discovery results. */
+    val endpointOverrides: OAuth2EndpointOverrides? = null,
 )

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/OAuth2EndpointOverrides.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/OAuth2EndpointOverrides.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.client
+
+/**
+ * Optional per-endpoint URL overrides for an [OAuth2Client].
+ *
+ * When provided via [OAuth2ClientBuilder.endpointOverrides], each non-null field replaces the
+ * corresponding URL that would otherwise be obtained from the OpenID Connect discovery document.
+ *
+ * **Skip-discovery optimization**: When **all** 8 fields are non-null, the SDK skips the HTTP
+ * request to `{issuerUrl}/.well-known/openid-configuration` entirely and uses the override values
+ * directly. This is useful for environments where the discovery URL is unavailable or when
+ * startup latency must be minimized.
+ *
+ * **Partial overrides**: When only some fields are non-null, the discovery document is still
+ * fetched. The override values then win over the discovered values for those specific fields.
+ *
+ * All non-null values must be valid HTTPS URLs; validation occurs at [OAuth2ClientBuilder] build time.
+ *
+ * Example — override only the token endpoint:
+ * ```kotlin
+ * val client = OAuth2ClientBuilder.create(
+ *     issuerUrl = "https://your-okta-domain.okta.com/oauth2/default",
+ *     clientId = "client-id",
+ *     scope = listOf("openid"),
+ * ) {
+ *     endpointOverrides = OAuth2EndpointOverrides(
+ *         tokenEndpoint = "https://proxy.example.com/token"
+ *     )
+ * }.getOrThrow()
+ * ```
+ *
+ * @param authorizationEndpoint override URL for the authorization endpoint, or `null` to use discovery.
+ * @param tokenEndpoint override URL for the token endpoint, or `null` to use discovery.
+ * @param userInfoEndpoint override URL for the user-info endpoint, or `null` to use discovery.
+ * @param jwksUri override URL for the JWKS URI, or `null` to use discovery.
+ * @param introspectionEndpoint override URL for the introspection endpoint, or `null` to use discovery.
+ * @param revocationEndpoint override URL for the revocation endpoint, or `null` to use discovery.
+ * @param endSessionEndpoint override URL for the end-session (logout) endpoint, or `null` to use discovery.
+ * @param deviceAuthorizationEndpoint override URL for the device authorization endpoint, or `null` to use discovery.
+ */
+class OAuth2EndpointOverrides(
+    val authorizationEndpoint: String? = null,
+    val tokenEndpoint: String? = null,
+    val userInfoEndpoint: String? = null,
+    val jwksUri: String? = null,
+    val introspectionEndpoint: String? = null,
+    val revocationEndpoint: String? = null,
+    val endSessionEndpoint: String? = null,
+    val deviceAuthorizationEndpoint: String? = null,
+)

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/internal/EndpointDiscovery.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/internal/EndpointDiscovery.kt
@@ -20,13 +20,21 @@ import com.okta.authfoundation.api.http.ApiRequest
 import com.okta.authfoundation.api.http.ApiRequestMethod
 import com.okta.authfoundation.client.OAuth2ClientConfiguration
 import com.okta.authfoundation.client.OAuth2ClientResult
+import com.okta.authfoundation.client.OAuth2EndpointOverrides
 
 internal class EndpointDiscovery(
     private val configuration: OAuth2ClientConfiguration,
 ) {
     @OptIn(InternalAuthFoundationApi::class)
-    suspend fun discover(): OAuth2ClientResult<OAuth2Endpoints> =
-        runCatching {
+    suspend fun discover(): OAuth2ClientResult<OAuth2Endpoints> {
+        val overrides = configuration.endpointOverrides
+
+        // Skip discovery entirely when all 8 endpoint overrides are provided.
+        if (OAuth2Endpoints.allFieldsNonNull(overrides)) {
+            return OAuth2ClientResult.Success(overrides!!.toOAuth2Endpoints(configuration.issuerUrl))
+        }
+
+        return runCatching {
             val request =
                 object : ApiRequest {
                     override fun method(): ApiRequestMethod = ApiRequestMethod.GET
@@ -40,9 +48,28 @@ internal class EndpointDiscovery(
                 response.body?.decodeToString()
                     ?: throw IllegalStateException("Empty response from discovery endpoint")
             val endpoints = configuration.json.decodeFromString<SerializableOAuth2Endpoints>(body)
-            endpoints.toEndpoints()
+            endpoints.toEndpoints().merge(overrides)
         }.fold(
             onSuccess = { OAuth2ClientResult.Success(it) },
             onFailure = { OAuth2ClientResult.Error(it as Exception) }
         )
+    }
 }
+
+/**
+ * Converts an [OAuth2EndpointOverrides] with all fields set to an [OAuth2Endpoints].
+ * The [issuer] is taken from the configuration's issuerUrl.
+ */
+@OptIn(InternalAuthFoundationApi::class)
+private fun OAuth2EndpointOverrides.toOAuth2Endpoints(issuer: String): OAuth2Endpoints =
+    OAuth2Endpoints(
+        issuer = issuer,
+        authorizationEndpoint = authorizationEndpoint,
+        tokenEndpoint = tokenEndpoint!!,
+        userInfoEndpoint = userInfoEndpoint,
+        jwksUri = jwksUri,
+        introspectionEndpoint = introspectionEndpoint,
+        revocationEndpoint = revocationEndpoint,
+        endSessionEndpoint = endSessionEndpoint,
+        deviceAuthorizationEndpoint = deviceAuthorizationEndpoint
+    )

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/internal/OAuth2Endpoints.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/internal/OAuth2Endpoints.kt
@@ -16,6 +16,7 @@
 package com.okta.authfoundation.client.internal
 
 import com.okta.authfoundation.InternalAuthFoundationApi
+import com.okta.authfoundation.client.OAuth2EndpointOverrides
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -33,7 +34,44 @@ class OAuth2Endpoints(
     val revocationEndpoint: String?,
     val endSessionEndpoint: String?,
     val deviceAuthorizationEndpoint: String?,
-)
+) {
+    companion object {
+        /**
+         * Returns `true` when [overrides] is non-null and every one of its 8 endpoint fields
+         * is non-null, allowing discovery to be skipped entirely.
+         */
+        fun allFieldsNonNull(overrides: OAuth2EndpointOverrides?): Boolean {
+            if (overrides == null) return false
+            return overrides.authorizationEndpoint != null &&
+                overrides.tokenEndpoint != null &&
+                overrides.userInfoEndpoint != null &&
+                overrides.jwksUri != null &&
+                overrides.introspectionEndpoint != null &&
+                overrides.revocationEndpoint != null &&
+                overrides.endSessionEndpoint != null &&
+                overrides.deviceAuthorizationEndpoint != null
+        }
+    }
+
+    /**
+     * Returns a new [OAuth2Endpoints] where each non-null field in [overrides] replaces the
+     * corresponding field from this instance. Null override fields keep the discovered value.
+     */
+    fun merge(overrides: OAuth2EndpointOverrides?): OAuth2Endpoints {
+        if (overrides == null) return this
+        return OAuth2Endpoints(
+            issuer = issuer,
+            authorizationEndpoint = overrides.authorizationEndpoint ?: authorizationEndpoint,
+            tokenEndpoint = overrides.tokenEndpoint ?: tokenEndpoint,
+            userInfoEndpoint = overrides.userInfoEndpoint ?: userInfoEndpoint,
+            jwksUri = overrides.jwksUri ?: jwksUri,
+            introspectionEndpoint = overrides.introspectionEndpoint ?: introspectionEndpoint,
+            revocationEndpoint = overrides.revocationEndpoint ?: revocationEndpoint,
+            endSessionEndpoint = overrides.endSessionEndpoint ?: endSessionEndpoint,
+            deviceAuthorizationEndpoint = overrides.deviceAuthorizationEndpoint ?: deviceAuthorizationEndpoint
+        )
+    }
+}
 
 @Serializable
 internal class SerializableOAuth2Endpoints(

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/kmp/OAuth2Client.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/kmp/OAuth2Client.kt
@@ -153,15 +153,43 @@ class OAuth2Client internal constructor(
      * - [OAuth2ClientResult.Error.HttpResponseException] if the server returns an error.
      * - [IdTokenValidator.Error] if ID token validation fails.
      * - Other exceptions for network or parsing failures.
+     * @see refreshToken for an overload that accepts additional request parameters.
      */
-    suspend fun refreshToken(refreshToken: String): Result<TokenInfo> =
+    suspend fun refreshToken(refreshToken: String): Result<TokenInfo> = refreshToken(refreshToken, emptyMap())
+
+    /**
+     * Attempt to refresh a token using the provided refresh token string, forwarding additional
+     * form body parameters to the token endpoint.
+     *
+     * Reserved keys (`grant_type`, `client_id`, `refresh_token`) are silently filtered out of
+     * [extraRequestParameters] and cannot be overridden.
+     *
+     * On success, a [TokenRefreshedEvent] is emitted on [events].
+     *
+     * @param refreshToken the refresh token string.
+     * @param extraRequestParameters additional form parameters to include in the token request
+     *   (e.g., `mapOf("acr_values" to "urn:okta:loa:2fa:any")`).
+     * @return [Result.success] with the new [TokenInfo], or [Result.failure] with:
+     * - [OAuth2ClientResult.Error.OidcEndpointsNotAvailableException] if endpoints cannot be resolved.
+     * - [OAuth2ClientResult.Error.HttpResponseException] if the server returns an error.
+     * - [IdTokenValidator.Error] if ID token validation fails.
+     * - Other exceptions for network or parsing failures.
+     */
+    suspend fun refreshToken(
+        refreshToken: String,
+        extraRequestParameters: Map<String, String>,
+    ): Result<TokenInfo> =
         runCatching {
+            val reserved = setOf("grant_type", "client_id", "refresh_token")
             val formParams =
-                mapOf(
-                    "client_id" to configuration.clientId,
-                    "grant_type" to "refresh_token",
-                    "refresh_token" to refreshToken
-                )
+                buildMap {
+                    put("client_id", configuration.clientId)
+                    put("grant_type", "refresh_token")
+                    put("refresh_token", refreshToken)
+                    extraRequestParameters.forEach { (key, value) ->
+                        if (key !in reserved) put(key, value)
+                    }
+                }
             val tokenInfo = tokenRequest(formParams).getOrThrow()
             _events.tryEmit(TokenRefreshedEvent(tokenInfo))
             tokenInfo

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/credential/kmp/Credential.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/credential/kmp/Credential.kt
@@ -176,8 +176,27 @@ interface Credential : CredentialIdentifier {
      *   or [Result.failure] with:
      * - [IllegalStateException] if no refresh token is available on this credential.
      * - Other exceptions if the refresh network request fails.
+     * @see refreshToken for an overload that accepts additional request parameters.
      */
     suspend fun refreshToken(): Result<Credential>
+
+    /**
+     * Refreshes the token with additional form body parameters and returns a **new** credential snapshot.
+     *
+     * Unlike [refreshToken], this overload **bypasses the coalescing orchestrator** — each call
+     * always makes a new network request. Use the no-parameter overload when deduplication is desired.
+     *
+     * Reserved keys (`grant_type`, `client_id`, `refresh_token`) are silently filtered out of
+     * [extraRequestParameters] and cannot be overridden.
+     *
+     * @param extraRequestParameters additional form parameters to forward to the token endpoint
+     *   (e.g., `mapOf("acr_values" to "urn:okta:loa:2fa:any")`).
+     * @return [Result.success] with a new [Credential] snapshot containing the refreshed token,
+     *   or [Result.failure] with:
+     * - [IllegalStateException] if no refresh token is available on this credential.
+     * - Other exceptions if the refresh network request fails.
+     */
+    suspend fun refreshToken(extraRequestParameters: Map<String, String>): Result<Credential> = refreshToken()
 
     /**
      * Retrieves the parsed [Jwt] from the ID token.

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/credential/kmp/CredentialImpl.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/credential/kmp/CredentialImpl.kt
@@ -116,6 +116,25 @@ class CredentialImpl internal constructor(
             replaceToken(newToken)
         }
 
+    /**
+     * Refreshes the token with extra request parameters, bypassing the coalescing orchestrator.
+     *
+     * When [extraRequestParameters] is empty, delegates to [refreshToken] (uses the orchestrator).
+     * When non-empty, calls the token endpoint directly — each call is a new network request.
+     *
+     * @param extraRequestParameters additional form parameters forwarded to the token endpoint.
+     * @return [Result.success] with a new [CredentialImpl] snapshot, or [Result.failure].
+     */
+    override suspend fun refreshToken(extraRequestParameters: Map<String, String>): Result<Credential> {
+        if (extraRequestParameters.isEmpty()) return refreshToken()
+        return runCatching {
+            val refreshTokenStr =
+                token.refreshToken ?: throw IllegalStateException("No refresh token available.")
+            val newToken = client.refreshToken(refreshTokenStr, extraRequestParameters).getOrThrow()
+            replaceToken(newToken)
+        }
+    }
+
     private suspend fun performRealRefresh(): Result<TokenInfo> {
         val refreshTokenStr =
             token.refreshToken ?: return Result.failure(

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/jwt/EcSignatureVerifier.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/jwt/EcSignatureVerifier.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.jwt
+
+/**
+ * Verifies an EC signature using the given public key coordinates and curve.
+ *
+ * @param x the X coordinate of the EC public key (decoded from JWK base64url `x` field).
+ * @param y the Y coordinate of the EC public key (decoded from JWK base64url `y` field).
+ * @param crv the curve name from the JWK `crv` field (e.g. `"P-256"`, `"P-384"`, `"P-521"`).
+ * @param data the signed data (the JWT header.payload bytes).
+ * @param signature the raw P1363-encoded ECDSA signature (decoded from JWT signature field).
+ * @return `true` if the signature is valid, `false` otherwise.
+ */
+internal expect fun verifyEcSignature(
+    x: ByteArray,
+    y: ByteArray,
+    crv: String,
+    data: ByteArray,
+    signature: ByteArray,
+): Boolean

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/jwt/Jwks.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/jwt/Jwks.kt
@@ -33,6 +33,9 @@ class Jwks internal constructor(
         val algorithm: String?,
         val exponent: String?,
         val modulus: String?,
+        val x: String? = null,
+        val y: String? = null,
+        val crv: String? = null,
     ) {
         internal fun toSerializableJwksKey(): SerializableJwks.Key =
             SerializableJwks.Key(
@@ -41,7 +44,10 @@ class Jwks internal constructor(
                 modulus = modulus,
                 keyId = keyId,
                 keyType = keyType,
-                use = use
+                use = use,
+                x = x,
+                y = y,
+                crv = crv
             )
     }
 
@@ -58,8 +64,11 @@ internal class SerializableJwks(
         @SerialName("use") val use: String,
         @SerialName("kty") val keyType: String,
         @SerialName("alg") val algorithm: String? = if (keyType == "RSA") "RS256" else null,
-        @SerialName("e") val exponent: String?,
-        @SerialName("n") val modulus: String?,
+        @SerialName("e") val exponent: String? = null,
+        @SerialName("n") val modulus: String? = null,
+        @SerialName("x") val x: String? = null,
+        @SerialName("y") val y: String? = null,
+        @SerialName("crv") val crv: String? = null,
     ) {
         fun toJwksKey(): Jwks.Key =
             Jwks.Key(
@@ -68,7 +77,10 @@ internal class SerializableJwks(
                 modulus = modulus,
                 keyId = keyId,
                 keyType = keyType,
-                use = use
+                use = use,
+                x = x,
+                y = y,
+                crv = crv
             )
     }
 

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/jwt/Jwt.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/jwt/Jwt.kt
@@ -59,15 +59,29 @@ class Jwt internal constructor(
         return withContext(computeDispatcher) {
             val key = jwks.keys.firstOrNull { it.keyId == keyId } ?: return@withContext false
             if (key.use != "sig") return@withContext false
-            if (key.keyType != "RSA") return@withContext false
-            if (key.algorithm != "RS256") return@withContext false
 
-            val modulus = key.modulus?.decodeBase64UrlOrNull() ?: return@withContext false
-            val exponent = key.exponent?.decodeBase64UrlOrNull() ?: return@withContext false
             val jwtContentBytes = rawValue.substringBeforeLast('.').toByteArray()
             val signatureBytes = signature.decodeBase64UrlOrNull() ?: return@withContext false
 
-            verifyRs256Signature(modulus, exponent, jwtContentBytes, signatureBytes)
+            when (key.keyType) {
+                "RSA" -> {
+                    if (key.algorithm != "RS256") return@withContext false
+                    val modulus = key.modulus?.decodeBase64UrlOrNull() ?: return@withContext false
+                    val exponent = key.exponent?.decodeBase64UrlOrNull() ?: return@withContext false
+                    verifyRs256Signature(modulus, exponent, jwtContentBytes, signatureBytes)
+                }
+
+                "EC" -> {
+                    val crv = key.crv ?: return@withContext false
+                    val x = key.x?.decodeBase64UrlOrNull() ?: return@withContext false
+                    val y = key.y?.decodeBase64UrlOrNull() ?: return@withContext false
+                    verifyEcSignature(x, y, crv, jwtContentBytes, signatureBytes)
+                }
+
+                else -> {
+                    false
+                }
+            }
         }
     }
 }

--- a/auth-foundation/src/commonTest/kotlin/com/okta/authfoundation/client/OAuth2EndpointOverridesTest.kt
+++ b/auth-foundation/src/commonTest/kotlin/com/okta/authfoundation/client/OAuth2EndpointOverridesTest.kt
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.client
+
+import com.okta.authfoundation.InternalAuthFoundationApi
+import com.okta.authfoundation.api.http.ApiExecutor
+import com.okta.authfoundation.api.http.ApiRequest
+import com.okta.authfoundation.api.http.ApiResponse
+import com.okta.authfoundation.client.internal.OAuth2Endpoints
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(InternalAuthFoundationApi::class)
+class OAuth2EndpointOverridesTest {
+    private val issuerUrl = "https://example.okta.com/oauth2/default"
+
+    // ── allFieldsNonNull ───────────────────────────────────────────────────────
+
+    @Test
+    fun allFieldsNonNull_whenNull_returnsFalse() {
+        assertFalse(OAuth2Endpoints.allFieldsNonNull(null))
+    }
+
+    @Test
+    fun allFieldsNonNull_whenPartial_returnsFalse() {
+        val partial = OAuth2EndpointOverrides(tokenEndpoint = "https://example.com/token")
+        assertFalse(OAuth2Endpoints.allFieldsNonNull(partial))
+    }
+
+    @Test
+    fun allFieldsNonNull_whenAllSet_returnsTrue() {
+        val full = fullOverrides()
+        assertTrue(OAuth2Endpoints.allFieldsNonNull(full))
+    }
+
+    // ── merge ──────────────────────────────────────────────────────────────────
+
+    @Test
+    fun merge_withNull_returnsOriginal() {
+        val endpoints = discoveredEndpoints()
+        val merged = endpoints.merge(null)
+        assertEquals(endpoints.tokenEndpoint, merged.tokenEndpoint)
+        assertEquals(endpoints.authorizationEndpoint, merged.authorizationEndpoint)
+    }
+
+    @Test
+    fun merge_withPartialOverrides_overridesOnlySpecifiedFields() {
+        val endpoints = discoveredEndpoints()
+        val override = OAuth2EndpointOverrides(tokenEndpoint = "https://proxy.example.com/token")
+        val merged = endpoints.merge(override)
+        assertEquals("https://proxy.example.com/token", merged.tokenEndpoint)
+        // Non-overridden fields keep their discovered values
+        assertEquals(endpoints.authorizationEndpoint, merged.authorizationEndpoint)
+        assertEquals(endpoints.userInfoEndpoint, merged.userInfoEndpoint)
+    }
+
+    @Test
+    fun merge_withFullOverrides_replacesAllFields() {
+        val endpoints = discoveredEndpoints()
+        val overrides = fullOverrides()
+        val merged = endpoints.merge(overrides)
+        assertEquals("https://override.example.com/authorize", merged.authorizationEndpoint)
+        assertEquals("https://override.example.com/token", merged.tokenEndpoint)
+        assertEquals("https://override.example.com/userinfo", merged.userInfoEndpoint)
+        assertEquals("https://override.example.com/keys", merged.jwksUri)
+        assertEquals("https://override.example.com/introspect", merged.introspectionEndpoint)
+        assertEquals("https://override.example.com/revoke", merged.revocationEndpoint)
+        assertEquals("https://override.example.com/logout", merged.endSessionEndpoint)
+        assertEquals("https://override.example.com/device", merged.deviceAuthorizationEndpoint)
+    }
+
+    // ── Builder validation ─────────────────────────────────────────────────────
+
+    @Test
+    fun endpointOverrides_Null_BehaviorUnchanged() {
+        val result =
+            OAuth2ClientBuilder.create(
+                issuerUrl = issuerUrl,
+                clientId = "client-id",
+                scope = listOf("openid")
+            ) {
+                endpointOverrides = null
+            }
+        assertTrue(result.isSuccess)
+        assertNull(result.getOrThrow().configuration.endpointOverrides)
+    }
+
+    @Test
+    fun endpointOverrides_MalformedUrl_ThrowsIllegalArgument() {
+        val result =
+            OAuth2ClientBuilder.create(
+                issuerUrl = issuerUrl,
+                clientId = "client-id",
+                scope = listOf("openid")
+            ) {
+                endpointOverrides = OAuth2EndpointOverrides(tokenEndpoint = "not-a-url")
+            }
+        assertTrue(result.isFailure)
+        assertIs<IllegalArgumentException>(result.exceptionOrNull())
+        assertTrue(result.exceptionOrNull()!!.message!!.contains("tokenEndpoint"))
+    }
+
+    @Test
+    fun endpointOverrides_HttpUrl_ThrowsIllegalArgument() {
+        val result =
+            OAuth2ClientBuilder.create(
+                issuerUrl = issuerUrl,
+                clientId = "client-id",
+                scope = listOf("openid")
+            ) {
+                endpointOverrides = OAuth2EndpointOverrides(tokenEndpoint = "http://insecure.example.com/token")
+            }
+        assertTrue(result.isFailure)
+        assertIs<IllegalArgumentException>(result.exceptionOrNull())
+    }
+
+    @Test
+    fun endpointOverrides_ValidPartialOverride_Stored() {
+        val result =
+            OAuth2ClientBuilder.create(
+                issuerUrl = issuerUrl,
+                clientId = "client-id",
+                scope = listOf("openid")
+            ) {
+                endpointOverrides = OAuth2EndpointOverrides(tokenEndpoint = "https://proxy.example.com/token")
+            }
+        assertTrue(result.isSuccess)
+        val config = result.getOrThrow().configuration
+        assertNotNull(config.endpointOverrides)
+        assertEquals("https://proxy.example.com/token", config.endpointOverrides!!.tokenEndpoint)
+    }
+
+    // ── Discovery skip ─────────────────────────────────────────────────────────
+
+    @Test
+    fun endpointOverrides_AllFieldsSet_DiscoverySkipped() =
+        runTest {
+            // Use a failing executor — if discovery is attempted, the test will fail
+            var discoveryCallCount = 0
+            val failingExecutor =
+                object : ApiExecutor {
+                    override suspend fun execute(request: ApiRequest): Result<ApiResponse> {
+                        discoveryCallCount++
+                        return Result.failure(IllegalStateException("Discovery should not be called"))
+                    }
+                }
+
+            val result =
+                OAuth2ClientBuilder.create(
+                    issuerUrl = issuerUrl,
+                    clientId = "client-id",
+                    scope = listOf("openid")
+                ) {
+                    apiExecutor = failingExecutor
+                    endpointOverrides = fullOverrides()
+                }
+            assertTrue(result.isSuccess)
+
+            // Trigger endpoint resolution
+            val client = result.getOrThrow()
+            val endpoints = client.endpointsOrNull()
+
+            // Discovery was never called because all overrides were provided
+            assertEquals(0, discoveryCallCount)
+            assertNotNull(endpoints)
+            assertEquals("https://override.example.com/token", endpoints.tokenEndpoint)
+        }
+
+    // ── Helpers ────────────────────────────────────────────────────────────────
+
+    private fun discoveredEndpoints(): OAuth2Endpoints =
+        OAuth2Endpoints(
+            issuer = issuerUrl,
+            authorizationEndpoint = "https://example.okta.com/oauth2/default/v1/authorize",
+            tokenEndpoint = "https://example.okta.com/oauth2/default/v1/token",
+            userInfoEndpoint = "https://example.okta.com/oauth2/default/v1/userinfo",
+            jwksUri = "https://example.okta.com/oauth2/default/v1/keys",
+            introspectionEndpoint = "https://example.okta.com/oauth2/default/v1/introspect",
+            revocationEndpoint = "https://example.okta.com/oauth2/default/v1/revoke",
+            endSessionEndpoint = "https://example.okta.com/oauth2/default/v1/logout",
+            deviceAuthorizationEndpoint = null
+        )
+
+    private fun fullOverrides(): OAuth2EndpointOverrides =
+        OAuth2EndpointOverrides(
+            authorizationEndpoint = "https://override.example.com/authorize",
+            tokenEndpoint = "https://override.example.com/token",
+            userInfoEndpoint = "https://override.example.com/userinfo",
+            jwksUri = "https://override.example.com/keys",
+            introspectionEndpoint = "https://override.example.com/introspect",
+            revocationEndpoint = "https://override.example.com/revoke",
+            endSessionEndpoint = "https://override.example.com/logout",
+            deviceAuthorizationEndpoint = "https://override.example.com/device"
+        )
+}

--- a/auth-foundation/src/commonTest/kotlin/com/okta/authfoundation/credential/kmp/CredentialKmpTest.kt
+++ b/auth-foundation/src/commonTest/kotlin/com/okta/authfoundation/credential/kmp/CredentialKmpTest.kt
@@ -484,6 +484,38 @@ class CredentialKmpTest {
             assertTrue(result.isFailure)
         }
 
+    @Test
+    fun refreshToken_WithExtraParams_NoRefreshToken_Fails() =
+        runTest {
+            val credential = createCredential(refreshToken = null)
+            val result = credential.refreshToken(mapOf("acr_values" to "urn:okta:loa:2fa:any"))
+            assertTrue(result.isFailure)
+            assertIs<IllegalStateException>(result.exceptionOrNull())
+        }
+
+    @Test
+    fun refreshToken_EmptyExtraParams_DelegatesToNoArgOverload() =
+        runTest {
+            // Empty map should delegate to the orchestrated refreshToken()
+            val credential = createCredential(refreshToken = "valid-rt")
+            val result = credential.refreshToken(emptyMap())
+            // Fails because NoOpApiExecutor returns failure — same behavior as no-arg overload
+            assertTrue(result.isFailure)
+        }
+
+    @Test
+    fun refreshToken_WithExtraParams_BypassesOrchestrator() =
+        runTest {
+            // When extra params are provided, the orchestrator is bypassed and a direct call is made.
+            // The NoOpApiExecutor always fails — so both paths fail — but we can verify the non-empty
+            // map path does NOT throw IllegalStateException (no-refresh-token error).
+            val credential = createCredential(refreshToken = "valid-rt")
+            val result = credential.refreshToken(mapOf("acr_values" to "urn:okta:loa:2fa:any"))
+            // Should fail with network error (not "No refresh token" error)
+            assertTrue(result.isFailure)
+            assertTrue(result.exceptionOrNull() !is IllegalStateException)
+        }
+
     // --- idToken tests ---
 
     @Test

--- a/auth-foundation/src/jvmMain/kotlin/com/okta/authfoundation/client/jvm/OAuth2ClientBuilder.kt
+++ b/auth-foundation/src/jvmMain/kotlin/com/okta/authfoundation/client/jvm/OAuth2ClientBuilder.kt
@@ -45,6 +45,7 @@ class OAuth2ClientBuilder(
     private var authorizationServerId: String? = null
     private var clientSecret: String? = null
     private var acrValues: String? = null
+    private var endpointOverrides: com.okta.authfoundation.client.OAuth2EndpointOverrides? = null
 
     /**
      * Sets the HTTP executor used for all network requests.
@@ -135,6 +136,21 @@ class OAuth2ClientBuilder(
         }
 
     /**
+     * Sets optional per-endpoint URL overrides.
+     *
+     * When provided, each non-null field in [overrides] replaces the corresponding URL from
+     * the OpenID Connect discovery document. When all 8 fields are non-null, the discovery
+     * HTTP call is skipped entirely. All non-null values must be valid HTTPS URLs.
+     *
+     * @param overrides The [OAuth2EndpointOverrides] to apply.
+     * @return This builder for chaining.
+     */
+    fun setEndpointOverrides(overrides: com.okta.authfoundation.client.OAuth2EndpointOverrides): com.okta.authfoundation.client.jvm.OAuth2ClientBuilder =
+        apply {
+            this.endpointOverrides = overrides
+        }
+
+    /**
      * Creates an [OAuth2Client] instance with the configured parameters.
      *
      * @return A [AuthFoundationResult] containing the [OAuth2Client] on success, or an exception on failure.
@@ -150,6 +166,7 @@ class OAuth2ClientBuilder(
                 this@OAuth2ClientBuilder.authorizationServerId?.let { authorizationServerId = it }
                 this@OAuth2ClientBuilder.clientSecret?.let { clientSecret = it }
                 this@OAuth2ClientBuilder.acrValues?.let { acrValues = it }
+                this@OAuth2ClientBuilder.endpointOverrides?.let { endpointOverrides = it }
             }
         return AuthFoundationResult.fromKotlinResult(kotlinResult)
     }

--- a/auth-foundation/src/jvmMain/kotlin/com/okta/authfoundation/jwt/EcSignatureVerifier.kt
+++ b/auth-foundation/src/jvmMain/kotlin/com/okta/authfoundation/jwt/EcSignatureVerifier.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.jwt
+
+import com.okta.authfoundation.api.log.LogLevel
+import com.okta.authfoundation.api.log.getDefaultAuthFoundationLogger
+import java.math.BigInteger
+import java.security.AlgorithmParameters
+import java.security.KeyFactory
+import java.security.Signature
+import java.security.spec.ECGenParameterSpec
+import java.security.spec.ECParameterSpec
+import java.security.spec.ECPoint
+import java.security.spec.ECPublicKeySpec
+
+private val logger = getDefaultAuthFoundationLogger()
+
+internal actual fun verifyEcSignature(
+    x: ByteArray,
+    y: ByteArray,
+    crv: String,
+    data: ByteArray,
+    signature: ByteArray,
+): Boolean =
+    try {
+        val curveName =
+            when (crv) {
+                "P-256" -> "secp256r1"
+                "P-384" -> "secp384r1"
+                "P-521" -> "secp521r1"
+                else -> return false
+            }
+        val jcaAlg =
+            when (crv) {
+                "P-256" -> "SHA256withECDSAinP1363Format"
+                "P-384" -> "SHA384withECDSAinP1363Format"
+                "P-521" -> "SHA512withECDSAinP1363Format"
+                else -> return false
+            }
+
+        val ecPoint = ECPoint(BigInteger(1, x), BigInteger(1, y))
+        val ecParams =
+            AlgorithmParameters.getInstance("EC").run {
+                init(ECGenParameterSpec(curveName))
+                getParameterSpec(ECParameterSpec::class.java)
+            }
+        val publicKey = KeyFactory.getInstance("EC").generatePublic(ECPublicKeySpec(ecPoint, ecParams))
+
+        Signature.getInstance(jcaAlg).run {
+            initVerify(publicKey)
+            update(data)
+            verify(signature)
+        }
+    } catch (e: Exception) {
+        logger.write("EC signature verification failed", tr = e, logLevel = LogLevel.WARN)
+        false
+    }


### PR DESCRIPTION
EC Key JWT Signature Validation
- Add x, y, crv fields to Jwks.Key and SerializableJwks.Key
- Add EcDerUtils.kt: pure-Kotlin P1363→DER converter (handles P-521 long-form)
- Add EcSignatureVerifier expect/actual (commonMain + androidMain + jvmMain)
- Update Jwt.hasValidSignature() with when(key.keyType) dispatch for RSA + EC
- Supports ES256 (P-256), ES384 (P-384), ES512 (P-521)

refreshToken Extra Request Parameters
- Add OAuth2Client.refreshToken(String, Map<String,String>) overload
- Add Credential.refreshToken(Map<String,String>) interface method with default impl
- CredentialImpl override: empty map delegates to orchestrator, non-empty bypasses it
- Reserved keys (grant_type, client_id, refresh_token) silently filtered Android-only legacy stack:
- OAuth2Client.refreshToken(Token): now delegates to new overload
- OAuth2Client.refreshToken(Token, Map<String,String>): adds extra params to the FormBody, filtering reserved keys (grant_type, client_id, refresh_token)
- Credential.refreshToken(Map<String,String>): bypasses coalescing orchestrator when extraRequestParameters is non-empty

Custom Endpoint Overrides
- Add OAuth2EndpointOverrides public class with 8 nullable String fields
- Add endpointOverrides to OAuth2ClientConfiguration and OAuth2ClientBuilder
- Builder validates each non-null override field is a valid HTTPS URL
- EndpointDiscovery: skip HTTP call when all 8 overrides set; merge partial overrides
- Add OAuth2Endpoints.merge() and allFieldsNonNull() helpers
- Expose setEndpointOverrides() in JVM OAuth2ClientBuilder Android-only legacy stack:
- OidcConfiguration: added endpointOverrides field (@Transient, nullable) and a new secondary constructor(clientId, defaultScope, issuer, endpointOverrides)
- EndpointsFactory: skip discovery when all 8 override fields are non-null; merge partial overrides on top of discovered OidcEndpoints after fetch

RESOLVES: OKTA-1179260