### PR TITLE
Add OAuth2 JVM flow demonstration to Java CLI sample

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,6 +57,7 @@ oktaAuthn = "3.0.0"
 oktaDirectAuth = "0.0.1"
 oktaLegacyOidc = "1.3.4"
 oktaManagement = "25.0.3"
+picocli = "4.7.6"
 protobufJava = "4.35.1"
 robolectric = "4.16.1"
 room = "2.8.4"
@@ -165,6 +166,7 @@ mockk-agent = { module = "io.mockk:mockk-agent", version.ref = "mockk" }
 mockk-android = { module = "io.mockk:mockk-android", version.ref = "mockk" }
 mockwebserver3 = { module = "com.squareup.okhttp3:mockwebserver3", version.ref = "okhttp" }
 navigation-fragment-ktx = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "navigation" }
+picocli = { module = "info.picocli:picocli", version.ref = "picocli" }
 navigation-safe-args-plugin = { module = "androidx.navigation:navigation-safe-args-gradle-plugin", version.ref = "navigation" }
 navigation-ui-ktx = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "navigation" }
 netty-codec-http = { module = "io.netty:netty-codec-http", version.ref = "netty" }

--- a/oauth2/api/jvm/oauth2.api
+++ b/oauth2/api/jvm/oauth2.api
@@ -82,12 +82,19 @@ public final class com/okta/oauth2/kmp/DeviceAuthorizationFlowContext {
 public final class com/okta/oauth2/kmp/LocalhostBrowserRedirectHandler : com/okta/oauth2/kmp/BrowserRedirectHandler {
 	public static final field Companion Lcom/okta/oauth2/kmp/LocalhostBrowserRedirectHandler$Companion;
 	public static final field DEFAULT_SUCCESS_RESPONSE Ljava/lang/String;
+	public fun <init> (ILjava/lang/String;)V
+	public fun <init> (ILjava/lang/String;J)V
+	public fun <init> (ILjava/lang/String;JLjava/lang/String;)V
 	public fun <init> (ILjava/lang/String;JLjava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public synthetic fun <init> (ILjava/lang/String;JLjava/lang/String;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (ILjava/lang/String;JLjava/lang/String;Ljava/util/function/Consumer;)Lcom/okta/oauth2/kmp/LocalhostBrowserRedirectHandler;
+	public static final fun create (ILjava/lang/String;Ljava/util/function/Consumer;)Lcom/okta/oauth2/kmp/LocalhostBrowserRedirectHandler;
 	public fun handleRedirect (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class com/okta/oauth2/kmp/LocalhostBrowserRedirectHandler$Companion {
+	public final fun create (ILjava/lang/String;JLjava/lang/String;Ljava/util/function/Consumer;)Lcom/okta/oauth2/kmp/LocalhostBrowserRedirectHandler;
+	public final fun create (ILjava/lang/String;Ljava/util/function/Consumer;)Lcom/okta/oauth2/kmp/LocalhostBrowserRedirectHandler;
 }
 
 public abstract interface class com/okta/oauth2/kmp/RedirectEndSessionFlow {

--- a/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/LocalhostBrowserRedirectHandler.kt
+++ b/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/LocalhostBrowserRedirectHandler.kt
@@ -23,6 +23,7 @@ import java.io.InputStreamReader
 import java.net.InetAddress
 import java.net.ServerSocket
 import java.net.URI
+import java.util.function.Consumer
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.time.Duration.Companion.milliseconds
@@ -43,74 +44,119 @@ import kotlin.time.Duration.Companion.milliseconds
  *   `"HTTP/1.1 302 Found\r\nLocation: https://app.example.com/done\r\n\r\n"`.
  * @param browserLauncher opens the given URL in a browser. Defaults to [Desktop.browse].
  */
-class LocalhostBrowserRedirectHandler(
-    private val port: Int,
-    private val path: String,
-    private val timeoutMs: Long = DEFAULT_TIMEOUT_MS,
-    private val successResponse: String = DEFAULT_SUCCESS_RESPONSE,
-    private val browserLauncher: (String) -> Unit = Companion::defaultBrowserLauncher,
-) : BrowserRedirectHandler {
-    override suspend fun handleRedirect(url: String): String =
-        withTimeout(timeoutMs.milliseconds) {
-            suspendCancellableCoroutine { continuation ->
-                val serverSocket = ServerSocket(port, 1, InetAddress.getLoopbackAddress())
+@Suppress("LongParameterList")
+class LocalhostBrowserRedirectHandler
+    @JvmOverloads
+    constructor(
+        private val port: Int,
+        private val path: String,
+        private val timeoutMs: Long = DEFAULT_TIMEOUT_MS,
+        private val successResponse: String = DEFAULT_SUCCESS_RESPONSE,
+        private val browserLauncher: (String) -> Unit = Companion::defaultBrowserLauncher,
+    ) : BrowserRedirectHandler {
+        override suspend fun handleRedirect(url: String): String =
+            withTimeout(timeoutMs.milliseconds) {
+                suspendCancellableCoroutine { continuation ->
+                    val serverSocket = ServerSocket(port, 1, InetAddress.getLoopbackAddress())
 
-                val thread =
-                    Thread {
-                        try {
-                            val socket = serverSocket.accept()
-                            val reader = BufferedReader(InputStreamReader(socket.getInputStream()))
-                            val requestLine = reader.readLine() ?: throw IllegalStateException("Empty request")
+                    val thread =
+                        Thread {
+                            try {
+                                val socket = serverSocket.accept()
+                                val reader = BufferedReader(InputStreamReader(socket.getInputStream()))
+                                val requestLine = reader.readLine() ?: throw IllegalStateException("Empty request")
 
-                            // Parse GET /callback?code=xxx&state=yyy HTTP/1.1
-                            val requestPath =
-                                requestLine.split(" ").getOrNull(1)
-                                    ?: throw IllegalStateException("Invalid request line: $requestLine")
+                                // Parse GET /callback?code=xxx&state=yyy HTTP/1.1
+                                val requestPath =
+                                    requestLine.split(" ").getOrNull(1)
+                                        ?: throw IllegalStateException("Invalid request line: $requestLine")
 
-                            if (!requestPath.startsWith(path)) {
-                                throw IllegalStateException("Unexpected path: $requestPath (expected: $path)")
+                                if (!requestPath.startsWith(path)) {
+                                    throw IllegalStateException("Unexpected path: $requestPath (expected: $path)")
+                                }
+
+                                val callbackUri = "http://localhost:$port$requestPath"
+
+                                socket.getOutputStream().write(successResponse.toByteArray())
+                                socket.close()
+
+                                continuation.resume(callbackUri)
+                            } catch (e: Exception) {
+                                if (continuation.isActive) {
+                                    continuation.resumeWithException(e)
+                                }
+                            } finally {
+                                runCatching { serverSocket.close() }
                             }
-
-                            val callbackUri = "http://localhost:$port$requestPath"
-
-                            socket.getOutputStream().write(successResponse.toByteArray())
-                            socket.close()
-
-                            continuation.resume(callbackUri)
-                        } catch (e: Exception) {
-                            if (continuation.isActive) {
-                                continuation.resumeWithException(e)
-                            }
-                        } finally {
-                            runCatching { serverSocket.close() }
                         }
+                    thread.isDaemon = true
+                    thread.start()
+
+                    continuation.invokeOnCancellation {
+                        runCatching { serverSocket.close() }
+                        thread.interrupt()
                     }
-                thread.isDaemon = true
-                thread.start()
 
-                continuation.invokeOnCancellation {
-                    runCatching { serverSocket.close() }
-                    thread.interrupt()
+                    browserLauncher(url)
                 }
-
-                browserLauncher(url)
             }
-        }
 
-    companion object {
-        private const val DEFAULT_TIMEOUT_MS = 300_000L // 5 minutes
+        companion object {
+            private const val DEFAULT_TIMEOUT_MS = 300_000L // 5 minutes
 
-        /** Default HTTP response sent to the browser after a successful redirect capture. */
-        const val DEFAULT_SUCCESS_RESPONSE: String =
-            "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n" +
-                "<html><body><h1>Authentication Complete</h1>" +
-                "<p>You can close this window.</p></body></html>"
+            /** Default HTTP response sent to the browser after a successful redirect capture. */
+            const val DEFAULT_SUCCESS_RESPONSE: String =
+                "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n" +
+                    "<html><body><h1>Authentication Complete</h1>" +
+                    "<p>You can close this window.</p></body></html>"
 
-        private fun defaultBrowserLauncher(url: String) {
-            if (!Desktop.isDesktopSupported() || !Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
-                throw UnsupportedOperationException("Desktop browser launch not supported on this platform")
+            /**
+             * Creates a [LocalhostBrowserRedirectHandler] with a Java-friendly
+             * [java.util.function.Consumer] browser launcher.
+             *
+             * Java usage:
+             * ```java
+             * LocalhostBrowserRedirectHandler handler =
+             *     LocalhostBrowserRedirectHandler.create(8080, "/callback", url -> myBrowser.open(url));
+             * ```
+             *
+             * @param port the port to listen on.
+             * @param path the expected callback path.
+             * @param browserLauncher a [Consumer] that opens the given URL in a browser.
+             * @return a new [LocalhostBrowserRedirectHandler]
+             */
+            @JvmStatic
+            fun create(
+                port: Int,
+                path: String,
+                browserLauncher: Consumer<String>,
+            ): LocalhostBrowserRedirectHandler = LocalhostBrowserRedirectHandler(port, path, browserLauncher = browserLauncher::accept)
+
+            /**
+             * Creates a [LocalhostBrowserRedirectHandler] with a custom timeout and
+             * Java-friendly [java.util.function.Consumer] browser launcher.
+             *
+             * @param port the port to listen on.
+             * @param path the expected callback path.
+             * @param timeoutMs maximum wait time in milliseconds.
+             * @param successResponse raw HTTP response written back to the browser on success.
+             * @param browserLauncher a [Consumer] that opens the given URL in a browser.
+             * @return a new [LocalhostBrowserRedirectHandler]
+             */
+            @JvmStatic
+            fun create(
+                port: Int,
+                path: String,
+                timeoutMs: Long,
+                successResponse: String,
+                browserLauncher: Consumer<String>,
+            ): LocalhostBrowserRedirectHandler = LocalhostBrowserRedirectHandler(port, path, timeoutMs, successResponse, browserLauncher::accept)
+
+            private fun defaultBrowserLauncher(url: String) {
+                if (!Desktop.isDesktopSupported() || !Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
+                    throw UnsupportedOperationException("Desktop browser launch not supported on this platform")
+                }
+                Desktop.getDesktop().browse(URI(url))
             }
-            Desktop.getDesktop().browse(URI(url))
         }
     }
-}

--- a/okta-direct-auth-java-cli-sample/README.md
+++ b/okta-direct-auth-java-cli-sample/README.md
@@ -1,27 +1,52 @@
-# Okta Direct Auth Java CLI Sample
+# Okta Auth Java CLI Sample
 
-A pure Java CLI application demonstrating the `okta-direct-auth` CompletableFuture API for direct authentication against an Okta org.
+A pure Java CLI application demonstrating two Okta authentication approaches:
+
+1. **Direct Authentication** — the `okta-direct-auth` CompletableFuture API (password, OTP, MFA, SSPR)
+2. **OAuth2 Flows** — all five OAuth2 standard flows via the `oauth2` module's Java-friendly wrappers
 
 ## Prerequisites
 
 - JDK 11 or later
-- An Okta org configured for [Direct Authentication](https://developer.okta.com/docs/guides/configure-direct-auth-grants/) with an OAuth 2.0 client
+- An Okta org with an OAuth 2.0 OIDC app configured for the flows you want to demo:
+  - **Direct Authentication**: enable [Direct Authentication grants](https://developer.okta.com/docs/guides/configure-direct-auth-grants/)
+  - **OAuth2 flows**: enable the matching grant types (see [Org Setup](#org-setup) below)
 
 ## Configuration
 
 Configuration values are resolved in this order:
 
-1. **CLI arguments** (`--issuer=`, `--clientId=`, `--authorizationServerId=`)
-2. **`local.properties`** in the project root (keys: `issuer`, `clientId`, `authorizationServerId`)
+1. **CLI arguments** (see [CLI Options](#cli-options))
+2. **`local.properties`** in the project root
 3. **Interactive prompt** (if neither of the above provides a value)
 
-Example `local.properties`:
+Example `local.properties` (same single Okta app for both modes):
 
 ```properties
 issuer=https://your-org.okta.com
 clientId=0oa...
 authorizationServerId=default
+desktopSignInRedirectUri=http://localhost:8080/callback
 ```
+
+`desktopSignInRedirectUri` defaults to `http://localhost:8080/callback` if not set. It is required for Browser Sign-In and Session Token flows.
+
+## Org Setup
+
+Org setup is identical to the current Direct Auth sample except for the OAuth2 additions:
+
+1. **Register the loopback redirect URI** `http://localhost:8080/callback` (or your configured `desktopSignInRedirectUri`) as a Sign-in redirect URI on the Okta app.
+2. **Enable the required grant types** on the Okta app for the flows you want to demo:
+
+   | Flow | Required grant type |
+   |---|---|
+   | Resource Owner Password | `password` |
+   | Device Authorization | `urn:ietf:params:oauth:grant-type:device_code` |
+   | Browser Sign-In | `authorization_code` (PKCE) |
+   | Token Exchange | `urn:ietf:params:oauth:grant-type:token-exchange` |
+   | Session Token | `authorization_code` (PKCE) + session token support |
+
+> **Note**: Tokens are displayed in-memory for demonstration purposes only and are not persisted.
 
 ## Build
 
@@ -37,10 +62,11 @@ Using the Gradle `run` task:
 ./gradlew :okta-direct-auth-java-cli-sample:run
 ```
 
-With arguments:
+With arguments (pre-select mode and format):
 
 ```bash
-./gradlew :okta-direct-auth-java-cli-sample:run --args="--issuer=https://your-org.okta.com --clientId=0oa... --format=decoded --verbose"
+./gradlew :okta-direct-auth-java-cli-sample:run --args="--mode=oauth2 --format=decoded"
+./gradlew :okta-direct-auth-java-cli-sample:run --args="--issuer=https://your-org.okta.com --clientId=0oa... --mode=direct"
 ```
 
 Using the distribution archive:
@@ -59,14 +85,28 @@ unzip okta-direct-auth-cli.zip
 | `--issuer=URL` | Okta issuer URL |
 | `--clientId=ID` | OAuth 2.0 client ID |
 | `--authorizationServerId=ID` | Authorization server ID (e.g., `default`) |
+| `--desktopSignInRedirectUri=URL` | Loopback redirect URI for OAuth2 redirect-based flows (default: `http://localhost:8080/callback`) |
+| `--mode=direct\|oauth2` | Pre-select demonstration mode (default: prompt at startup) |
 | `--format=raw\|decoded` | Token display format (default: `raw`) |
-| `--verbose` | Enable debug logging to stderr |
-| `--version`, `-v` | Show version and exit |
+| `--verbose`, `-v` | Enable debug logging to stderr |
+| `--version` | Show version and exit |
 | `--help`, `-h` | Show help and exit |
 
-## Usage Example
+## Usage Examples
 
-### Password sign-in
+### Mode selection
+
+On startup (without `--mode`), the CLI shows a top-level menu:
+
+```
+=== Okta Auth CLI ===
+[1] Direct Authentication
+[2] OAuth2 Flows
+[3] Exit
+Select option:
+```
+
+### Direct Authentication — password sign-in
 
 ```
 === Okta Direct Auth CLI ===
@@ -100,7 +140,56 @@ eyJraWQiOiJ...
 Press Enter to sign out...
 ```
 
-With `--format=decoded`, the success output shows parsed JWT claims instead of raw tokens:
+### OAuth2 — Resource Owner Password
+
+```
+=== OAuth2 Flows ===
+[1] Resource Owner Password
+[2] Device Authorization
+[3] Browser Sign-In (Auth Code + PKCE)
+[4] Token Exchange
+[5] Session Token
+[0] Back
+Select option: 1
+
+Username: user@example.com
+Password:
+
+=== Authentication Successful ===
+Access Token:
+eyJraWQiOiJ...
+...
+Press Enter to continue...
+```
+
+### OAuth2 — Device Authorization
+
+```
+Select option: 2
+
+=== Device Authorization ===
+Visit: https://your-org.okta.com/activate
+Enter code: ABCD-1234
+Code expires in 300 seconds. Waiting for approval...
+
+=== Authentication Successful ===
+...
+```
+
+### OAuth2 — Browser Sign-In
+
+```
+Select option: 3
+
+Opening browser for sign-in. Waiting for redirect...
+# System browser opens to Okta sign-in page.
+# After sign-in, the CLI captures the loopback redirect automatically.
+
+=== Authentication Successful ===
+...
+```
+
+With `--format=decoded`, success output shows parsed JWT claims:
 
 ```
 === Authentication Successful ===
@@ -109,37 +198,27 @@ Subject: 00u1example
 Name:    Test User
 Email:   user@example.com
 
-Press Enter to sign out...
-```
-
-### MFA sign-in
-
-When the Okta org requires a second factor, the CLI prompts for an MFA method after the primary factor succeeds:
-
-```
-MFA Required. Select method:
-[1] OTP
-[2] SMS
-[3] Voice
-[4] Push (Okta Verify)
-[0] Back to menu
-Select option: 1
-
-Enter verification code (or [0] to go back):
-Code: 123456
-
-=== Authentication Successful ===
-...
+Press Enter to continue...
 ```
 
 ## Features
 
+### Direct Authentication
 - **Password authentication** — Sign in with username and password
 - **MFA** — OTP, SMS, Voice, and Okta Verify push
 - **Device transfer with binding code** — Okta Verify number challenge
 - **Self-service password recovery (SSPR)** — Reset password via the MyAccount API
+
+### OAuth2 Flows (Java-friendly wrappers)
+- **Resource Owner Password** — `ResourceOwnerFlow`: sign in with username and password
+- **Device Authorization** — `DeviceAuthorizationFlow`: device-code flow with polling
+- **Browser Sign-In** — `AuthorizationCodeFlow` + `LocalhostBrowserRedirectHandler`: opens the system browser and captures the loopback redirect
+- **Token Exchange** — `TokenExchangeFlow`: exchange an existing ID token + device secret
+- **Session Token** — `SessionTokenFlow`: exchange a legacy session token
+
+### Shared
 - **JWT decoding** — View token claims with `--format=decoded`
-- **Username persistence** — Remembers your last username across sessions
+- **Username persistence** — Direct Auth mode remembers your last username across sessions
 
 ## Tests
 
@@ -148,6 +227,10 @@ Code: 123456
 ```
 
 ## Known Limitations
+
+### Browser Sign-In requires a desktop environment
+
+The `LocalhostBrowserRedirectHandler` uses `java.awt.Desktop` to open the system browser. It is not supported in headless server environments. If the configured loopback port is already in use, the CLI reports a clear error.
 
 ### Concurrent instances and username persistence
 

--- a/okta-direct-auth-java-cli-sample/build.gradle.kts
+++ b/okta-direct-auth-java-cli-sample/build.gradle.kts
@@ -39,6 +39,8 @@ val localProperties =
 val issuer = localProperties.getProperty("issuer") ?: ""
 val clientId = localProperties.getProperty("clientId") ?: ""
 val authorizationServerId = localProperties.getProperty("authorizationServerId") ?: ""
+val signInRedirectUri = localProperties.getProperty("signInRedirectUri") ?: ""
+val desktopSignInRedirectUri = localProperties.getProperty("desktopSignInRedirectUri") ?: ""
 
 val isCi = System.getenv("CI")?.toBoolean() ?: false
 if (!isCi && (issuer.isEmpty() || clientId.isEmpty() || authorizationServerId.isEmpty())) {
@@ -47,6 +49,8 @@ if (!isCi && (issuer.isEmpty() || clientId.isEmpty() || authorizationServerId.is
             "issuer=<your_issuer>\n" +
             "clientId=<your_client_id>\n" +
             "authorizationServerId=<your_authorization_server_id>\n" +
+            "signInRedirectUri=<android_custom_scheme_uri> (optional, for Android browser sign-in)\n" +
+            "desktopSignInRedirectUri=<localhost_uri> (optional, for JVM browser sign-in, e.g. http://localhost:8080/callback)\n" +
             "Direct Auth configuration: https://developer.okta.com/docs/guides/configure-direct-auth-grants"
     )
 }
@@ -64,12 +68,14 @@ val generateAppConfig =
             outputFile.writeText(
                 """
             |package com.okta.directauth.cli;
-            |       
+            |
             |public final class AppConfig {
             |  public static final String ISSUER = "$issuer";
             |  public static final String CLIENT_ID = "$clientId";
             |  public static final String AUTHORIZATION_SERVER_ID = "$authorizationServerId";
-            |  
+            |  public static final String SIGN_IN_REDIRECT_URI = "$signInRedirectUri";
+            |  public static final String DESKTOP_SIGN_IN_REDIRECT_URI = "$desktopSignInRedirectUri";
+            |
             |  private AppConfig() {}
             |}
                 """.trimMargin()
@@ -85,9 +91,12 @@ sourceSets {
 
 dependencies {
     implementation(project(":okta-direct-auth"))
+    implementation(project(":oauth2"))
     implementation(project(":auth-foundation"))
     implementation(libs.ktor.client.core)
     implementation(libs.jjwt.api)
+    implementation(libs.picocli)
+    runtimeOnly(libs.ktor.client.cio)
     runtimeOnly(libs.jjwt.impl)
     runtimeOnly(libs.jjwt.jackson)
     runtimeOnly(libs.slf4j.nop)

--- a/okta-direct-auth-java-cli-sample/src/main/java/com/okta/directauth/cli/Main.java
+++ b/okta-direct-auth-java-cli-sample/src/main/java/com/okta/directauth/cli/Main.java
@@ -15,87 +15,142 @@
  */
 package com.okta.directauth.cli;
 
+import com.okta.authfoundation.client.jvm.AuthFoundationResult;
+import com.okta.authfoundation.client.jvm.OAuth2ClientBuilder;
+import com.okta.authfoundation.client.kmp.OAuth2Client;
 import com.okta.directauth.cli.model.CliPreferences;
+import com.okta.directauth.cli.oauth2.OAuth2Flows;
+import com.okta.directauth.cli.oauth2.WrapperOAuth2Flows;
 import com.okta.directauth.cli.view.ConsoleView;
+import com.okta.directauth.cli.view.OAuth2ConsoleView;
 import com.okta.directauth.cli.view.SystemConsoleInput;
 import com.okta.directauth.cli.view.SystemConsoleOutput;
 import com.okta.directauth.cli.viewmodel.AuthViewModel;
+import com.okta.directauth.cli.viewmodel.OAuth2ViewModel;
 import com.okta.directauth.jvm.DirectAuthResult;
 import com.okta.directauth.jvm.DirectAuthenticationFlow;
 import com.okta.directauth.jvm.DirectAuthenticationFlowBuilder;
 import com.okta.directauth.model.DirectAuthenticationIntent;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
+import java.util.concurrent.Callable;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
 
-/** Entry point for the Java CLI direct authentication sample app. */
-public final class Main {
+/**
+ * Entry point for the Okta Auth CLI sample demonstrating Direct Authentication and OAuth2 flows.
+ */
+@Command(
+    name = "okta-direct-auth-cli",
+    version = "okta-direct-auth-cli 1.0.0",
+    description =
+        "Interactive CLI demonstrating Okta Direct Authentication and OAuth2 authorization flows.",
+    mixinStandardHelpOptions = true)
+public final class Main implements Callable<Integer> {
   private static final String TAG = "Main";
   private static final String VERSION = "1.0.0";
   private static final String CONFIG_DOCS_URL =
       "https://developer.okta.com/docs/guides/configure-direct-auth-grants/";
+  private static final List<String> OAUTH2_SCOPES =
+      Arrays.asList("openid", "profile", "email", "offline_access");
 
-  private Main() {}
+  @Option(names = "--issuer", description = "Okta issuer URL")
+  private String issuerArg;
 
-  /**
-   * Main entry point.
-   *
-   * @param args command-line arguments
-   */
-  public static void main(String[] args) {
-    if (hasFlag(args, "help") || hasFlag(args, "h")) {
-      printHelp();
-      return;
-    }
+  @Option(names = "--clientId", description = "OAuth 2.0 client ID")
+  private String clientIdArg;
 
-    if (hasFlag(args, "version") || hasFlag(args, "v")) {
-      System.out.println("okta-direct-auth-cli " + VERSION);
-      return;
-    }
+  @Option(
+      names = "--authorizationServerId",
+      description = "Authorization server ID (e.g., 'default')")
+  private String authorizationServerIdArg;
 
-    if (hasFlag(args, "verbose")) {
+  @Option(
+      names = "--desktopSignInRedirectUri",
+      description =
+          "Loopback redirect URI for OAuth2 redirect-based flows (default:"
+              + " http://localhost:8080/callback)")
+  private String signInRedirectUriArg;
+
+  @Option(
+      names = "--format",
+      description = "Token display format: ${COMPLETION-CANDIDATES} (default: raw)",
+      defaultValue = "raw")
+  private TokenFormat format;
+
+  @Option(names = "--mode", description = "Pre-select demonstration mode: ${COMPLETION-CANDIDATES}")
+  private DemoMode modeArg;
+
+  @Option(
+      names = {"-v", "--verbose"},
+      description = "Enable debug logging to stderr")
+  private boolean verbose;
+
+  private enum TokenFormat {
+    raw,
+    decoded
+  }
+
+  private enum DemoMode {
+    direct,
+    oauth2
+  }
+
+  @Override
+  public Integer call() {
+    if (verbose) {
       CliLogger.setVerbose(true);
     }
 
-    CliLogger.info(TAG, "Starting Okta Direct Auth CLI v" + VERSION);
+    CliLogger.info(TAG, "Starting Okta Auth CLI v" + VERSION);
     CliLogger.debug(TAG, "Java " + System.getProperty("java.version"));
     CliLogger.debug(
         TAG, "OS: " + System.getProperty("os.name") + " " + System.getProperty("os.arch"));
+    CliLogger.debug(TAG, "Token format: " + format);
 
-    boolean decodedFormat = parseArg(args, "format", "raw").equals("decoded");
-    CliLogger.debug(TAG, "Token format: " + (decodedFormat ? "decoded" : "raw"));
-
-    String issuer = resolveConfig(args, "issuer", AppConfig.ISSUER, "Issuer URL");
-    String clientId = resolveConfig(args, "clientId", AppConfig.CLIENT_ID, "Client ID");
+    String issuer = resolveConfig(issuerArg, AppConfig.ISSUER, "Issuer URL");
+    String clientId = resolveConfig(clientIdArg, AppConfig.CLIENT_ID, "Client ID");
     String authorizationServerId =
         resolveConfig(
-            args,
-            "authorizationServerId",
+            authorizationServerIdArg,
             AppConfig.AUTHORIZATION_SERVER_ID,
             "Authorization Server ID (e.g., 'default')");
+    // JVM: prefer desktopSignInRedirectUri, fall back to signInRedirectUri.
+    String defaultRedirectUri =
+        !AppConfig.DESKTOP_SIGN_IN_REDIRECT_URI.isEmpty()
+            ? AppConfig.DESKTOP_SIGN_IN_REDIRECT_URI
+            : AppConfig.SIGN_IN_REDIRECT_URI;
+    String signInRedirectUri =
+        resolveConfig(
+            signInRedirectUriArg,
+            defaultRedirectUri,
+            "Desktop Sign-In Redirect URI (OAuth2 redirect-based flows, e.g. http://localhost:8080/callback)");
 
     if (issuer.isEmpty() || clientId.isEmpty() || authorizationServerId.isEmpty()) {
       System.err.println("=== Configuration Error ===");
       System.err.println("Missing required configuration values.");
       System.err.println("See: " + CONFIG_DOCS_URL);
-      System.exit(1);
+      return 1;
     }
 
     CliLogger.debug(TAG, "Issuer: " + issuer);
     CliLogger.debug(TAG, "Client ID: " + clientId);
     CliLogger.debug(TAG, "Authorization Server ID: " + authorizationServerId);
+    CliLogger.debug(TAG, "Sign-In Redirect URI: " + signInRedirectUri);
 
+    // --- Build Direct Auth flows ---
     List<String> signInScopes = Arrays.asList("openid", "profile", "email");
     List<String> recoveryScopes = List.of("okta.myAccount.password.manage");
 
-    CliLogger.info(TAG, "Building sign-in flow (scopes: " + signInScopes + ")");
+    CliLogger.info(TAG, "Building Direct Auth sign-in flow (scopes: " + signInScopes + ")");
     DirectAuthResult<DirectAuthenticationFlow> signInResult =
         new DirectAuthenticationFlowBuilder(issuer, clientId, signInScopes)
             .setAuthorizationServerId(authorizationServerId)
             .setIntent(DirectAuthenticationIntent.SIGN_IN)
             .build();
 
-    CliLogger.info(TAG, "Building recovery flow (scopes: " + recoveryScopes + ")");
+    CliLogger.info(TAG, "Building Direct Auth recovery flow (scopes: " + recoveryScopes + ")");
     DirectAuthResult<DirectAuthenticationFlow> recoveryResult =
         new DirectAuthenticationFlowBuilder(issuer, clientId, recoveryScopes)
             .setAuthorizationServerId(authorizationServerId)
@@ -103,13 +158,11 @@ public final class Main {
             .build();
 
     if (signInResult.isFailure()) {
-      CliLogger.error(
-          TAG,
-          "Failed to create sign-in flow",
-          Objects.requireNonNull(signInResult.exceptionOrNull()));
-      System.err.println("Failed to create sign-in flow: " + signInResult.exceptionOrNull());
+      Throwable cause = signInResult.exceptionOrNull();
+      CliLogger.error(TAG, "Failed to create sign-in flow", cause);
+      System.err.println("Failed to create sign-in flow: " + cause);
       System.err.println("See: " + CONFIG_DOCS_URL);
-      System.exit(1);
+      return 1;
     }
 
     DirectAuthenticationFlow signInFlow = signInResult.getOrThrow();
@@ -119,6 +172,33 @@ public final class Main {
       CliLogger.info(TAG, "Recovery flow unavailable (password recovery disabled)");
     }
 
+    // --- Build OAuth2 client and flows ---
+    CliLogger.info(TAG, "Building OAuth2 client (scopes: " + OAUTH2_SCOPES + ")");
+    AuthFoundationResult<OAuth2Client> oauth2ClientResult =
+        new OAuth2ClientBuilder(issuer, clientId, OAUTH2_SCOPES)
+            .setAuthorizationServerId(authorizationServerId)
+            .build();
+
+    if (oauth2ClientResult.isFailure()) {
+      Throwable cause = oauth2ClientResult.exceptionOrNull();
+      CliLogger.error(TAG, "Failed to create OAuth2 client", cause);
+      System.err.println("Failed to create OAuth2 client: " + cause);
+      return 1;
+    }
+
+    OAuth2Client oauth2Client = oauth2ClientResult.getOrThrow();
+    OAuth2Flows oauth2Flows;
+    try {
+      oauth2Flows = new WrapperOAuth2Flows(oauth2Client, OAUTH2_SCOPES, signInRedirectUri);
+    } catch (IllegalArgumentException e) {
+      System.err.println("=== Configuration Error ===");
+      System.err.println("Invalid desktopSignInRedirectUri: " + e.getMessage());
+      System.err.println(
+          "Use --desktopSignInRedirectUri or set desktopSignInRedirectUri in local.properties.");
+      return 1;
+    }
+
+    // --- Wire views and view models ---
     CliPreferences preferences = new CliPreferences();
     CliLogger.debug(
         TAG,
@@ -126,107 +206,110 @@ public final class Main {
             + (preferences.getLastUsername().isEmpty() ? "<none>" : preferences.getLastUsername())
             + ")");
 
-    AuthViewModel viewModel = new AuthViewModel(signInFlow, recoveryFlow, issuer);
-    ConsoleView view =
+    boolean decoded = format == TokenFormat.decoded;
+
+    AuthViewModel directAuthViewModel = new AuthViewModel(signInFlow, recoveryFlow, issuer);
+    ConsoleView directAuthView =
         new ConsoleView(
-            viewModel,
+            directAuthViewModel,
             new SystemConsoleInput(),
             new SystemConsoleOutput(),
-            decodedFormat,
+            decoded,
             preferences);
+
+    OAuth2ViewModel oauth2ViewModel = new OAuth2ViewModel(oauth2Flows, decoded);
+    OAuth2ConsoleView oauth2View =
+        new OAuth2ConsoleView(oauth2ViewModel, new SystemConsoleInput(), new SystemConsoleOutput());
 
     Runtime.getRuntime()
         .addShutdownHook(
             new Thread(
                 () -> {
                   CliLogger.debug(TAG, "Shutdown hook triggered");
-                  view.stop();
-                  viewModel.close();
+                  directAuthView.stop();
+                  directAuthViewModel.close();
+                  oauth2View.stop();
+                  oauth2ViewModel.close();
                 }));
 
-    CliLogger.info(TAG, "Ready. Entering interactive mode.");
+    // --- Top-level mode selection ---
+    DemoMode mode = modeArg;
+    if (mode == null) {
+      mode = promptMode();
+    }
+
+    CliLogger.info(TAG, "Mode selected: " + mode);
+
     try {
-      view.run();
+      if (mode == DemoMode.direct) {
+        CliLogger.info(TAG, "Entering Direct Authentication mode.");
+        directAuthView.run();
+      } else {
+        CliLogger.info(TAG, "Entering OAuth2 Flows mode.");
+        oauth2View.run();
+      }
     } finally {
       CliLogger.info(TAG, "Exiting.");
-      viewModel.close();
+      directAuthViewModel.close();
+      oauth2ViewModel.close();
     }
+    return 0;
+  }
+
+  private static DemoMode promptMode() {
+    System.out.println("\n=== Okta Auth CLI ===");
+    System.out.println("[1] Direct Authentication");
+    System.out.println("[2] OAuth2 Flows");
+    System.out.println("[3] Exit");
+    System.out.print("Select option: ");
+    if (System.console() != null) {
+      String line = System.console().readLine();
+      if (line != null) {
+        switch (line.trim()) {
+          case "1":
+            return DemoMode.direct;
+          case "2":
+            return DemoMode.oauth2;
+          case "3":
+            System.exit(0);
+        }
+      }
+    }
+    // Default to direct auth if input unavailable
+    return DemoMode.direct;
   }
 
   /**
    * Resolves a configuration value from: (1) CLI arg, (2) local.properties default, (3) interactive
    * prompt.
    */
-  private static String resolveConfig(
-      String[] args, String key, String defaultValue, String promptLabel) {
-    String fromArg = parseArg(args, key, "");
-    if (!fromArg.isEmpty()) {
-      CliLogger.debug(TAG, "Config '" + key + "' from CLI arg");
-      return fromArg;
+  private static String resolveConfig(String argValue, String defaultValue, String promptLabel) {
+    if (argValue != null && !argValue.isEmpty()) {
+      CliLogger.debug("Main", "Config '" + promptLabel + "' from CLI arg");
+      return argValue;
     }
     if (!defaultValue.isEmpty()) {
-      CliLogger.debug(TAG, "Config '" + key + "' from local.properties");
+      CliLogger.debug("Main", "Config '" + promptLabel + "' from local.properties");
       return defaultValue;
     }
     if (System.console() == null) {
-      CliLogger.error(TAG, "Config '" + key + "' is required but stdin is not available");
+      CliLogger.error(
+          "Main", "Config '" + promptLabel + "' is required but stdin is not available");
       return "";
     }
-    CliLogger.debug(TAG, "Config '" + key + "' prompting user");
+    CliLogger.debug("Main", "Config '" + promptLabel + "' prompting user");
     System.out.print(promptLabel + ": ");
     String line = System.console().readLine();
     return (line != null) ? line.trim() : "";
   }
 
   /**
-   * Parses a {@code --key=value} argument from the args array.
+   * Main entry point.
    *
-   * @return the value, or the default if not found
+   * @param args command-line arguments
    */
-  private static String parseArg(String[] args, String key, String defaultValue) {
-    String prefix = "--" + key + "=";
-    for (String arg : args) {
-      if (arg.startsWith(prefix)) {
-        return arg.substring(prefix.length());
-      }
-    }
-    return defaultValue;
-  }
-
-  /** Returns true if a boolean flag (e.g., {@code --verbose}, {@code --help}) is present. */
-  private static boolean hasFlag(String[] args, String flag) {
-    String dashed = "--" + flag;
-    String singleDash = "-" + flag;
-    for (String arg : args) {
-      if (dashed.equals(arg) || singleDash.equals(arg)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  private static void printHelp() {
-    System.out.println("okta-direct-auth-cli v" + VERSION);
-    System.out.println();
-    System.out.println("Usage: okta-direct-auth-cli [OPTIONS]");
-    System.out.println();
-    System.out.println("Options:");
-    System.out.println("  --issuer=URL                  Okta issuer URL");
-    System.out.println("  --clientId=ID                 OAuth 2.0 client ID");
-    System.out.println(
-        "  --authorizationServerId=ID    Authorization server ID (default: 'default')");
-    System.out.println("  --format=raw|decoded          Token display format (default: raw)");
-    System.out.println("  --verbose                     Enable debug logging to stderr");
-    System.out.println("  --version, -v                 Show version and exit");
-    System.out.println("  --help, -h                    Show this help and exit");
-    System.out.println();
-    System.out.println("Configuration:");
-    System.out.println(
-        "  Values are resolved in order: CLI args > local.properties > interactive prompt.");
-    System.out.println("  See: " + CONFIG_DOCS_URL);
-    System.out.println();
-    System.out.println("Examples:");
-    System.out.println("  okta-direct-auth-cli --issuer=https://dev-123.okta.com --clientId=abc");
-    System.out.println("  okta-direct-auth-cli --format=decoded --verbose");
+  public static void main(String[] args) {
+    int exitCode = new CommandLine(new Main()).execute(args);
+    System.exit(exitCode);
   }
 }

--- a/okta-direct-auth-java-cli-sample/src/main/java/com/okta/directauth/cli/model/DeviceCodeDisplay.java
+++ b/okta-direct-auth-java-cli-sample/src/main/java/com/okta/directauth/cli/model/DeviceCodeDisplay.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.directauth.cli.model;
+
+import com.okta.oauth2.kmp.DeviceAuthorizationFlowContext;
+
+/**
+ * Immutable snapshot of a device authorization code for display purposes.
+ *
+ * <p>Use {@link #fromContext(DeviceAuthorizationFlowContext)} to construct from the SDK type.
+ */
+public final class DeviceCodeDisplay {
+  private final String userCode;
+  private final String verificationUri;
+  private final String verificationUriComplete;
+  private final int expiresIn;
+
+  private DeviceCodeDisplay(
+      String userCode, String verificationUri, String verificationUriComplete, int expiresIn) {
+    this.userCode = userCode;
+    this.verificationUri = verificationUri;
+    this.verificationUriComplete = verificationUriComplete;
+    this.expiresIn = expiresIn;
+  }
+
+  /**
+   * Creates a {@link DeviceCodeDisplay} from the SDK {@link DeviceAuthorizationFlowContext}.
+   *
+   * @param context the SDK device authorization context
+   * @return a new DeviceCodeDisplay instance
+   */
+  public static DeviceCodeDisplay fromContext(DeviceAuthorizationFlowContext context) {
+    return new DeviceCodeDisplay(
+        context.getUserCode(),
+        context.getVerificationUri(),
+        context.getVerificationUriComplete(),
+        context.getExpiresIn());
+  }
+
+  /**
+   * Returns the user code to enter at the verification URI.
+   *
+   * @return user code
+   */
+  public String getUserCode() {
+    return userCode;
+  }
+
+  /**
+   * Returns the verification URI the user should visit.
+   *
+   * @return verification URI
+   */
+  public String getVerificationUri() {
+    return verificationUri;
+  }
+
+  /**
+   * Returns the complete verification URI with the code pre-filled, or null if not provided.
+   *
+   * @return complete verification URI, or null
+   */
+  public String getVerificationUriComplete() {
+    return verificationUriComplete;
+  }
+
+  /**
+   * Returns the number of seconds until the device code expires.
+   *
+   * @return seconds until expiry
+   */
+  public int getExpiresIn() {
+    return expiresIn;
+  }
+}

--- a/okta-direct-auth-java-cli-sample/src/main/java/com/okta/directauth/cli/model/OAuth2Flow.java
+++ b/okta-direct-auth-java-cli-sample/src/main/java/com/okta/directauth/cli/model/OAuth2Flow.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.directauth.cli.model;
+
+/** The five OAuth2 standard flows demonstrated by this sample. */
+public enum OAuth2Flow {
+  RESOURCE_OWNER("Resource Owner Password", true, false, false),
+  DEVICE_AUTHORIZATION("Device Authorization", false, false, false),
+  BROWSER_SIGN_IN("Browser Sign-In (Auth Code + PKCE)", false, false, false),
+  TOKEN_EXCHANGE("Token Exchange", false, true, false),
+  SESSION_TOKEN("Session Token", false, false, true);
+
+  private final String label;
+  private final boolean requiresCredentials;
+  private final boolean requiresTokens;
+  private final boolean requiresSessionToken;
+
+  OAuth2Flow(
+      String label,
+      boolean requiresCredentials,
+      boolean requiresTokens,
+      boolean requiresSessionToken) {
+    this.label = label;
+    this.requiresCredentials = requiresCredentials;
+    this.requiresTokens = requiresTokens;
+    this.requiresSessionToken = requiresSessionToken;
+  }
+
+  /**
+   * Returns the human-readable display label for this flow.
+   *
+   * @return display label
+   */
+  public String getLabel() {
+    return label;
+  }
+
+  /**
+   * Returns true if this flow requires a username and password input.
+   *
+   * @return true if credentials are required
+   */
+  public boolean requiresCredentials() {
+    return requiresCredentials;
+  }
+
+  /**
+   * Returns true if this flow requires an ID token and device secret input.
+   *
+   * @return true if token inputs are required
+   */
+  public boolean requiresTokens() {
+    return requiresTokens;
+  }
+
+  /**
+   * Returns true if this flow requires a session token input.
+   *
+   * @return true if a session token is required
+   */
+  public boolean requiresSessionToken() {
+    return requiresSessionToken;
+  }
+}

--- a/okta-direct-auth-java-cli-sample/src/main/java/com/okta/directauth/cli/model/OAuth2Screen.java
+++ b/okta-direct-auth-java-cli-sample/src/main/java/com/okta/directauth/cli/model/OAuth2Screen.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.directauth.cli.model;
+
+/** Navigation states for the OAuth2 demonstration mode. */
+public enum OAuth2Screen {
+  MENU,
+  INPUT,
+  DEVICE_POLLING,
+  BROWSER_WAITING,
+  AUTHENTICATED,
+  ERROR
+}

--- a/okta-direct-auth-java-cli-sample/src/main/java/com/okta/directauth/cli/oauth2/OAuth2Flows.java
+++ b/okta-direct-auth-java-cli-sample/src/main/java/com/okta/directauth/cli/oauth2/OAuth2Flows.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.directauth.cli.oauth2;
+
+import com.okta.authfoundation.client.TokenInfo;
+import com.okta.oauth2.kmp.DeviceAuthorizationFlowContext;
+import java.io.Closeable;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Abstraction over the OAuth2 module's JVM flow wrappers.
+ *
+ * <p>Each method returns a {@link CompletableFuture} that completes with the result on success, or
+ * completes exceptionally on failure. No Kotlin coroutine types are exposed to callers.
+ *
+ * <p>Production implementation: {@link WrapperOAuth2Flows}. Test implementation: use a fake that
+ * returns pre-baked futures.
+ */
+public interface OAuth2Flows extends Closeable {
+
+  /**
+   * Starts the Resource Owner Password flow.
+   *
+   * @param username the user's username
+   * @param password the user's password
+   * @return future completing with {@link TokenInfo} on success
+   */
+  CompletableFuture<TokenInfo> resourceOwner(String username, String password);
+
+  /**
+   * Starts the Device Authorization flow and returns the device context (user code + verification
+   * URI).
+   *
+   * @return future completing with {@link DeviceAuthorizationFlowContext}
+   */
+  CompletableFuture<DeviceAuthorizationFlowContext> deviceStart();
+
+  /**
+   * Polls for device authorization completion.
+   *
+   * @param context the context returned by {@link #deviceStart()}
+   * @return future completing with {@link TokenInfo} on approval
+   */
+  CompletableFuture<TokenInfo> deviceResume(DeviceAuthorizationFlowContext context);
+
+  /**
+   * Starts the Browser Sign-In (Authorization Code + PKCE) flow.
+   *
+   * <p>Opens the system browser and captures the loopback redirect.
+   *
+   * @return future completing with {@link TokenInfo} on success
+   */
+  CompletableFuture<TokenInfo> browserSignIn();
+
+  /**
+   * Starts the Token Exchange flow.
+   *
+   * @param idToken an existing ID token to exchange
+   * @param deviceSecret an existing device secret
+   * @return future completing with {@link TokenInfo} on success
+   */
+  CompletableFuture<TokenInfo> tokenExchange(String idToken, String deviceSecret);
+
+  /**
+   * Starts the Session Token flow.
+   *
+   * @param sessionToken a session token from the Okta Authn API
+   * @return future completing with {@link TokenInfo} on success
+   */
+  CompletableFuture<TokenInfo> sessionToken(String sessionToken);
+
+  /** Releases all underlying flow resources and cancels any background coroutine scopes. */
+  @Override
+  void close();
+}

--- a/okta-direct-auth-java-cli-sample/src/main/java/com/okta/directauth/cli/oauth2/WrapperOAuth2Flows.java
+++ b/okta-direct-auth-java-cli-sample/src/main/java/com/okta/directauth/cli/oauth2/WrapperOAuth2Flows.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.directauth.cli.oauth2;
+
+import com.okta.authfoundation.client.TokenInfo;
+import com.okta.authfoundation.client.kmp.OAuth2Client;
+import com.okta.oauth2.kmp.DeviceAuthorizationFlowContext;
+import com.okta.oauth2.kmp.LocalhostBrowserRedirectHandler;
+import com.okta.oauth2.kmp.jvm.AuthorizationCodeFlow;
+import com.okta.oauth2.kmp.jvm.DeviceAuthorizationFlow;
+import com.okta.oauth2.kmp.jvm.ResourceOwnerFlow;
+import com.okta.oauth2.kmp.jvm.SessionTokenFlow;
+import com.okta.oauth2.kmp.jvm.TokenExchangeFlow;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Production implementation of {@link OAuth2Flows} backed by the OAuth2 module's JVM wrappers.
+ *
+ * <p>Each flow wrapper wraps Kotlin coroutines and exposes {@link CompletableFuture}-based methods
+ * so this class (and all callers) remain pure Java with no coroutine API surface.
+ *
+ * <p>Each flow instance is closed automatically when its future completes (success or failure). The
+ * Device Authorization flow is kept alive between {@link #deviceStart()} and {@link #deviceResume}
+ * and closed after resumption.
+ */
+public final class WrapperOAuth2Flows implements OAuth2Flows {
+  private final OAuth2Client client;
+  private final String scope;
+  private final String redirectUrl;
+  private final int redirectPort;
+  private final String redirectPath;
+
+  // Maps each device-start context to the live flow that owns it so resume uses the right instance.
+  // IdentityHashMap is appropriate: context equality is object identity (data class with device
+  // code
+  // field that is internal/not accessible from Java and may differ across instances).
+  private final Map<DeviceAuthorizationFlowContext, DeviceAuthorizationFlow> activeDeviceFlows =
+      Collections.synchronizedMap(new IdentityHashMap<>());
+
+  /**
+   * Creates a {@link WrapperOAuth2Flows}.
+   *
+   * @param client the shared OAuth2 client
+   * @param scopes the OAuth2 scopes to request
+   * @param signInRedirectUri the loopback redirect URI (e.g. {@code
+   *     http://localhost:8080/callback})
+   * @throws IllegalArgumentException if {@code signInRedirectUri} is not a valid http loopback URI
+   */
+  public WrapperOAuth2Flows(OAuth2Client client, List<String> scopes, String signInRedirectUri) {
+    this.client = client;
+    this.scope = String.join(" ", scopes);
+    this.redirectUrl = signInRedirectUri;
+
+    try {
+      URI uri = new URI(signInRedirectUri);
+      String scheme = uri.getScheme();
+      String host = uri.getHost();
+      if (!"http".equalsIgnoreCase(scheme)) {
+        throw new IllegalArgumentException(
+            "signInRedirectUri must use the http scheme; got: " + signInRedirectUri);
+      }
+      if (host == null || !isLoopbackHost(host)) {
+        throw new IllegalArgumentException(
+            "signInRedirectUri must be a loopback address (localhost / 127.0.0.1 / ::1); got: "
+                + signInRedirectUri);
+      }
+      int port = uri.getPort();
+      this.redirectPort = (port == -1) ? 80 : port;
+      String path = uri.getPath();
+      this.redirectPath = (path == null || path.isEmpty()) ? "/" : path;
+    } catch (URISyntaxException e) {
+      throw new IllegalArgumentException("Invalid signInRedirectUri: " + signInRedirectUri, e);
+    }
+  }
+
+  @Override
+  public CompletableFuture<TokenInfo> resourceOwner(String username, String password) {
+    ResourceOwnerFlow flow = new ResourceOwnerFlow(client);
+    return flow.start(username, password, scope).whenComplete((r, t) -> closeQuietly(flow));
+  }
+
+  @Override
+  public CompletableFuture<DeviceAuthorizationFlowContext> deviceStart() {
+    DeviceAuthorizationFlow flow = new DeviceAuthorizationFlow(client);
+    return flow.start(scope)
+        .thenApply(
+            ctx -> {
+              activeDeviceFlows.put(ctx, flow);
+              return ctx;
+            })
+        .exceptionally(
+            t -> {
+              closeQuietly(flow);
+              sneakyThrow(t);
+              return null; // unreachable
+            });
+  }
+
+  @Override
+  public CompletableFuture<TokenInfo> deviceResume(DeviceAuthorizationFlowContext context) {
+    // Remove before resuming so a second call with the same context creates a fresh flow.
+    DeviceAuthorizationFlow flow = activeDeviceFlows.remove(context);
+    if (flow == null) {
+      // Fallback: resume via a new wrapper (context already carries the device code internally).
+      flow = new DeviceAuthorizationFlow(client);
+    }
+    DeviceAuthorizationFlow finalFlow = flow;
+    return finalFlow.resume(context).whenComplete((r, t) -> closeQuietly(finalFlow));
+  }
+
+  @Override
+  public CompletableFuture<TokenInfo> browserSignIn() {
+    LocalhostBrowserRedirectHandler handler =
+        new LocalhostBrowserRedirectHandler(redirectPort, redirectPath);
+    AuthorizationCodeFlow flow = new AuthorizationCodeFlow(client);
+    return flow.start(redirectUrl, handler, Collections.emptyMap(), scope)
+        .whenComplete((r, t) -> closeQuietly(flow));
+  }
+
+  @Override
+  public CompletableFuture<TokenInfo> tokenExchange(String idToken, String deviceSecret) {
+    TokenExchangeFlow flow = new TokenExchangeFlow(client);
+    return flow.start(idToken, deviceSecret, null, scope)
+        .whenComplete((r, t) -> closeQuietly(flow));
+  }
+
+  @Override
+  public CompletableFuture<TokenInfo> sessionToken(String sessionToken) {
+    SessionTokenFlow flow = new SessionTokenFlow(client);
+    return flow.start(sessionToken, redirectUrl, Collections.emptyMap(), scope)
+        .whenComplete((r, t) -> closeQuietly(flow));
+  }
+
+  @Override
+  public void close() {
+    // Close any device flows that were started but never resumed (e.g. on app exit).
+    activeDeviceFlows.values().forEach(WrapperOAuth2Flows::closeQuietly);
+    activeDeviceFlows.clear();
+  }
+
+  private static boolean isLoopbackHost(String host) {
+    // URI.getHost() strips brackets from IPv6 addresses (returns "::1" not "[::1]").
+    return host.equals("localhost")
+        || host.equals("127.0.0.1")
+        || host.equals("::1")
+        || host.equals("[::1]"); // guard against JDK implementations that retain brackets
+  }
+
+  private static void closeQuietly(AutoCloseable c) {
+    try {
+      c.close();
+    } catch (Exception ignored) {
+      // Best-effort: cancel any remaining coroutine scope.
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T extends Throwable> void sneakyThrow(Throwable t) throws T {
+    throw (T) t;
+  }
+}

--- a/okta-direct-auth-java-cli-sample/src/main/java/com/okta/directauth/cli/view/OAuth2ConsoleView.java
+++ b/okta-direct-auth-java-cli-sample/src/main/java/com/okta/directauth/cli/view/OAuth2ConsoleView.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.directauth.cli.view;
+
+import com.okta.directauth.cli.model.DeviceCodeDisplay;
+import com.okta.directauth.cli.model.OAuth2Flow;
+import com.okta.directauth.cli.model.OAuth2Screen;
+import com.okta.directauth.cli.model.TokenDisplay;
+import com.okta.directauth.cli.viewmodel.OAuth2ViewModel;
+import com.okta.directauth.cli.viewmodel.OAuth2ViewModelListener;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+/**
+ * CLI view for the OAuth2 demonstration mode.
+ *
+ * <p>Renders the OAuth2 flow menu, collects user input, delegates to {@link OAuth2ViewModel}, and
+ * displays token results and error messages. Token rendering reuses the stateless {@link
+ * StateRenderer#renderToken(TokenDisplay, boolean)} method. OAuth2 errors are rendered from the
+ * flow's exception message since {@link StateRenderer#renderError} is Direct-Auth-specific.
+ *
+ * <h3>Concurrency contract</h3>
+ *
+ * Each flow execution creates a private {@link CountDownLatch}(1) that is released when the
+ * ViewModel transitions to {@code AUTHENTICATED} or {@code ERROR}. The latch reference is captured
+ * into a local variable before the flow starts, so a callback from a prior cancelled flow cannot
+ * release the latch belonging to a new flow. {@link #stop()} and {@link OAuth2ViewModel#reset()}
+ * both release any active latch to prevent the menu loop from hanging on shutdown.
+ */
+public final class OAuth2ConsoleView implements OAuth2ViewModelListener {
+  private final OAuth2ViewModel viewModel;
+  private final ConsoleInput input;
+  private final ConsoleOutput output;
+  private volatile boolean running = true;
+
+  // Holds the latch for the currently executing flow. Replaced atomically before each flow start.
+  private final AtomicReference<CountDownLatch> activeLatch = new AtomicReference<>();
+  // Holds the most recent error message for rendering in showError().
+  private volatile String lastErrorMessage;
+
+  /**
+   * Creates a new OAuth2ConsoleView.
+   *
+   * @param viewModel the OAuth2 view model
+   * @param input the console input source
+   * @param output the console output target
+   */
+  public OAuth2ConsoleView(OAuth2ViewModel viewModel, ConsoleInput input, ConsoleOutput output) {
+    this.viewModel = viewModel;
+    this.input = input;
+    this.output = output;
+    viewModel.addListener(this);
+  }
+
+  /** Runs the OAuth2 menu loop until the user exits. */
+  public void run() {
+    while (running) {
+      OAuth2Screen screen = viewModel.getCurrentScreen();
+      if (screen == OAuth2Screen.MENU) {
+        showFlowMenu();
+      } else if (screen == OAuth2Screen.AUTHENTICATED) {
+        showSuccess();
+      } else if (screen == OAuth2Screen.ERROR) {
+        showError();
+      }
+      // DEVICE_POLLING and BROWSER_WAITING are transient: the listener callback releases the latch.
+    }
+  }
+
+  /**
+   * Stops the run loop and releases any waiting latch so the thread can exit cleanly.
+   *
+   * <p>Safe to call from any thread (e.g. the JVM shutdown hook).
+   */
+  public void stop() {
+    running = false;
+    releaseLatch();
+  }
+
+  @Override
+  public void onScreenChanged(OAuth2Screen screen) {
+    if (screen == OAuth2Screen.AUTHENTICATED || screen == OAuth2Screen.ERROR) {
+      releaseLatch();
+    }
+  }
+
+  @Override
+  public void onDeviceCode(DeviceCodeDisplay deviceCode) {
+    output.println("");
+    output.println("=== Device Authorization ===");
+    output.println("Visit: " + deviceCode.getVerificationUri());
+    if (deviceCode.getVerificationUriComplete() != null) {
+      output.println("Or open: " + deviceCode.getVerificationUriComplete());
+    }
+    output.println("Enter code: " + deviceCode.getUserCode());
+    output.println(
+        "Code expires in " + deviceCode.getExpiresIn() + " seconds. Waiting for approval...");
+  }
+
+  @Override
+  public void onResult(TokenDisplay token) {
+    // Rendering happens in showSuccess() after the screen transitions to AUTHENTICATED.
+  }
+
+  @Override
+  public void onError(String message) {
+    lastErrorMessage = message;
+    // Rendering happens in showError() after the screen transitions to ERROR.
+  }
+
+  private void showFlowMenu() {
+    List<String> labels =
+        Arrays.stream(OAuth2Flow.values()).map(OAuth2Flow::getLabel).collect(Collectors.toList());
+
+    output.println("");
+    output.println(StateRenderer.renderMenu("=== OAuth2 Flows ===", labels));
+    output.print("[0] Back\nSelect option: ");
+
+    String line = input.readLine();
+    if (line == null) {
+      running = false;
+      return;
+    }
+    line = line.trim();
+
+    if ("0".equals(line)) {
+      running = false;
+      return;
+    }
+
+    int choice;
+    try {
+      choice = Integer.parseInt(line) - 1;
+    } catch (NumberFormatException e) {
+      output.println("Invalid option. Please enter a number.");
+      return;
+    }
+
+    OAuth2Flow[] flows = OAuth2Flow.values();
+    if (choice < 0 || choice >= flows.length) {
+      output.println("Invalid option. Please enter a number between 1 and " + flows.length + ".");
+      return;
+    }
+
+    executeFlow(flows[choice]);
+  }
+
+  private void executeFlow(OAuth2Flow flow) {
+    // Create a fresh latch for this invocation and register it atomically BEFORE starting the
+    // flow. This ensures no callback from a prior invocation can release the new latch.
+    CountDownLatch latch = new CountDownLatch(1);
+    activeLatch.set(latch);
+
+    boolean started = startFlow(flow);
+    if (!started) {
+      // Input validation failed; latch not needed.
+      activeLatch.compareAndSet(latch, null);
+      return;
+    }
+
+    // Block until onScreenChanged delivers AUTHENTICATED or ERROR, or stop() is called.
+    try {
+      latch.await();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  /**
+   * Collects required inputs for {@code flow} and starts it via the ViewModel.
+   *
+   * @return true if the flow was started, false if input validation aborted early
+   */
+  private boolean startFlow(OAuth2Flow flow) {
+    if (flow.requiresCredentials()) {
+      String username = input.readLine("Username: ");
+      if (username == null || username.trim().isEmpty()) {
+        output.println("Username cannot be empty.");
+        return false;
+      }
+      // readPassword masks the input so the credential is not echoed to the terminal.
+      String password = input.readPassword("Password: ");
+      if (password == null || password.isEmpty()) {
+        output.println("Password cannot be empty.");
+        return false;
+      }
+      viewModel.startResourceOwner(username.trim(), password);
+      return true;
+    }
+
+    if (flow.requiresTokens()) {
+      String idToken = input.readLine("ID Token: ");
+      if (idToken == null || idToken.trim().isEmpty()) {
+        output.println("ID token cannot be empty.");
+        return false;
+      }
+      // Device secrets are bearer credentials; read without echo.
+      String deviceSecret = input.readPassword("Device Secret: ");
+      if (deviceSecret == null || deviceSecret.trim().isEmpty()) {
+        output.println("Device secret cannot be empty.");
+        return false;
+      }
+      viewModel.startTokenExchange(idToken.trim(), deviceSecret.trim());
+      return true;
+    }
+
+    if (flow.requiresSessionToken()) {
+      // Session tokens are bearer credentials; read without echo.
+      String sessionToken = input.readPassword("Session Token: ");
+      if (sessionToken == null || sessionToken.trim().isEmpty()) {
+        output.println("Session token cannot be empty.");
+        return false;
+      }
+      viewModel.startSessionToken(sessionToken.trim());
+      return true;
+    }
+
+    // Flows that need no user input before starting:
+    switch (flow) {
+      case DEVICE_AUTHORIZATION:
+        viewModel.startDeviceAuthorization();
+        return true;
+      case BROWSER_SIGN_IN:
+        output.println("Opening browser for sign-in. Waiting for redirect...");
+        viewModel.startBrowserSignIn();
+        return true;
+      default:
+        output.println("Unknown flow: " + flow);
+        return false;
+    }
+  }
+
+  private void showSuccess() {
+    TokenDisplay token = viewModel.getLastTokenDisplay();
+    if (token != null) {
+      output.println(StateRenderer.renderToken(token, viewModel.isDecoded()));
+    }
+    output.print("Press Enter to continue...");
+    input.readLine();
+    viewModel.reset();
+  }
+
+  private void showError() {
+    output.println("");
+    output.println("=== OAuth2 Error ===");
+    String message = lastErrorMessage;
+    if (message != null && !message.isBlank()) {
+      output.println("Error: " + message);
+    } else {
+      output.println("An unknown error occurred.");
+    }
+    output.print("Press Enter to return to the menu...");
+    input.readLine();
+    lastErrorMessage = null;
+    viewModel.reset();
+  }
+
+  private void releaseLatch() {
+    CountDownLatch latch = activeLatch.getAndSet(null);
+    if (latch != null) {
+      latch.countDown();
+    }
+  }
+}

--- a/okta-direct-auth-java-cli-sample/src/main/java/com/okta/directauth/cli/viewmodel/OAuth2ViewModel.java
+++ b/okta-direct-auth-java-cli-sample/src/main/java/com/okta/directauth/cli/viewmodel/OAuth2ViewModel.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.directauth.cli.viewmodel;
+
+import com.okta.authfoundation.client.TokenInfo;
+import com.okta.directauth.cli.CliLogger;
+import com.okta.directauth.cli.model.DeviceCodeDisplay;
+import com.okta.directauth.cli.model.OAuth2Screen;
+import com.okta.directauth.cli.model.TokenDisplay;
+import com.okta.directauth.cli.oauth2.OAuth2Flows;
+import java.io.Closeable;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Orchestration ViewModel for the OAuth2 demonstration flows.
+ *
+ * <p>Delegates to the {@link OAuth2Flows} seam (production: {@link
+ * com.okta.directauth.cli.oauth2.WrapperOAuth2Flows}, tests: a fake) and notifies registered {@link
+ * OAuth2ViewModelListener}s of state changes. All flow methods are non-blocking; results arrive via
+ * listener callbacks.
+ */
+public final class OAuth2ViewModel implements Closeable {
+  private static final String TAG = "OAuth2ViewModel";
+
+  private final OAuth2Flows flows;
+  private final boolean decoded;
+  private final List<OAuth2ViewModelListener> listeners = new CopyOnWriteArrayList<>();
+
+  private volatile OAuth2Screen currentScreen = OAuth2Screen.MENU;
+  private volatile TokenDisplay lastTokenDisplay;
+  private volatile CompletableFuture<?> pendingFuture;
+
+  /**
+   * Creates a new OAuth2ViewModel.
+   *
+   * @param flows the OAuth2 flow seam to use
+   * @param decoded true to display decoded JWT claims, false for raw tokens
+   */
+  public OAuth2ViewModel(OAuth2Flows flows, boolean decoded) {
+    this.flows = flows;
+    this.decoded = decoded;
+  }
+
+  /**
+   * Adds a listener for state change notifications.
+   *
+   * @param listener the listener to add
+   */
+  public void addListener(OAuth2ViewModelListener listener) {
+    listeners.add(listener);
+  }
+
+  /**
+   * Returns the current OAuth2 navigation screen.
+   *
+   * @return current screen
+   */
+  public OAuth2Screen getCurrentScreen() {
+    return currentScreen;
+  }
+
+  /**
+   * Returns the token display from the last successful flow, or null.
+   *
+   * @return last token display, or null
+   */
+  public TokenDisplay getLastTokenDisplay() {
+    return lastTokenDisplay;
+  }
+
+  /**
+   * Returns whether decoded JWT display mode is active.
+   *
+   * @return true if decoded mode
+   */
+  public boolean isDecoded() {
+    return decoded;
+  }
+
+  /**
+   * Starts the Resource Owner Password flow (non-blocking).
+   *
+   * @param username the user's username
+   * @param password the user's password
+   */
+  public void startResourceOwner(String username, String password) {
+    if (username == null || username.trim().isEmpty()) {
+      notifyError("Username cannot be empty");
+      return;
+    }
+    if (password == null || password.isEmpty()) {
+      notifyError("Password cannot be empty");
+      return;
+    }
+    CliLogger.info(TAG, "Starting Resource Owner flow for: " + username);
+    pendingFuture =
+        flows
+            .resourceOwner(username, password)
+            .thenAccept(this::handleSuccess)
+            .exceptionally(
+                t -> {
+                  handleError("Resource Owner flow failed", t);
+                  return null;
+                });
+  }
+
+  /**
+   * Starts the Device Authorization flow (non-blocking).
+   *
+   * <p>On success, fires {@link OAuth2ViewModelListener#onDeviceCode(DeviceCodeDisplay)} with the
+   * code details, then polls for approval.
+   */
+  public void startDeviceAuthorization() {
+    CliLogger.info(TAG, "Starting Device Authorization flow");
+    setScreen(OAuth2Screen.DEVICE_POLLING);
+    pendingFuture =
+        flows
+            .deviceStart()
+            .thenCompose(
+                context -> {
+                  DeviceCodeDisplay display = DeviceCodeDisplay.fromContext(context);
+                  CliLogger.info(TAG, "Device code received: " + context.getUserCode());
+                  notifyDeviceCode(display);
+                  return flows.deviceResume(context);
+                })
+            .thenAccept(this::handleSuccess)
+            .exceptionally(
+                t -> {
+                  handleError("Device Authorization flow failed", t);
+                  return null;
+                });
+  }
+
+  /**
+   * Starts the Browser Sign-In (Authorization Code + PKCE) flow (non-blocking).
+   *
+   * <p>Opens the system browser and waits for the loopback redirect.
+   */
+  public void startBrowserSignIn() {
+    CliLogger.info(TAG, "Starting Browser Sign-In flow");
+    setScreen(OAuth2Screen.BROWSER_WAITING);
+    pendingFuture =
+        flows
+            .browserSignIn()
+            .thenAccept(this::handleSuccess)
+            .exceptionally(
+                t -> {
+                  handleError("Browser Sign-In flow failed", t);
+                  return null;
+                });
+  }
+
+  /**
+   * Starts the Token Exchange flow (non-blocking).
+   *
+   * @param idToken an existing ID token
+   * @param deviceSecret an existing device secret
+   */
+  public void startTokenExchange(String idToken, String deviceSecret) {
+    if (idToken == null || idToken.trim().isEmpty()) {
+      notifyError("ID token cannot be empty");
+      return;
+    }
+    if (deviceSecret == null || deviceSecret.trim().isEmpty()) {
+      notifyError("Device secret cannot be empty");
+      return;
+    }
+    CliLogger.info(TAG, "Starting Token Exchange flow");
+    pendingFuture =
+        flows
+            .tokenExchange(idToken.trim(), deviceSecret.trim())
+            .thenAccept(this::handleSuccess)
+            .exceptionally(
+                t -> {
+                  handleError("Token Exchange flow failed", t);
+                  return null;
+                });
+  }
+
+  /**
+   * Starts the Session Token flow (non-blocking).
+   *
+   * @param sessionToken a session token from the Okta Authn API
+   */
+  public void startSessionToken(String sessionToken) {
+    if (sessionToken == null || sessionToken.trim().isEmpty()) {
+      notifyError("Session token cannot be empty");
+      return;
+    }
+    CliLogger.info(TAG, "Starting Session Token flow");
+    pendingFuture =
+        flows
+            .sessionToken(sessionToken.trim())
+            .thenAccept(this::handleSuccess)
+            .exceptionally(
+                t -> {
+                  handleError("Session Token flow failed", t);
+                  return null;
+                });
+  }
+
+  /** Cancels any pending flow and returns to the OAuth2 menu. */
+  public void reset() {
+    CompletableFuture<?> pending = pendingFuture;
+    if (pending != null) {
+      pending.cancel(true);
+    }
+    pendingFuture = null;
+    lastTokenDisplay = null;
+    setScreen(OAuth2Screen.MENU);
+  }
+
+  @Override
+  public void close() {
+    reset();
+    flows.close();
+  }
+
+  private void handleSuccess(TokenInfo tokenInfo) {
+    CliLogger.info(TAG, "Flow succeeded");
+    lastTokenDisplay = TokenDisplay.fromTokenInfo(tokenInfo);
+    setScreen(OAuth2Screen.AUTHENTICATED);
+    for (OAuth2ViewModelListener listener : listeners) {
+      listener.onResult(lastTokenDisplay);
+    }
+  }
+
+  private void handleError(String context, Throwable t) {
+    // Unwrap CompletableFuture wrappers to get the root cause.
+    Throwable cause = t;
+    while (cause.getCause() != null && cause != cause.getCause()) {
+      cause = cause.getCause();
+    }
+    String message = cause.getMessage();
+    if (message == null || message.isBlank()) {
+      // Provide an actionable fallback rather than an opaque class name.
+      message =
+          "Unexpected error ("
+              + cause.getClass().getSimpleName()
+              + "). Check --verbose for details.";
+    }
+    CliLogger.error(TAG, context + ": " + message, cause);
+    // notifyError is the single source of truth for the ERROR transition.
+    notifyError(message);
+  }
+
+  private void setScreen(OAuth2Screen screen) {
+    CliLogger.debug(TAG, "Screen: " + screen);
+    this.currentScreen = screen;
+    for (OAuth2ViewModelListener listener : listeners) {
+      listener.onScreenChanged(screen);
+    }
+  }
+
+  private void notifyDeviceCode(DeviceCodeDisplay deviceCode) {
+    for (OAuth2ViewModelListener listener : listeners) {
+      listener.onDeviceCode(deviceCode);
+    }
+  }
+
+  /**
+   * Single source of truth for the ERROR screen transition and error callbacks.
+   *
+   * <p>Callers must NOT call {@link #setScreen(OAuth2Screen)} with {@code ERROR} separately.
+   */
+  private void notifyError(String message) {
+    setScreen(OAuth2Screen.ERROR);
+    for (OAuth2ViewModelListener listener : listeners) {
+      listener.onError(message);
+    }
+  }
+}

--- a/okta-direct-auth-java-cli-sample/src/main/java/com/okta/directauth/cli/viewmodel/OAuth2ViewModelListener.java
+++ b/okta-direct-auth-java-cli-sample/src/main/java/com/okta/directauth/cli/viewmodel/OAuth2ViewModelListener.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.directauth.cli.viewmodel;
+
+import com.okta.directauth.cli.model.DeviceCodeDisplay;
+import com.okta.directauth.cli.model.OAuth2Screen;
+import com.okta.directauth.cli.model.TokenDisplay;
+
+/** Callback interface for {@link OAuth2ViewModel} state changes. */
+public interface OAuth2ViewModelListener {
+
+  /**
+   * Called when the current OAuth2 screen changes.
+   *
+   * @param screen the new screen
+   */
+  void onScreenChanged(OAuth2Screen screen);
+
+  /**
+   * Called when the device authorization code is ready for display.
+   *
+   * @param deviceCode the device code details to show the user
+   */
+  void onDeviceCode(DeviceCodeDisplay deviceCode);
+
+  /**
+   * Called when a flow completes successfully with tokens.
+   *
+   * @param token the token display object
+   */
+  void onResult(TokenDisplay token);
+
+  /**
+   * Called when a flow fails with a readable error message.
+   *
+   * @param message the error message
+   */
+  void onError(String message);
+}

--- a/okta-direct-auth-java-cli-sample/src/test/java/com/okta/directauth/cli/model/OAuth2FlowTest.java
+++ b/okta-direct-auth-java-cli-sample/src/test/java/com/okta/directauth/cli/model/OAuth2FlowTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.directauth.cli.model;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+public class OAuth2FlowTest {
+
+  @Test
+  public void resourceOwner_RequiresCredentials() {
+    assertThat(OAuth2Flow.RESOURCE_OWNER.requiresCredentials()).isTrue();
+    assertThat(OAuth2Flow.RESOURCE_OWNER.requiresTokens()).isFalse();
+    assertThat(OAuth2Flow.RESOURCE_OWNER.requiresSessionToken()).isFalse();
+    assertThat(OAuth2Flow.RESOURCE_OWNER.getLabel()).isNotEmpty();
+  }
+
+  @Test
+  public void deviceAuthorization_RequiresNoInput() {
+    assertThat(OAuth2Flow.DEVICE_AUTHORIZATION.requiresCredentials()).isFalse();
+    assertThat(OAuth2Flow.DEVICE_AUTHORIZATION.requiresTokens()).isFalse();
+    assertThat(OAuth2Flow.DEVICE_AUTHORIZATION.requiresSessionToken()).isFalse();
+  }
+
+  @Test
+  public void browserSignIn_RequiresNoInput() {
+    assertThat(OAuth2Flow.BROWSER_SIGN_IN.requiresCredentials()).isFalse();
+    assertThat(OAuth2Flow.BROWSER_SIGN_IN.requiresTokens()).isFalse();
+    assertThat(OAuth2Flow.BROWSER_SIGN_IN.requiresSessionToken()).isFalse();
+  }
+
+  @Test
+  public void tokenExchange_RequiresTokens() {
+    assertThat(OAuth2Flow.TOKEN_EXCHANGE.requiresTokens()).isTrue();
+    assertThat(OAuth2Flow.TOKEN_EXCHANGE.requiresCredentials()).isFalse();
+    assertThat(OAuth2Flow.TOKEN_EXCHANGE.requiresSessionToken()).isFalse();
+  }
+
+  @Test
+  public void sessionToken_RequiresSessionToken() {
+    assertThat(OAuth2Flow.SESSION_TOKEN.requiresSessionToken()).isTrue();
+    assertThat(OAuth2Flow.SESSION_TOKEN.requiresCredentials()).isFalse();
+    assertThat(OAuth2Flow.SESSION_TOKEN.requiresTokens()).isFalse();
+  }
+
+  @Test
+  public void allFlows_HaveLabels() {
+    for (OAuth2Flow flow : OAuth2Flow.values()) {
+      assertThat(flow.getLabel()).isNotEmpty();
+    }
+  }
+
+  @Test
+  public void fiveFlows_Defined() {
+    assertThat(OAuth2Flow.values()).hasLength(5);
+  }
+}

--- a/okta-direct-auth-java-cli-sample/src/test/java/com/okta/directauth/cli/oauth2/FakeOAuth2Flows.java
+++ b/okta-direct-auth-java-cli-sample/src/test/java/com/okta/directauth/cli/oauth2/FakeOAuth2Flows.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.directauth.cli.oauth2;
+
+import com.okta.authfoundation.client.TokenInfo;
+import com.okta.oauth2.kmp.DeviceAuthorizationFlowContext;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Test double for {@link OAuth2Flows}.
+ *
+ * <p>Returns pre-configured futures so tests can exercise success, error, and timeout paths without
+ * network access. Records the last invoked method and arguments for assertion.
+ */
+public final class FakeOAuth2Flows implements OAuth2Flows {
+  private CompletableFuture<TokenInfo> tokenResult = new CompletableFuture<>();
+  private CompletableFuture<DeviceAuthorizationFlowContext> deviceStartResult =
+      new CompletableFuture<>();
+  private boolean closed = false;
+
+  // Last invocation tracking
+  private String lastMethod;
+  private String lastUsername;
+  private String lastPassword;
+  private String lastIdToken;
+  private String lastDeviceSecret;
+  private String lastSessionToken;
+  private DeviceAuthorizationFlowContext lastDeviceContext;
+
+  /** Configures the fake to complete token futures successfully with the given token. */
+  public void succeedWith(TokenInfo token) {
+    tokenResult = CompletableFuture.completedFuture(token);
+  }
+
+  /** Configures the fake to fail token futures with the given exception. */
+  public void failWith(Throwable error) {
+    tokenResult = CompletableFuture.failedFuture(error);
+  }
+
+  /** Configures the fake device start to succeed with the given context. */
+  public void deviceStartSucceedWith(DeviceAuthorizationFlowContext context) {
+    deviceStartResult = CompletableFuture.completedFuture(context);
+  }
+
+  /** Configures the fake device start to fail. */
+  public void deviceStartFailWith(Throwable error) {
+    deviceStartResult = CompletableFuture.failedFuture(error);
+  }
+
+  /** Returns the name of the last method called on this fake. */
+  public String getLastMethod() {
+    return lastMethod;
+  }
+
+  public String getLastUsername() {
+    return lastUsername;
+  }
+
+  public String getLastPassword() {
+    return lastPassword;
+  }
+
+  public String getLastIdToken() {
+    return lastIdToken;
+  }
+
+  public String getLastDeviceSecret() {
+    return lastDeviceSecret;
+  }
+
+  public String getLastSessionToken() {
+    return lastSessionToken;
+  }
+
+  public DeviceAuthorizationFlowContext getLastDeviceContext() {
+    return lastDeviceContext;
+  }
+
+  public boolean isClosed() {
+    return closed;
+  }
+
+  @Override
+  public CompletableFuture<TokenInfo> resourceOwner(String username, String password) {
+    lastMethod = "resourceOwner";
+    lastUsername = username;
+    lastPassword = password;
+    return tokenResult;
+  }
+
+  @Override
+  public CompletableFuture<DeviceAuthorizationFlowContext> deviceStart() {
+    lastMethod = "deviceStart";
+    return deviceStartResult;
+  }
+
+  @Override
+  public CompletableFuture<TokenInfo> deviceResume(DeviceAuthorizationFlowContext context) {
+    lastMethod = "deviceResume";
+    lastDeviceContext = context;
+    return tokenResult;
+  }
+
+  @Override
+  public CompletableFuture<TokenInfo> browserSignIn() {
+    lastMethod = "browserSignIn";
+    return tokenResult;
+  }
+
+  @Override
+  public CompletableFuture<TokenInfo> tokenExchange(String idToken, String deviceSecret) {
+    lastMethod = "tokenExchange";
+    lastIdToken = idToken;
+    lastDeviceSecret = deviceSecret;
+    return tokenResult;
+  }
+
+  @Override
+  public CompletableFuture<TokenInfo> sessionToken(String sessionToken) {
+    lastMethod = "sessionToken";
+    lastSessionToken = sessionToken;
+    return tokenResult;
+  }
+
+  @Override
+  public void close() {
+    closed = true;
+  }
+}

--- a/okta-direct-auth-java-cli-sample/src/test/java/com/okta/directauth/cli/oauth2/WrapperOAuth2FlowsTest.java
+++ b/okta-direct-auth-java-cli-sample/src/test/java/com/okta/directauth/cli/oauth2/WrapperOAuth2FlowsTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.directauth.cli.oauth2;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import com.okta.authfoundation.client.kmp.OAuth2Client;
+import java.util.List;
+import org.junit.Test;
+
+public class WrapperOAuth2FlowsTest {
+
+  // ── Valid loopback URIs ───────────────────────────────────────────────────────
+
+  @Test
+  public void signInRedirectUri_Localhost_Accepted() {
+    WrapperOAuth2Flows flows =
+        new WrapperOAuth2Flows(mockClient(), scopes(), "http://localhost:8080/callback");
+    flows.close();
+  }
+
+  @Test
+  public void signInRedirectUri_LoopbackIp_Accepted() {
+    WrapperOAuth2Flows flows =
+        new WrapperOAuth2Flows(mockClient(), scopes(), "http://127.0.0.1:9090/auth");
+    flows.close();
+  }
+
+  @Test
+  public void signInRedirectUri_Ipv6Loopback_Accepted() {
+    // URI.getHost() may return "::1" (brackets stripped) or "[::1]" (brackets retained) depending
+    // on JDK parsing. Both are accepted.
+    WrapperOAuth2Flows flows =
+        new WrapperOAuth2Flows(mockClient(), scopes(), "http://[::1]:8080/callback");
+    flows.close();
+  }
+
+  @Test
+  public void signInRedirectUri_DefaultPort_Accepted() {
+    // Port omitted → treated as 80.
+    WrapperOAuth2Flows flows =
+        new WrapperOAuth2Flows(mockClient(), scopes(), "http://localhost/callback");
+    flows.close();
+  }
+
+  @Test
+  public void signInRedirectUri_CustomPath_Accepted() {
+    WrapperOAuth2Flows flows =
+        new WrapperOAuth2Flows(mockClient(), scopes(), "http://localhost:8080/oauth/callback");
+    flows.close();
+  }
+
+  @Test
+  public void signInRedirectUri_EmptyPath_DefaultsToSlash() {
+    // URI with no path component should not throw.
+    WrapperOAuth2Flows flows =
+        new WrapperOAuth2Flows(mockClient(), scopes(), "http://localhost:8080");
+    flows.close();
+  }
+
+  // ── Invalid URIs ─────────────────────────────────────────────────────────────
+
+  @Test
+  public void signInRedirectUri_HttpsScheme_Rejected() {
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                new WrapperOAuth2Flows(mockClient(), scopes(), "https://localhost:8080/callback"));
+    assertThat(ex.getMessage()).contains("http scheme");
+  }
+
+  @Test
+  public void signInRedirectUri_NonLoopbackHost_Rejected() {
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                new WrapperOAuth2Flows(mockClient(), scopes(), "http://example.com:8080/callback"));
+    assertThat(ex.getMessage()).contains("loopback");
+  }
+
+  @Test
+  public void signInRedirectUri_PublicIp_Rejected() {
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                new WrapperOAuth2Flows(mockClient(), scopes(), "http://192.168.1.1:8080/callback"));
+    assertThat(ex.getMessage()).contains("loopback");
+  }
+
+  @Test
+  public void signInRedirectUri_InvalidSyntax_Rejected() {
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> new WrapperOAuth2Flows(mockClient(), scopes(), "not a valid uri ::"));
+    assertThat(ex.getMessage()).contains("Invalid signInRedirectUri");
+  }
+
+  @Test
+  public void signInRedirectUri_NullHost_Rejected() {
+    // Opaque URIs have no host component.
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> new WrapperOAuth2Flows(mockClient(), scopes(), "http:callback"));
+    assertThat(ex.getMessage()).isNotEmpty();
+  }
+
+  // ── Resource lifecycle ────────────────────────────────────────────────────────
+
+  @Test
+  public void close_IdempotentOnEmptyState() {
+    WrapperOAuth2Flows flows =
+        new WrapperOAuth2Flows(mockClient(), scopes(), "http://localhost:8080/callback");
+    flows.close();
+    // Second close must not throw.
+    flows.close();
+  }
+
+  // ── Helpers ──────────────────────────────────────────────────────────────────
+
+  private static OAuth2Client mockClient() {
+    return mock(OAuth2Client.class);
+  }
+
+  private static List<String> scopes() {
+    return List.of("openid", "profile", "email");
+  }
+}

--- a/okta-direct-auth-java-cli-sample/src/test/java/com/okta/directauth/cli/viewmodel/OAuth2ViewModelTest.java
+++ b/okta-direct-auth-java-cli-sample/src/test/java/com/okta/directauth/cli/viewmodel/OAuth2ViewModelTest.java
@@ -1,0 +1,373 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.directauth.cli.viewmodel;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.okta.authfoundation.client.TokenInfo;
+import com.okta.directauth.cli.model.DeviceCodeDisplay;
+import com.okta.directauth.cli.model.OAuth2Screen;
+import com.okta.directauth.cli.model.TokenDisplay;
+import com.okta.directauth.cli.oauth2.FakeOAuth2Flows;
+import com.okta.oauth2.kmp.DeviceAuthorizationFlowContext;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class OAuth2ViewModelTest {
+  private FakeOAuth2Flows fakeFlows;
+  private OAuth2ViewModel viewModel;
+  private CapturingListener listener;
+
+  @Before
+  public void setUp() {
+    fakeFlows = new FakeOAuth2Flows();
+    viewModel = new OAuth2ViewModel(fakeFlows, false);
+    listener = new CapturingListener();
+    viewModel.addListener(listener);
+  }
+
+  @After
+  public void tearDown() {
+    viewModel.close();
+  }
+
+  // ── US1: Resource Owner Password ────────────────────────────────────────────
+
+  @Test
+  public void startResourceOwner_Success() throws Exception {
+    fakeFlows.succeedWith(makeToken("at-123", "it-456"));
+    viewModel.startResourceOwner("user@example.com", "password");
+    listener.awaitTerminal();
+
+    assertThat(viewModel.getCurrentScreen()).isEqualTo(OAuth2Screen.AUTHENTICATED);
+    assertThat(listener.lastResult).isNotNull();
+    assertThat(listener.lastResult.getAccessToken()).isEqualTo("at-123");
+    assertThat(listener.lastResult.getIdToken()).isEqualTo("it-456");
+    assertThat(fakeFlows.getLastMethod()).isEqualTo("resourceOwner");
+    assertThat(fakeFlows.getLastUsername()).isEqualTo("user@example.com");
+    assertThat(listener.screenHistory).containsExactly(OAuth2Screen.AUTHENTICATED).inOrder();
+  }
+
+  @Test
+  public void startResourceOwner_Error() throws Exception {
+    fakeFlows.failWith(new RuntimeException("invalid_grant: Bad credentials"));
+    viewModel.startResourceOwner("user@example.com", "wrong");
+    listener.awaitTerminal();
+
+    assertThat(viewModel.getCurrentScreen()).isEqualTo(OAuth2Screen.ERROR);
+    assertThat(listener.lastError).contains("invalid_grant");
+    assertThat(listener.screenHistory).containsExactly(OAuth2Screen.ERROR).inOrder();
+  }
+
+  @Test
+  public void startResourceOwner_EmptyUsername_ValidationError() {
+    viewModel.startResourceOwner("", "password");
+
+    assertThat(viewModel.getCurrentScreen()).isEqualTo(OAuth2Screen.ERROR);
+    assertThat(listener.lastError).isNotNull();
+  }
+
+  @Test
+  public void startResourceOwner_EmptyPassword_ValidationError() {
+    viewModel.startResourceOwner("user@example.com", "");
+
+    assertThat(viewModel.getCurrentScreen()).isEqualTo(OAuth2Screen.ERROR);
+    assertThat(listener.lastError).isNotNull();
+  }
+
+  // ── US2: Device Authorization ────────────────────────────────────────────────
+
+  @Test
+  public void startDeviceAuthorization_EmitsDeviceCodeThenToken() throws Exception {
+    DeviceAuthorizationFlowContext ctx =
+        makeDeviceContext("ABC-123", "https://example.okta.com/activate", 300);
+    fakeFlows.deviceStartSucceedWith(ctx);
+    fakeFlows.succeedWith(makeToken("at-device", null));
+
+    viewModel.startDeviceAuthorization();
+    listener.awaitTerminal();
+
+    assertThat(viewModel.getCurrentScreen()).isEqualTo(OAuth2Screen.AUTHENTICATED);
+    assertThat(listener.lastDeviceCode).isNotNull();
+    assertThat(listener.lastDeviceCode.getUserCode()).isEqualTo("ABC-123");
+    assertThat(listener.lastDeviceCode.getVerificationUri())
+        .isEqualTo("https://example.okta.com/activate");
+    assertThat(listener.lastResult).isNotNull();
+    assertThat(listener.lastResult.getAccessToken()).isEqualTo("at-device");
+    // State machine: DEVICE_POLLING set synchronously, then AUTHENTICATED when resume completes.
+    assertThat(listener.screenHistory)
+        .containsAtLeast(OAuth2Screen.DEVICE_POLLING, OAuth2Screen.AUTHENTICATED)
+        .inOrder();
+  }
+
+  @Test
+  public void startDeviceAuthorization_Timeout() throws Exception {
+    DeviceAuthorizationFlowContext ctx =
+        makeDeviceContext("XYZ-789", "https://example.okta.com/activate", 30);
+    fakeFlows.deviceStartSucceedWith(ctx);
+    fakeFlows.failWith(new RuntimeException("authorization_pending: timed out"));
+
+    viewModel.startDeviceAuthorization();
+    listener.awaitTerminal();
+
+    assertThat(viewModel.getCurrentScreen()).isEqualTo(OAuth2Screen.ERROR);
+    assertThat(listener.lastError).contains("authorization_pending");
+    assertThat(listener.screenHistory)
+        .containsAtLeast(OAuth2Screen.DEVICE_POLLING, OAuth2Screen.ERROR)
+        .inOrder();
+  }
+
+  @Test
+  public void startDeviceAuthorization_StartFails() throws Exception {
+    fakeFlows.deviceStartFailWith(new RuntimeException("Device code request failed"));
+
+    viewModel.startDeviceAuthorization();
+    listener.awaitTerminal();
+
+    assertThat(viewModel.getCurrentScreen()).isEqualTo(OAuth2Screen.ERROR);
+    assertThat(listener.lastError).contains("Device code request failed");
+  }
+
+  // ── US3: Browser Sign-In ─────────────────────────────────────────────────────
+
+  @Test
+  public void startBrowserSignIn_Success() throws Exception {
+    fakeFlows.succeedWith(makeToken("at-browser", "it-browser"));
+    viewModel.startBrowserSignIn();
+    listener.awaitTerminal();
+
+    assertThat(viewModel.getCurrentScreen()).isEqualTo(OAuth2Screen.AUTHENTICATED);
+    assertThat(listener.lastResult.getAccessToken()).isEqualTo("at-browser");
+    assertThat(fakeFlows.getLastMethod()).isEqualTo("browserSignIn");
+    assertThat(listener.screenHistory)
+        .containsAtLeast(OAuth2Screen.BROWSER_WAITING, OAuth2Screen.AUTHENTICATED)
+        .inOrder();
+  }
+
+  @Test
+  public void startBrowserSignIn_Canceled() throws Exception {
+    fakeFlows.failWith(new RuntimeException("Browser sign-in was cancelled or timed out"));
+    viewModel.startBrowserSignIn();
+    listener.awaitTerminal();
+
+    assertThat(viewModel.getCurrentScreen()).isEqualTo(OAuth2Screen.ERROR);
+    assertThat(listener.lastError).contains("cancelled or timed out");
+  }
+
+  // ── US4: Token Exchange ───────────────────────────────────────────────────────
+
+  @Test
+  public void startTokenExchange_Success() throws Exception {
+    fakeFlows.succeedWith(makeToken("at-exchange", null));
+    viewModel.startTokenExchange("id-token-value", "device-secret-value");
+    listener.awaitTerminal();
+
+    assertThat(viewModel.getCurrentScreen()).isEqualTo(OAuth2Screen.AUTHENTICATED);
+    assertThat(fakeFlows.getLastMethod()).isEqualTo("tokenExchange");
+    assertThat(fakeFlows.getLastIdToken()).isEqualTo("id-token-value");
+    assertThat(fakeFlows.getLastDeviceSecret()).isEqualTo("device-secret-value");
+  }
+
+  @Test
+  public void startTokenExchange_EmptyIdToken_ValidationError() {
+    viewModel.startTokenExchange("", "device-secret");
+
+    assertThat(viewModel.getCurrentScreen()).isEqualTo(OAuth2Screen.ERROR);
+    assertThat(listener.lastError).isNotNull();
+  }
+
+  @Test
+  public void startTokenExchange_EmptyDeviceSecret_ValidationError() {
+    viewModel.startTokenExchange("id-token", "");
+
+    assertThat(viewModel.getCurrentScreen()).isEqualTo(OAuth2Screen.ERROR);
+    assertThat(listener.lastError).isNotNull();
+  }
+
+  // ── US4: Session Token ───────────────────────────────────────────────────────
+
+  @Test
+  public void startSessionToken_Success() throws Exception {
+    fakeFlows.succeedWith(makeToken("at-session", "it-session"));
+    viewModel.startSessionToken("session-token-value");
+    listener.awaitTerminal();
+
+    assertThat(viewModel.getCurrentScreen()).isEqualTo(OAuth2Screen.AUTHENTICATED);
+    assertThat(fakeFlows.getLastMethod()).isEqualTo("sessionToken");
+    assertThat(fakeFlows.getLastSessionToken()).isEqualTo("session-token-value");
+  }
+
+  @Test
+  public void startSessionToken_EmptyToken_ValidationError() {
+    viewModel.startSessionToken("");
+
+    assertThat(viewModel.getCurrentScreen()).isEqualTo(OAuth2Screen.ERROR);
+    assertThat(listener.lastError).isNotNull();
+  }
+
+  @Test
+  public void startSessionToken_Error() throws Exception {
+    fakeFlows.failWith(new RuntimeException("invalid_token"));
+    viewModel.startSessionToken("bad-session-token");
+    listener.awaitTerminal();
+
+    assertThat(viewModel.getCurrentScreen()).isEqualTo(OAuth2Screen.ERROR);
+    assertThat(listener.lastError).contains("invalid_token");
+  }
+
+  // ── Lifecycle ────────────────────────────────────────────────────────────────
+
+  @Test
+  public void reset_ReturnToMenu() throws Exception {
+    fakeFlows.succeedWith(makeToken("at-x", null));
+    viewModel.startResourceOwner("u", "p");
+    listener.awaitTerminal();
+
+    viewModel.reset();
+    assertThat(viewModel.getCurrentScreen()).isEqualTo(OAuth2Screen.MENU);
+    assertThat(viewModel.getLastTokenDisplay()).isNull();
+  }
+
+  @Test
+  public void close_ClosesFlows() {
+    viewModel.close();
+    assertThat(fakeFlows.isClosed()).isTrue();
+  }
+
+  // ── Helpers ──────────────────────────────────────────────────────────────────
+
+  private static TokenInfo makeToken(String accessToken, String idToken) {
+    return new TokenInfo() {
+      @NotNull
+      @Override
+      public String getId() {
+        return "test-id";
+      }
+
+      @NotNull
+      @Override
+      public String getClientId() {
+        return "test-client";
+      }
+
+      @NotNull
+      @Override
+      public String getIssuerUrl() {
+        return "https://example.okta.com";
+      }
+
+      @NotNull
+      @Override
+      public String getTokenType() {
+        return "Bearer";
+      }
+
+      @Override
+      public int getExpiresIn() {
+        return 3600;
+      }
+
+      @NotNull
+      @Override
+      public String getAccessToken() {
+        return accessToken;
+      }
+
+      @Nullable
+      @Override
+      public String getScope() {
+        return "openid profile email";
+      }
+
+      @Nullable
+      @Override
+      public String getRefreshToken() {
+        return null;
+      }
+
+      @Nullable
+      @Override
+      public String getIdToken() {
+        return idToken;
+      }
+
+      @Nullable
+      @Override
+      public String getDeviceSecret() {
+        return null;
+      }
+
+      @Nullable
+      @Override
+      public String getIssuedTokenType() {
+        return null;
+      }
+    };
+  }
+
+  private static DeviceAuthorizationFlowContext makeDeviceContext(
+      String userCode, String verificationUri, int expiresIn) {
+    return new DeviceAuthorizationFlowContext(
+        verificationUri, null, userCode, expiresIn, "fake-device-code", 5);
+  }
+
+  private static class CapturingListener implements OAuth2ViewModelListener {
+    // Released when the screen reaches a terminal state (AUTHENTICATED or ERROR).
+    private final CountDownLatch terminalLatch = new CountDownLatch(1);
+    OAuth2Screen lastScreen;
+    DeviceCodeDisplay lastDeviceCode;
+    TokenDisplay lastResult;
+    String lastError;
+    final List<OAuth2Screen> screenHistory = new ArrayList<>();
+
+    /** Blocks until the ViewModel reaches AUTHENTICATED or ERROR, with a 5-second timeout. */
+    void awaitTerminal() throws InterruptedException {
+      boolean reached = terminalLatch.await(5, TimeUnit.SECONDS);
+      assertThat(reached).isTrue();
+    }
+
+    @Override
+    public void onScreenChanged(OAuth2Screen screen) {
+      lastScreen = screen;
+      screenHistory.add(screen);
+      if (screen == OAuth2Screen.AUTHENTICATED || screen == OAuth2Screen.ERROR) {
+        terminalLatch.countDown();
+      }
+    }
+
+    @Override
+    public void onDeviceCode(DeviceCodeDisplay deviceCode) {
+      lastDeviceCode = deviceCode;
+    }
+
+    @Override
+    public void onResult(TokenDisplay token) {
+      lastResult = token;
+    }
+
+    @Override
+    public void onError(String message) {
+      lastError = message;
+    }
+  }
+}


### PR DESCRIPTION
Extends okta-direct-auth-java-cli-sample with a second demonstration mode (OAuth2 Flows) alongside the existing Direct Authentication mode. All five OAuth2 standard flows are driven through the oauth2 module's Java-friendly CompletableFuture wrappers with no Kotlin coroutine surface exposed to Java callers. Use picocli for CLI inerface

New classes:
- OAuth2Flow / OAuth2Screen / DeviceCodeDisplay (model)
- OAuth2Flows interface + WrapperOAuth2Flows (jvm.* wrappers)
- OAuth2ViewModel + OAuth2ViewModelListener
- OAuth2ConsoleView (reuses StateRenderer.renderToken)

Main.java gains --mode / --desktopSignInRedirectUri options and a top-level mode menu; build.gradle.kts adds :oauth2 dep and signInRedirectUri in generated AppConfig. README fully updated (org setup, CLI options, usage examples, Features section).

RESOLVES: OKTA-1213658