### PR TITLE
Fix step-up redirect race condition in DefaultRedirectCoordinator

### DIFF
--- a/web-authentication-ui/api/web-authentication-ui.api
+++ b/web-authentication-ui/api/web-authentication-ui.api
@@ -63,6 +63,9 @@ public final class com/okta/webauthenticationui/WebAuthentication {
 public final class com/okta/webauthenticationui/WebAuthentication$Companion {
 }
 
+public final class com/okta/webauthenticationui/WebAuthentication$FlowAlreadyInProgressException : java/lang/Exception {
+}
+
 public final class com/okta/webauthenticationui/WebAuthentication$FlowCancelledException : java/lang/Exception {
 }
 

--- a/web-authentication-ui/src/main/java/com/okta/webauthenticationui/RedirectCoordinator.kt
+++ b/web-authentication-ui/src/main/java/com/okta/webauthenticationui/RedirectCoordinator.kt
@@ -30,6 +30,8 @@ import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import okhttp3.HttpUrl
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.resume
@@ -53,22 +55,29 @@ internal class DefaultRedirectCoordinator(
 
     private var emitErrorJob: Job? = null
 
+    private val flowMutex = Mutex()
+
+    @Volatile private var isFlowActive = false
+
     @Suppress("UNCHECKED_CAST")
     override suspend fun <T> initialize(
         webAuthenticationProvider: WebAuthenticationProvider,
         context: Context,
         initializer: suspend () -> RedirectInitializationResult<T>,
     ): RedirectInitializationResult<T> {
-        if (!currentCoroutineContext().isActive) {
-            reset()
-        }
         currentCoroutineContext().ensureActive()
-
-        this.webAuthenticationProvider = webAuthenticationProvider
-        this.initializer = initializer
+        flowMutex.withLock {
+            if (isFlowActive) {
+                return RedirectInitializationResult.Error(WebAuthentication.FlowAlreadyInProgressException())
+            }
+            isFlowActive = true
+            this.webAuthenticationProvider = webAuthenticationProvider
+            this.initializer = initializer
+        }
 
         if (context is ComponentActivity) {
             if (!context.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
+                reset()
                 return RedirectInitializationResult.Error(IllegalStateException("Activity is not resumed."))
             }
         }
@@ -157,6 +166,7 @@ internal class DefaultRedirectCoordinator(
 
     // Nulls all instance variables.
     private fun reset() {
+        isFlowActive = false
         initializationContinuation = null
         initializerContinuationListeningCallback = null
         initializer = null

--- a/web-authentication-ui/src/main/java/com/okta/webauthenticationui/WebAuthentication.kt
+++ b/web-authentication-ui/src/main/java/com/okta/webauthenticationui/WebAuthentication.kt
@@ -90,6 +90,14 @@ class WebAuthentication(
     class FlowCancelledException internal constructor() : Exception("Flow cancelled.")
 
     /**
+     * Used in a [OAuth2ClientResult.Error.exception].
+     *
+     * Indicates that [login] or [logoutOfBrowser] was called while another flow was already in
+     * progress. Only one redirect flow can be active at a time.
+     */
+    class FlowAlreadyInProgressException internal constructor() : Exception("Another flow is already in progress.")
+
+    /**
      * Initiates the OIDC Authorization Code redirect flow.
      *
      * @param context the Android [Activity] [Context] which is used to display the login flow via the configured

--- a/web-authentication-ui/src/test/java/com/okta/webauthenticationui/RedirectCoordinatorTest.kt
+++ b/web-authentication-ui/src/test/java/com/okta/webauthenticationui/RedirectCoordinatorTest.kt
@@ -356,6 +356,29 @@ class RedirectCoordinatorTest {
             assertThat(foregroundActivity).isNull()
         }
 
+    @Test fun testInitializeReturnsErrorWhenFlowAlreadyActive(): Unit =
+        testScope.runTest {
+            val initializerCountDownLatch = CountDownLatch(1)
+            subject.initializerContinuationListeningCallback = {
+                initializerCountDownLatch.countDown()
+            }
+            val firstJob =
+                launch(Dispatchers.IO) {
+                    subject.initialize(mock(), mock()) {
+                        RedirectInitializationResult.Success(mock(), Any())
+                    }
+                }
+            assertThat(initializerCountDownLatch.await(1, TimeUnit.SECONDS)).isTrue()
+            val concurrentResult =
+                subject.initialize(mock(), mock()) {
+                    RedirectInitializationResult.Success(mock(), Any())
+                }
+            assertThat(concurrentResult).isInstanceOf(RedirectInitializationResult.Error::class.java)
+            val error = concurrentResult as RedirectInitializationResult.Error
+            assertThat(error.exception).isInstanceOf(WebAuthentication.FlowAlreadyInProgressException::class.java)
+            firstJob.cancel()
+        }
+
     @Test fun testListenForRedirectDoesNothingWhenCancelled(): Unit =
         testScope.runTest {
             val startedCountDownLatch = CountDownLatch(1)


### PR DESCRIPTION
SingletonRedirectCoordinator is a global singleton. When initialize() was called concurrently (e.g. step-up auth triggered while primary auth was in progress), the second call silently overwrote the first flow's continuations, causing the primary flow to be dropped.

Added a Mutex-guarded isFlowActive flag: a second concurrent call to initialize() now returns RedirectInitializationResult.Error immediately instead of clobbering the in-flight flow's state.

Added test: testInitializeReturnsErrorWhenFlowAlreadyActive

Fixes: https://github.com/okta/okta-mobile-kotlin/issues/235
RESOLVES: OKTA-1209107