### PR TITLE
Fix uncaught ProviderException in AndroidKeystoreUtil.getOrCreateAesKey

### DIFF
--- a/auth-foundation/src/androidHostTest/kotlin/com/okta/authfoundation/credential/DefaultCredentialIdDataStoreTest.kt
+++ b/auth-foundation/src/androidHostTest/kotlin/com/okta/authfoundation/credential/DefaultCredentialIdDataStoreTest.kt
@@ -63,7 +63,7 @@ class DefaultCredentialIdDataStoreTest {
     fun `getDefaultCredentialId returns the token id provided in setDefaultTokenId`() =
         runTest {
             val tokenId = "tokenId"
-            defaultCredentialIdDataStore.setDefaultCredentialId(tokenId)
+            defaultCredentialIdDataStore.setDefaultCredentialId(tokenId).getOrThrow()
             assertThat(defaultCredentialIdDataStore.getDefaultCredentialId()).isEqualTo(tokenId)
             coVerify { AuthFoundation.initializeStorage() }
         }
@@ -73,8 +73,8 @@ class DefaultCredentialIdDataStoreTest {
         runTest {
             val oldTokenId = "oldTokenId"
             val newTokenId = "newTokenId"
-            defaultCredentialIdDataStore.setDefaultCredentialId(oldTokenId)
-            defaultCredentialIdDataStore.setDefaultCredentialId(newTokenId)
+            defaultCredentialIdDataStore.setDefaultCredentialId(oldTokenId).getOrThrow()
+            defaultCredentialIdDataStore.setDefaultCredentialId(newTokenId).getOrThrow()
 
             assertThat(defaultCredentialIdDataStore.getDefaultCredentialId()).isEqualTo(newTokenId)
             coVerify { AuthFoundation.initializeStorage() }

--- a/auth-foundation/src/androidHostTest/kotlin/com/okta/authfoundation/util/AesEncryptionHandlerTest.kt
+++ b/auth-foundation/src/androidHostTest/kotlin/com/okta/authfoundation/util/AesEncryptionHandlerTest.kt
@@ -39,7 +39,7 @@ class AesEncryptionHandlerTest {
     fun setUp() {
         mockkObject(AndroidKeystoreUtil)
         keyGenerator = KeyGenerator.getInstance("AES")
-        every { AndroidKeystoreUtil.getOrCreateAesKey(any()) } returns keyGenerator.generateKey()
+        every { AndroidKeystoreUtil.getOrCreateAesKey(any()) } returns Result.success(keyGenerator.generateKey())
         mockEncryptionKeySpec = mockk(relaxed = true)
 
         aesEncryptionHandler = AesEncryptionHandler(mockEncryptionKeySpec)
@@ -53,7 +53,7 @@ class AesEncryptionHandlerTest {
     @Test
     fun `encrypt then decrypt string successfully`() {
         val testString = "testString"
-        val encryptedString = aesEncryptionHandler.encryptString(testString)
+        val encryptedString = aesEncryptionHandler.encryptString(testString).getOrThrow()
         assertThat(encryptedString).isNotEqualTo(testString)
 
         val decryptedString = aesEncryptionHandler.decryptString(encryptedString)
@@ -63,10 +63,10 @@ class AesEncryptionHandlerTest {
     @Test
     fun `encrypt then decrypt string with exception`() {
         val testString = "testString"
-        val encryptedString = aesEncryptionHandler.encryptString(testString)
+        val encryptedString = aesEncryptionHandler.encryptString(testString).getOrThrow()
         assertThat(encryptedString).isNotEqualTo(testString)
 
-        every { AndroidKeystoreUtil.getOrCreateAesKey(any()) } returns keyGenerator.generateKey() // wrong key
+        every { AndroidKeystoreUtil.getOrCreateAesKey(any()) } returns Result.success(keyGenerator.generateKey()) // wrong key
         val decryptedString = aesEncryptionHandler.decryptString(encryptedString)
         assertThat(decryptedString.isFailure).isTrue()
         assertThat(decryptedString.exceptionOrNull()).isInstanceOf(AEADBadTagException::class.java)

--- a/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/client/EncryptionTokenProvider.kt
+++ b/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/client/EncryptionTokenProvider.kt
@@ -64,8 +64,10 @@ internal class EncryptionTokenProvider(
         }
     }
 
-    private suspend fun setDeviceToken(deviceToken: String) =
+    private suspend fun setDeviceToken(deviceToken: String) {
+        val encrypted = aesEncryptionHandler.encryptString(deviceToken).getOrThrow()
         context.dataStore.edit { preferences ->
-            preferences[PREFERENCE_KEY] = aesEncryptionHandler.encryptString(deviceToken)
+            preferences[PREFERENCE_KEY] = encrypted
         }
+    }
 }

--- a/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/credential/Credential.kt
+++ b/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/credential/Credential.kt
@@ -152,6 +152,8 @@ class Credential internal constructor(
          * set to null to unset the default [Credential].
          *
          * > Note: This blocks on [setDefaultAsync] and [getDefaultAsync].
+         * > Setting this property may throw [java.security.ProviderException] if AES key generation
+         * > fails (see [setDefaultAsync]).
          */
         var default: Credential?
             get() =
@@ -168,10 +170,13 @@ class Credential internal constructor(
         /**
          * Sets the default [Credential] to provided [credential]. Unsets the default [Credential] if
          * [credential] is null.
+         *
+         * @throws java.security.ProviderException if the underlying AES key generation fails (e.g.
+         * StrongBox unavailable on certain OEM devices).
          */
         suspend fun setDefaultAsync(credential: Credential?) {
             credential?.let {
-                defaultCredentialIdDataStore.setDefaultCredentialId(credential.id)
+                defaultCredentialIdDataStore.setDefaultCredentialId(credential.id).getOrThrow()
                 AuthFoundationDefaults.eventCoordinator.sendEvent(
                     DefaultCredentialChangedEvent(
                         credential

--- a/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/credential/DefaultCredentialIdDataStore.kt
+++ b/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/credential/DefaultCredentialIdDataStore.kt
@@ -49,9 +49,12 @@ internal class DefaultCredentialIdDataStore(
         }
     }
 
-    suspend fun setDefaultCredentialId(id: String) =
-        context.dataStore.edit { preferences ->
-            preferences[PREFERENCE_KEY] = aesEncryptionHandler.encryptString(id)
+    suspend fun setDefaultCredentialId(id: String): Result<Unit> =
+        runCatching {
+            val encrypted = aesEncryptionHandler.encryptString(id).getOrThrow()
+            context.dataStore.edit { preferences ->
+                preferences[PREFERENCE_KEY] = encrypted
+            }
         }
 
     suspend fun clearDefaultCredentialId() =

--- a/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/credential/storage/migration/V1ToV2StorageMigrator.kt
+++ b/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/credential/storage/migration/V1ToV2StorageMigrator.kt
@@ -92,7 +92,7 @@ class V1ToV2StorageMigrator internal constructor(
             val metadata = Token.Metadata(entry.identifier, entry.tags, idToken)
             tokenStorage.add(entry.token, metadata)
             if (entry.isDefaultTokenEntry()) {
-                defaultCredentialIdDataStore.setDefaultCredentialId(entry.identifier)
+                defaultCredentialIdDataStore.setDefaultCredentialId(entry.identifier).getOrNull()
             }
         }
     }

--- a/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/util/AesEncryptionHandler.kt
+++ b/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/util/AesEncryptionHandler.kt
@@ -40,17 +40,18 @@ class AesEncryptionHandler(
         }
     }
 
-    fun encryptString(string: String): String {
-        val aesKey = AndroidKeystoreUtil.getOrCreateAesKey(encryptionKeySpec)
-        val cipher = getCipher().apply { init(Cipher.ENCRYPT_MODE, aesKey) }
-        val encryptedStringByteArray = cipher.doFinal(string.toByteArray())
-        val encryptedString = Base64.encodeToString(encryptedStringByteArray, Base64.NO_WRAP)
-        return Base64.encodeToString(cipher.iv, Base64.NO_WRAP) + SEPARATOR + encryptedString
-    }
+    fun encryptString(string: String): Result<String> =
+        runCatching {
+            val aesKey = AndroidKeystoreUtil.getOrCreateAesKey(encryptionKeySpec).getOrThrow()
+            val cipher = getCipher().apply { init(Cipher.ENCRYPT_MODE, aesKey) }
+            val encryptedStringByteArray = cipher.doFinal(string.toByteArray())
+            val encryptedString = Base64.encodeToString(encryptedStringByteArray, Base64.NO_WRAP)
+            Base64.encodeToString(cipher.iv, Base64.NO_WRAP) + SEPARATOR + encryptedString
+        }
 
     fun decryptString(encryptedString: String): Result<String> =
         runCatching {
-            val aesKey = AndroidKeystoreUtil.getOrCreateAesKey(encryptionKeySpec)
+            val aesKey = AndroidKeystoreUtil.getOrCreateAesKey(encryptionKeySpec).getOrThrow()
             val (ivBase64, encryptedAesStringBase64) = encryptedString.split(SEPARATOR, limit = 2)
             val iv = Base64.decode(ivBase64, Base64.NO_WRAP)
             val encryptedAesString = Base64.decode(encryptedAesStringBase64, Base64.NO_WRAP)

--- a/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/util/AndroidKeystoreUtil.kt
+++ b/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/util/AndroidKeystoreUtil.kt
@@ -43,13 +43,13 @@ object AndroidKeystoreUtil {
         keyStore.deleteEntry(alias)
     }
 
-    fun getOrCreateAesKey(keyGenParameterSpec: KeyGenParameterSpec): Key {
-        if (keyStore.containsAlias(keyGenParameterSpec.keystoreAlias)) {
-            return keyStore.getKey(keyGenParameterSpec.keystoreAlias, null)
+    fun getOrCreateAesKey(keyGenParameterSpec: KeyGenParameterSpec): Result<Key> =
+        runCatching {
+            if (keyStore.containsAlias(keyGenParameterSpec.keystoreAlias)) {
+                return@runCatching keyStore.getKey(keyGenParameterSpec.keystoreAlias, null)
+            }
+            val aesKeyGenerator = getAesKeyGenerator()
+            aesKeyGenerator.init(keyGenParameterSpec)
+            aesKeyGenerator.generateKey()
         }
-
-        val aesKeyGenerator = getAesKeyGenerator()
-        aesKeyGenerator.init(keyGenParameterSpec)
-        return aesKeyGenerator.generateKey()
-    }
 }

--- a/test-helpers/src/main/java/com/okta/testhelpers/MockAesEncryptionHandler.kt
+++ b/test-helpers/src/main/java/com/okta/testhelpers/MockAesEncryptionHandler.kt
@@ -26,8 +26,8 @@ import io.mockk.runs
 object MockAesEncryptionHandler {
     fun getInstance() =
         mockk<AesEncryptionHandler>().apply {
-            every { encryptString(any()) } returnsArgument 0
-            every { decryptString(any()) } returnsArgument 0
+            every { encryptString(any()) } answers { Result.success(firstArg()) }
+            every { decryptString(any()) } answers { Result.success(firstArg()) }
             every { resetEncryptionKey() } just runs
         }
 }


### PR DESCRIPTION
aesKeyGenerator.generateKey() can throw ProviderException (including StrongBoxUnavailableException) on certain OEM devices and Android 10 and below. Wrapped the method body in runCatching and changed return type to Result<Key> so callers can handle the failure explicitly.

AesEncryptionHandler.encryptString return type updated to Result<String> accordingly; callers in DefaultCredentialIdDataStore and EncryptionTokenProvider use .getOrThrow() to preserve throw-on-failure semantics. Test mocks updated to return Result.success().

Fixes: https://github.com/okta/okta-mobile-kotlin/issues/348
RESOLVES: OKTA-1209102