### PR TITLE
Fix NPE when getCertificate() returns null in TokenEncryptionHandler

### DIFF
--- a/auth-foundation/src/androidDeviceTest/kotlin/com/okta/authfoundation/credential/DefaultTokenEncryptionHandlerTest.kt
+++ b/auth-foundation/src/androidDeviceTest/kotlin/com/okta/authfoundation/credential/DefaultTokenEncryptionHandlerTest.kt
@@ -15,6 +15,7 @@
  */
 package com.okta.authfoundation.credential
 
+import android.security.keystore.KeyPermanentlyInvalidatedException
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import com.okta.authfoundation.client.OidcConfiguration
@@ -71,6 +72,15 @@ internal class DefaultTokenEncryptionHandlerTest {
                     defaultSecurity
                 )
             assertThat(decryptionResult).isEqualTo(token)
+        }
+
+    @Test fun encryptThrowsKeyPermanentlyInvalidatedException_whenKeyDeletedAfterGeneration() =
+        runTest {
+            tokenEncryptionHandler.generateKey(defaultSecurity)
+            tokenEncryptionHandler.keyStore.deleteEntry(defaultSecurity.keyAlias)
+            assertFailsWith<KeyPermanentlyInvalidatedException> {
+                tokenEncryptionHandler.encrypt(token, defaultSecurity)
+            }
         }
 
     @Test fun decryptingBioTokenWithNoPromptFails() =

--- a/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/credential/TokenEncryptionHandler.kt
+++ b/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/credential/TokenEncryptionHandler.kt
@@ -204,14 +204,14 @@ class DefaultTokenEncryptionHandler(
         token: Token,
         security: Credential.Security,
     ): TokenEncryptionHandler.EncryptionResult {
-        val publicRsaKey =
-            keyStore.getCertificate(security.keyAlias).publicKey.let {
-                // workaround for using public key from
-                // https://developer.android.com/reference/android/security/keystore/KeyGenParameterSpec.html#known-issues
-                KeyFactory
-                    .getInstance(it.algorithm)
-                    .generatePublic(X509EncodedKeySpec(it.encoded))
-            }
+        val publicRsaKey = keyStore.getCertificate(security.keyAlias)?.publicKey ?: throw KeyPermanentlyInvalidatedException()
+
+        // workaround for using public key from
+        // https://developer.android.com/reference/android/security/keystore/KeyGenParameterSpec.html#known-issues
+        KeyFactory
+            .getInstance(publicRsaKey.algorithm)
+            .generatePublic(X509EncodedKeySpec(publicRsaKey.encoded))
+
         val aesKey = aesKeyGenerator.generateKey()
         val encryptionExtras = mutableMapOf<String, String>()
 


### PR DESCRIPTION
KeyStore.getCertificate() returns null when a key alias no longer exists (e.g. after lock screen credential change or factory reset). The chained .publicKey call then throws NPE. Changed to null-safe ?.publicKey with a fallback throw of KeyPermanentlyInvalidatedException, which callers already handle in the decrypt path.

Fixes: https://github.com/okta/okta-mobile-kotlin/issues/332
RESOLVES: OKTA-1209101