### PR TITLE
Update web-authentication-ui to use KMP AuthorizationCodeFlow internally. Add KMP OAuth2Client constructor to WebAuthentication; deprecate Android-only path

### DIFF
--- a/app/src/main/java/sample/okta/android/SampleApplication.kt
+++ b/app/src/main/java/sample/okta/android/SampleApplication.kt
@@ -20,7 +20,9 @@ import android.app.Application
 import android.content.Context
 import androidx.biometric.BiometricPrompt
 import com.okta.authfoundation.AuthFoundation
+import com.okta.authfoundation.client.OAuth2ClientBuilder
 import com.okta.authfoundation.client.OidcConfiguration
+import com.okta.authfoundation.client.kmp.OAuth2Client
 import com.okta.authfoundation.credential.Credential
 import com.okta.authfoundation.credential.TokenDbRecoveryUtil
 import timber.log.Timber
@@ -29,6 +31,15 @@ class SampleApplication : Application() {
     companion object {
         @SuppressLint("StaticFieldLeak")
         lateinit var context: Context
+
+        val oAuth2Client: OAuth2Client by lazy {
+            OAuth2ClientBuilder
+                .create(
+                    issuerUrl = BuildConfig.ISSUER,
+                    clientId = BuildConfig.CLIENT_ID,
+                    scope = SampleHelper.DEFAULT_SCOPE.split(" ")
+                ).getOrThrow()
+        }
     }
 
     override fun onCreate() {

--- a/app/src/main/java/sample/okta/android/browser/BrowserFragment.kt
+++ b/app/src/main/java/sample/okta/android/browser/BrowserFragment.kt
@@ -17,6 +17,7 @@ package sample.okta.android.browser
 
 import android.os.Bundle
 import android.view.View
+import android.widget.Toast
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import sample.okta.android.databinding.FragmentBrowserBinding
@@ -45,6 +46,7 @@ internal class BrowserFragment :
                 is BrowserState.Error -> {
                     binding.errorTextView.visibility = View.VISIBLE
                     binding.errorTextView.text = state.message
+                    Toast.makeText(requireContext(), state.message, Toast.LENGTH_LONG).show()
                 }
 
                 BrowserState.Idle -> {

--- a/app/src/main/java/sample/okta/android/browser/BrowserViewModel.kt
+++ b/app/src/main/java/sample/okta/android/browser/BrowserViewModel.kt
@@ -25,6 +25,7 @@ import com.okta.authfoundation.credential.Credential
 import com.okta.webauthenticationui.WebAuthentication
 import kotlinx.coroutines.launch
 import sample.okta.android.BuildConfig
+import sample.okta.android.SampleApplication
 import sample.okta.android.SampleHelper
 import timber.log.Timber
 
@@ -39,11 +40,13 @@ class BrowserViewModel : ViewModel() {
         viewModelScope.launch {
             _state.value = BrowserState.Loading
 
-            val webAuthentication = WebAuthentication()
-            var scope = SampleHelper.DEFAULT_SCOPE
-            if (addDeviceSsoScope) {
-                scope += " device_sso"
-            }
+            val webAuthentication = WebAuthentication(SampleApplication.oAuth2Client)
+            val scope =
+                if (addDeviceSsoScope) {
+                    "${SampleHelper.DEFAULT_SCOPE} device_sso"
+                } else {
+                    SampleHelper.DEFAULT_SCOPE
+                }
 
             when (
                 val result =
@@ -56,7 +59,7 @@ class BrowserViewModel : ViewModel() {
             ) {
                 is OAuth2ClientResult.Error -> {
                     Timber.e(result.exception, "Failed to start login flow.")
-                    _state.value = BrowserState.Error("Failed to start login flow.")
+                    _state.value = BrowserState.Error(result.exception.message ?: "Failed to start login flow.")
                 }
 
                 is OAuth2ClientResult.Success -> {

--- a/app/src/main/java/sample/okta/android/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/sample/okta/android/dashboard/DashboardViewModel.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.launch
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import sample.okta.android.BuildConfig
+import sample.okta.android.SampleApplication
 import sample.okta.android.SampleHelper
 import timber.log.Timber
 
@@ -135,7 +136,7 @@ internal class DashboardViewModel(
             val idToken = credential.token.idToken ?: return@launch
             when (
                 val result =
-                    WebAuthentication().logoutOfBrowser(
+                    WebAuthentication(SampleApplication.oAuth2Client).logoutOfBrowser(
                         context = context,
                         redirectUrl = BuildConfig.SIGN_OUT_REDIRECT_URI,
                         idToken = idToken

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -5,6 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:filterTouchesWhenObscured="true"
+    android:fitsSystemWindows="true"
     tools:context="sample.okta.android.MainActivity"
     >
 

--- a/web-authentication-ui/api/web-authentication-ui.api
+++ b/web-authentication-ui/api/web-authentication-ui.api
@@ -45,19 +45,17 @@ public final class com/okta/webauthenticationui/ForegroundActivityEvent$OnResume
 
 public final class com/okta/webauthenticationui/WebAuthentication {
 	public static final field Companion Lcom/okta/webauthenticationui/WebAuthentication$Companion;
+	public fun <init> (Lcom/okta/authfoundation/client/kmp/OAuth2Client;Lcom/okta/webauthenticationui/WebAuthenticationProvider;)V
+	public synthetic fun <init> (Lcom/okta/authfoundation/client/kmp/OAuth2Client;Lcom/okta/webauthenticationui/WebAuthenticationProvider;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lcom/okta/authfoundation/client/OAuth2Client;Lcom/okta/webauthenticationui/WebAuthenticationProvider;)V
 	public synthetic fun <init> (Lcom/okta/authfoundation/client/OAuth2Client;Lcom/okta/webauthenticationui/WebAuthenticationProvider;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lcom/okta/authfoundation/client/OidcConfiguration;Lcom/okta/webauthenticationui/WebAuthenticationProvider;)V
 	public synthetic fun <init> (Lcom/okta/authfoundation/client/OidcConfiguration;Lcom/okta/webauthenticationui/WebAuthenticationProvider;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lcom/okta/webauthenticationui/WebAuthenticationProvider;)V
 	public synthetic fun <init> (Lcom/okta/webauthenticationui/WebAuthenticationProvider;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getAuthorizationCodeFlow ()Lcom/okta/oauth2/AuthorizationCodeFlow;
-	public final fun getRedirectEndSessionFlow ()Lcom/okta/oauth2/RedirectEndSessionFlow;
 	public final fun login (Landroid/content/Context;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun login$default (Lcom/okta/webauthenticationui/WebAuthentication;Landroid/content/Context;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun logoutOfBrowser (Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun setAuthorizationCodeFlow (Lcom/okta/oauth2/AuthorizationCodeFlow;)V
-	public final fun setRedirectEndSessionFlow (Lcom/okta/oauth2/RedirectEndSessionFlow;)V
 }
 
 public final class com/okta/webauthenticationui/WebAuthentication$Companion {

--- a/web-authentication-ui/src/main/java/com/okta/webauthenticationui/WebAuthentication.kt
+++ b/web-authentication-ui/src/main/java/com/okta/webauthenticationui/WebAuthentication.kt
@@ -18,16 +18,20 @@ package com.okta.webauthenticationui
 import android.app.Activity
 import android.content.Context
 import androidx.annotation.VisibleForTesting
-import com.okta.authfoundation.client.OAuth2Client
 import com.okta.authfoundation.client.OAuth2ClientResult
 import com.okta.authfoundation.client.OidcConfiguration
+import com.okta.authfoundation.client.TokenInfo
 import com.okta.authfoundation.client.internal.SdkVersionsRegistry
+import com.okta.authfoundation.client.kmp.OAuth2Client
 import com.okta.authfoundation.credential.Token
-import com.okta.oauth2.AuthorizationCodeFlow
-import com.okta.oauth2.RedirectEndSessionFlow
+import com.okta.authfoundation.events.EventCoordinator
+import com.okta.oauth2.kmp.AuthorizationCodeFlow
+import com.okta.oauth2.kmp.RedirectEndSessionFlow
 import com.okta.webauthenticationui.BuildConfig.SDK_VERSION
 import com.okta.webauthenticationui.events.CustomizeBrowserEvent
 import com.okta.webauthenticationui.events.CustomizeCustomTabsEvent
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import com.okta.authfoundation.client.OAuth2Client as AndroidOAuth2Client
 
 @Deprecated(
     message = "Renamed to WebAuthentication",
@@ -45,9 +49,12 @@ typealias WebAuthenticationClient = WebAuthentication
  * To further customize the authentication flow, please read more about the underlying flows: [AuthorizationCodeFlow],
  * [RedirectEndSessionFlow].
  */
-class WebAuthentication(
-    private val client: OAuth2Client,
-    private val webAuthenticationProvider: WebAuthenticationProvider = DefaultWebAuthenticationProvider(client.configuration.eventCoordinator),
+class WebAuthentication private constructor(
+    private val authorizationCodeFlowFactory: () -> AuthorizationCodeFlow,
+    private val redirectEndSessionFlowFactory: () -> RedirectEndSessionFlow,
+    private val tokenOidcConfiguration: OidcConfiguration,
+    private val defaultScopeValue: String,
+    private val webAuthenticationProvider: WebAuthenticationProvider,
 ) {
     companion object {
         init {
@@ -56,14 +63,49 @@ class WebAuthentication(
     }
 
     /**
+     * Initializes a web authentication client backed by a KMP [OAuth2Client].
+     *
+     * This is the preferred constructor. The KMP client is used directly to create the underlying
+     * [AuthorizationCodeFlow] and [RedirectEndSessionFlow].
+     *
+     * @param oAuth2Client the KMP [OAuth2Client] to use for authorization requests.
+     * @param webAuthenticationProvider the [WebAuthenticationProvider] which will be used to show
+     * the UI when performing the redirect flows.
+     */
+    constructor(
+        oAuth2Client: OAuth2Client,
+        webAuthenticationProvider: WebAuthenticationProvider = DefaultWebAuthenticationProvider(EventCoordinator(emptyList())),
+    ) : this(
+        authorizationCodeFlowFactory = { AuthorizationCodeFlow(oAuth2Client) },
+        redirectEndSessionFlowFactory = { RedirectEndSessionFlow(oAuth2Client) },
+        tokenOidcConfiguration =
+            OidcConfiguration(
+                clientId = oAuth2Client.configuration.clientId,
+                defaultScope = oAuth2Client.configuration.defaultScope,
+                issuer = oAuth2Client.configuration.issuerUrl
+            ),
+        defaultScopeValue = oAuth2Client.configuration.defaultScope,
+        webAuthenticationProvider = webAuthenticationProvider
+    )
+
+    /**
      * Initializes a web authentication client.
      *
      * @param webAuthenticationProvider the [WebAuthenticationProvider] which will be used to show the UI when performing the
      * redirect flows.
      */
+    @Deprecated(
+        message = "Use the constructor taking com.okta.authfoundation.client.kmp.OAuth2Client instead.",
+        replaceWith =
+            ReplaceWith(
+                "WebAuthentication(kmpClient, webAuthenticationProvider)",
+                "com.okta.authfoundation.client.kmp.OAuth2Client"
+            )
+    )
+    @Suppress("DEPRECATION")
     constructor(
         webAuthenticationProvider: WebAuthenticationProvider = DefaultWebAuthenticationProvider(OidcConfiguration.default.eventCoordinator),
-    ) : this(OAuth2Client.default, webAuthenticationProvider)
+    ) : this(AndroidOAuth2Client.default, webAuthenticationProvider)
 
     /**
      * Initializes a web authentication client.
@@ -72,15 +114,72 @@ class WebAuthentication(
      * @param webAuthenticationProvider the [WebAuthenticationProvider] which will be used to show the UI when performing the
      * redirect flows.
      */
+    @Deprecated(
+        message = "Use the constructor taking com.okta.authfoundation.client.kmp.OAuth2Client instead.",
+        replaceWith =
+            ReplaceWith(
+                "WebAuthentication(kmpClient, webAuthenticationProvider)",
+                "com.okta.authfoundation.client.kmp.OAuth2Client"
+            )
+    )
+    @Suppress("DEPRECATION")
     constructor(
         oidcConfiguration: OidcConfiguration,
         webAuthenticationProvider: WebAuthenticationProvider = DefaultWebAuthenticationProvider(oidcConfiguration.eventCoordinator),
-    ) : this(OAuth2Client.createFromConfiguration(oidcConfiguration), webAuthenticationProvider)
+    ) : this(AndroidOAuth2Client.createFromConfiguration(oidcConfiguration), webAuthenticationProvider)
 
-    var authorizationCodeFlow: AuthorizationCodeFlow = AuthorizationCodeFlow(client)
-    var redirectEndSessionFlow: RedirectEndSessionFlow = RedirectEndSessionFlow(client)
+    /**
+     * Initializes a web authentication client backed by an Android-only [OAuth2Client].
+     *
+     * @param client the Android [OAuth2Client] to use for authorization requests.
+     * @param webAuthenticationProvider the [WebAuthenticationProvider] which will be used to show the UI when performing the
+     * redirect flows.
+     */
+    @Deprecated(
+        message = "Use the constructor taking com.okta.authfoundation.client.kmp.OAuth2Client instead.",
+        replaceWith =
+            ReplaceWith(
+                "WebAuthentication(kmpClient, webAuthenticationProvider)",
+                "com.okta.authfoundation.client.kmp.OAuth2Client"
+            )
+    )
+    constructor(
+        client: AndroidOAuth2Client,
+        webAuthenticationProvider: WebAuthenticationProvider = DefaultWebAuthenticationProvider(client.configuration.eventCoordinator),
+    ) : this(
+        authorizationCodeFlowFactory = { AuthorizationCodeFlow(client) },
+        redirectEndSessionFlowFactory = { RedirectEndSessionFlow(client) },
+        tokenOidcConfiguration = client.configuration,
+        defaultScopeValue = client.configuration.defaultScope,
+        webAuthenticationProvider = webAuthenticationProvider
+    )
 
-    @VisibleForTesting internal var redirectCoordinator: RedirectCoordinator = SingletonRedirectCoordinator
+    private val flowLock = Any()
+
+    @Volatile
+    private var authorizationCodeFlowBacking: AuthorizationCodeFlow? = null
+
+    @VisibleForTesting
+    internal var authorizationCodeFlow: AuthorizationCodeFlow
+        get() =
+            authorizationCodeFlowBacking ?: synchronized(flowLock) {
+                authorizationCodeFlowBacking ?: authorizationCodeFlowFactory().also { authorizationCodeFlowBacking = it }
+            }
+        set(value) = synchronized(flowLock) { authorizationCodeFlowBacking = value }
+
+    @Volatile
+    private var redirectEndSessionFlowBacking: RedirectEndSessionFlow? = null
+
+    @VisibleForTesting
+    internal var redirectEndSessionFlow: RedirectEndSessionFlow
+        get() =
+            redirectEndSessionFlowBacking ?: synchronized(flowLock) {
+                redirectEndSessionFlowBacking ?: redirectEndSessionFlowFactory().also { redirectEndSessionFlowBacking = it }
+            }
+        set(value) = synchronized(flowLock) { redirectEndSessionFlowBacking = value }
+
+    @VisibleForTesting
+    internal var redirectCoordinator: RedirectCoordinator = SingletonRedirectCoordinator
 
     /**
      * Used in a [OAuth2ClientResult.Error.exception].
@@ -105,50 +204,38 @@ class WebAuthentication(
      * @param redirectUrl the redirect URL.
      * @param extraRequestParameters the extra key value pairs to send to the authorize endpoint.
      *  See [Authorize Documentation](https://developer.okta.com/docs/reference/api/oidc/#authorize) for parameter options.
-     * @param scope the scopes to request during sign in. Defaults to the configured [client] [OidcConfiguration.defaultScope].
+     * @param scope the scopes to request during sign in. Defaults to the configured client's default scope.
      */
     suspend fun login(
         context: Context,
         redirectUrl: String,
         extraRequestParameters: Map<String, String> = emptyMap(),
-        scope: String = client.configuration.defaultScope,
+        scope: String = defaultScopeValue,
     ): OAuth2ClientResult<Token> {
         val initializationResult =
             redirectCoordinator.initialize(webAuthenticationProvider, context) {
-                when (val result = authorizationCodeFlow.start(redirectUrl, extraRequestParameters, scope)) {
-                    is OAuth2ClientResult.Success -> {
-                        RedirectInitializationResult.Success(result.result.url, result.result)
+                authorizationCodeFlow
+                    .start(redirectUrl, extraRequestParameters, scope)
+                    .mapCatching { flowContext ->
+                        RedirectInitializationResult.Success(flowContext.url.toHttpUrl(), flowContext)
+                    }.getOrElse { e ->
+                        RedirectInitializationResult.Error(e.asException())
                     }
-
-                    is OAuth2ClientResult.Error -> {
-                        RedirectInitializationResult.Error(result.exception)
-                    }
-                }
             }
 
         val flowContext =
             when (initializationResult) {
-                is RedirectInitializationResult.Error -> {
-                    return OAuth2ClientResult.Error(initializationResult.exception)
-                }
-
-                is RedirectInitializationResult.Success -> {
-                    initializationResult.flowContext
-                }
+                is RedirectInitializationResult.Error -> return OAuth2ClientResult.Error(initializationResult.exception)
+                is RedirectInitializationResult.Success -> initializationResult.flowContext
             }
 
         val uri =
             when (val redirectResult = redirectCoordinator.listenForResult()) {
-                is RedirectResult.Error -> {
-                    return OAuth2ClientResult.Error(redirectResult.exception)
-                }
-
-                is RedirectResult.Redirect -> {
-                    redirectResult.uri
-                }
+                is RedirectResult.Error -> return OAuth2ClientResult.Error(redirectResult.exception)
+                is RedirectResult.Redirect -> redirectResult.uri
             }
 
-        return authorizationCodeFlow.resume(uri, flowContext)
+        return authorizationCodeFlow.resume(uri.toString(), flowContext).mapToOAuth2ClientResult { it.toToken() }
     }
 
     /**
@@ -168,39 +255,52 @@ class WebAuthentication(
     ): OAuth2ClientResult<Unit> {
         val initializationResult =
             redirectCoordinator.initialize(webAuthenticationProvider, context) {
-                when (val result = redirectEndSessionFlow.start(redirectUrl, idToken)) {
-                    is OAuth2ClientResult.Success -> {
-                        RedirectInitializationResult.Success(result.result.url, result.result)
+                redirectEndSessionFlow
+                    .start(idToken, redirectUrl)
+                    .mapCatching { flowContext ->
+                        RedirectInitializationResult.Success(flowContext.url.toHttpUrl(), flowContext)
+                    }.getOrElse { e ->
+                        RedirectInitializationResult.Error(e.asException())
                     }
-
-                    is OAuth2ClientResult.Error -> {
-                        RedirectInitializationResult.Error(result.exception)
-                    }
-                }
             }
 
         val flowContext =
             when (initializationResult) {
-                is RedirectInitializationResult.Error -> {
-                    return OAuth2ClientResult.Error(initializationResult.exception)
-                }
-
-                is RedirectInitializationResult.Success -> {
-                    initializationResult.flowContext
-                }
+                is RedirectInitializationResult.Error -> return OAuth2ClientResult.Error(initializationResult.exception)
+                is RedirectInitializationResult.Success -> initializationResult.flowContext
             }
 
         val uri =
             when (val redirectResult = redirectCoordinator.listenForResult()) {
-                is RedirectResult.Error -> {
-                    return OAuth2ClientResult.Error(redirectResult.exception)
-                }
-
-                is RedirectResult.Redirect -> {
-                    redirectResult.uri
-                }
+                is RedirectResult.Error -> return OAuth2ClientResult.Error(redirectResult.exception)
+                is RedirectResult.Redirect -> redirectResult.uri
             }
 
-        return redirectEndSessionFlow.resume(uri, flowContext)
+        return redirectEndSessionFlow.resume(uri.toString(), flowContext).fold(
+            onSuccess = { OAuth2ClientResult.Success(Unit) },
+            onFailure = { OAuth2ClientResult.Error(it.asException()) }
+        )
     }
+
+    private fun Throwable.asException(): Exception = this as? Exception ?: RuntimeException(this)
+
+    private fun TokenInfo.toToken(): Token =
+        Token(
+            id = id,
+            tokenType = tokenType,
+            expiresIn = expiresIn,
+            accessToken = accessToken,
+            scope = scope,
+            refreshToken = refreshToken,
+            idToken = idToken,
+            deviceSecret = deviceSecret,
+            issuedTokenType = issuedTokenType,
+            oidcConfiguration = tokenOidcConfiguration
+        )
+
+    private fun <T, R> Result<T>.mapToOAuth2ClientResult(transform: (T) -> R): OAuth2ClientResult<R> =
+        fold(
+            onSuccess = { OAuth2ClientResult.Success(transform(it)) },
+            onFailure = { OAuth2ClientResult.Error(it.asException()) }
+        )
 }

--- a/web-authentication-ui/src/main/java/com/okta/webauthenticationui/WebAuthenticationProvider.kt
+++ b/web-authentication-ui/src/main/java/com/okta/webauthenticationui/WebAuthenticationProvider.kt
@@ -26,6 +26,7 @@ import android.os.Bundle
 import android.provider.Browser
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.browser.customtabs.CustomTabsService
+import androidx.core.net.toUri
 import com.okta.authfoundation.events.EventCoordinator
 import com.okta.webauthenticationui.events.CustomizeBrowserEvent
 import com.okta.webauthenticationui.events.CustomizeCustomTabsEvent
@@ -76,7 +77,7 @@ internal class DefaultWebAuthenticationProvider(
         tabsIntent.intent.putExtra(Browser.EXTRA_HEADERS, headers)
 
         try {
-            tabsIntent.launchUrl(context, Uri.parse(url.toString()))
+            tabsIntent.launchUrl(context, url.toString().toUri())
             return null
         } catch (e: ActivityNotFoundException) {
             return e

--- a/web-authentication-ui/src/test/java/com/okta/webauthenticationui/WebAuthenticationTest.kt
+++ b/web-authentication-ui/src/test/java/com/okta/webauthenticationui/WebAuthenticationTest.kt
@@ -19,11 +19,13 @@ import android.content.Context
 import android.net.Uri
 import com.google.common.truth.Truth.assertThat
 import com.okta.authfoundation.client.OAuth2ClientResult
+import com.okta.authfoundation.client.TokenInfo
 import com.okta.authfoundation.credential.Token
+import com.okta.oauth2.kmp.AuthorizationCodeFlow
+import com.okta.oauth2.kmp.AuthorizationCodeFlowContext
+import com.okta.oauth2.kmp.RedirectEndSessionFlow
+import com.okta.oauth2.kmp.RedirectEndSessionFlowContext
 import com.okta.testhelpers.OktaRule
-import com.okta.testhelpers.RequestMatchers.method
-import com.okta.testhelpers.RequestMatchers.path
-import com.okta.testhelpers.testBodyFromFile
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.test.runTest
@@ -37,25 +39,96 @@ import java.util.concurrent.TimeUnit
 
 @RunWith(RobolectricTestRunner::class)
 class WebAuthenticationTest {
-    private val mockPrefix = "test_responses"
-
     @get:Rule val oktaRule = OktaRule()
+
+    private val loginFlowContext =
+        AuthorizationCodeFlowContext(
+            url = "http://example.com/authorize?state=test-login-state",
+            redirectUrl = "unitTest:/login",
+            codeVerifier = "test-code-verifier",
+            state = "test-login-state",
+            nonce = "test-nonce",
+            maxAge = null
+        )
+
+    private val loginTokenInfo: TokenInfo =
+        object : TokenInfo {
+            override val id = "test-token-id"
+            override val clientId = "test-client-id"
+            override val issuerUrl = "https://example-test.okta.com/oauth2/default"
+            override val tokenType = "Bearer"
+            override val expiresIn = 3600
+            override val accessToken = "exampleAccessToken"
+            override val scope = "offline_access profile openid email"
+            override val refreshToken = "exampleRefreshToken"
+            override val idToken =
+                "eyJraWQiOiJGSkEwSEdOdHN1dWRhX1BsNDVKNDJrdlFxY3N1XzBDNEZnN3BiSkxYVEhZIiwiYWxnIjoiUlMyNTYifQ" +
+                    ".eyJzdWIiOiIwMHViNDF6N21nek5xcnlNdjY5NiIsIm5hbWUiOiJKYXkgTmV3c3Ryb20iLCJlbWFpbCI6ImpheW5l" +
+                    "d3N0cm9tQGV4YW1wbGUuY29tIiwidmVyIjoxLCJpc3MiOiJodHRwczovL2V4YW1wbGUtdGVzdC5va3RhLmNvbS9v" +
+                    "YXV0aDIvZGVmYXVsdCIsImF1ZCI6IjBvYThmdXAwbEFQWUZDNEkyNjk2IiwiaWF0IjoxNjQ0MzQ3MDY5LCJleHAi" +
+                    "OjE2NDQzNTA2NjksImp0aSI6IklELjU1Y3hCdGRZbDhsNmFyS0lTUEJ3ZDB5T1QtOVVDVGFYYVFUWHQybGFSTHMi" +
+                    "LCJhbXIiOlsicHdkIl0sImlkcCI6IjAwbzhmb3U3c1JhR0d3ZG40Njk2Iiwic2lkIjoiaWR4V3hrbHBfNGtTeHVD" +
+                    "X25VMXBYRC1uQSIsInByZWZlcnJlZF91c2VybmFtZSI6ImpheW5ld3N0cm9tQGV4YW1wbGUuY29tIiwiYXV0aF90" +
+                    "aW1lIjoxNjQ0MzQ3MDY4LCJhdF9oYXNoIjoiZ01jR1RiaEdUMUdfbGRzSG9Kc1B6USIsImRzX2hhc2giOiJEQWVM" +
+                    "T0ZScWlmeXNiZ3NyYk9nYm9nIn0.z7LBgWT2O-DUZiOOUzr90qEgLoMiR5eHZsY1V2XPbhfOrjIv9ax9niHE7lPS" +
+                    "5GYq02w4Cuf0DbdWjiNj96n4wTPmNU6N0x-XRluv4kved_wBBIvWNLGu_ZZZAFXaIFqmFGxPB6hIsYKvB3FmQCC0N" +
+                    "vSXyDquadW9X7bBA7BO7VfX_jOKCkK_1MC1FZdU9n8rppu190Gk-z5dEWegHHtKy3vb12t4NR9CkA2uQgolnii8fN" +
+                    "bie-3Z6zAdMXAZXkIcFu43Wn4TGwuzWK25IThcMNsPbLFFI4r0zo9E20IsH4gcJQiE_vFUzukzCsbppaiSAWBdSgE" +
+                    "S9K-QskWacZIWOg"
+            override val deviceSecret = "exampleDeviceSecret"
+            override val issuedTokenType = "urn:ietf:params:oauth:token-type:access_token"
+        }
+
+    private val logoutFlowContext =
+        RedirectEndSessionFlowContext(
+            url = "http://example.com/logout?state=test-logout-state",
+            redirectUrl = "unitTest:/logout",
+            state = "test-logout-state"
+        )
+
+    private fun authorizationCodeFlowStub(
+        startResult: Result<AuthorizationCodeFlowContext> = Result.success(loginFlowContext),
+        resumeResult: Result<TokenInfo> = Result.success(loginTokenInfo),
+    ): AuthorizationCodeFlow =
+        object : AuthorizationCodeFlow {
+            override suspend fun start(
+                redirectUrl: String,
+                extraRequestParameters: Map<String, String>,
+                scope: String?,
+            ): Result<AuthorizationCodeFlowContext> = startResult
+
+            override suspend fun resume(
+                uri: String,
+                flowContext: AuthorizationCodeFlowContext,
+            ): Result<TokenInfo> = resumeResult
+        }
+
+    private fun redirectEndSessionFlowStub(
+        startResult: Result<RedirectEndSessionFlowContext> = Result.success(logoutFlowContext),
+        resumeResult: Result<Unit> = Result.success(Unit),
+    ): RedirectEndSessionFlow =
+        object : RedirectEndSessionFlow {
+            override suspend fun start(
+                idToken: String,
+                redirectUrl: String,
+                extraRequestParameters: Map<String, String>,
+            ): Result<RedirectEndSessionFlowContext> = startResult
+
+            override fun resume(
+                uri: String,
+                flowContext: RedirectEndSessionFlowContext,
+            ): Result<Unit> = resumeResult
+        }
 
     @Test fun testLogin(): Unit =
         runTest {
-            oktaRule.enqueue(
-                method("POST"),
-                path("/oauth2/default/v1/token")
-            ) { response ->
-                response.testBodyFromFile("$mockPrefix/token.json")
-            }
-
             val webAuthenticationProvider = mock<WebAuthenticationProvider>()
             val webAuthentication = WebAuthentication(webAuthenticationProvider)
             val context = mock<Context>()
 
             val redirectCoordinator = DefaultRedirectCoordinator(this)
             webAuthentication.redirectCoordinator = redirectCoordinator
+            webAuthentication.authorizationCodeFlow = authorizationCodeFlowStub()
 
             val initializeCountDownLatch = CountDownLatch(1)
             redirectCoordinator.initializerContinuationListeningCallback = {
@@ -83,9 +156,153 @@ class WebAuthenticationTest {
             assertThat(token.accessToken).isEqualTo("exampleAccessToken")
             assertThat(token.scope).isEqualTo("offline_access profile openid email")
             assertThat(token.refreshToken).isEqualTo("exampleRefreshToken")
-            assertThat(token.idToken).isEqualTo(
-                "eyJraWQiOiJGSkEwSEdOdHN1dWRhX1BsNDVKNDJrdlFxY3N1XzBDNEZnN3BiSkxYVEhZIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiIwMHViNDF6N21nek5xcnlNdjY5NiIsIm5hbWUiOiJKYXkgTmV3c3Ryb20iLCJlbWFpbCI6ImpheW5ld3N0cm9tQGV4YW1wbGUuY29tIiwidmVyIjoxLCJpc3MiOiJodHRwczovL2V4YW1wbGUtdGVzdC5va3RhLmNvbS9vYXV0aDIvZGVmYXVsdCIsImF1ZCI6IjBvYThmdXAwbEFQWUZDNEkyNjk2IiwiaWF0IjoxNjQ0MzQ3MDY5LCJleHAiOjE2NDQzNTA2NjksImp0aSI6IklELjU1Y3hCdGRZbDhsNmFyS0lTUEJ3ZDB5T1QtOVVDVGFYYVFUWHQybGFSTHMiLCJhbXIiOlsicHdkIl0sImlkcCI6IjAwbzhmb3U3c1JhR0d3ZG40Njk2Iiwic2lkIjoiaWR4V3hrbHBfNGtTeHVDX25VMXBYRC1uQSIsInByZWZlcnJlZF91c2VybmFtZSI6ImpheW5ld3N0cm9tQGV4YW1wbGUuY29tIiwiYXV0aF90aW1lIjoxNjQ0MzQ3MDY4LCJhdF9oYXNoIjoiZ01jR1RiaEdUMUdfbGRzSG9Kc1B6USIsImRzX2hhc2giOiJEQWVMT0ZScWlmeXNiZ3NyYk9nYm9nIn0.z7LBgWT2O-DUZiOOUzr90qEgLoMiR5eHZsY1V2XPbhfOrjIv9ax9niHE7lPS5GYq02w4Cuf0DbdWjiNj96n4wTPmNU6N0x-XRluv4kved_wBBIvWNLGu_ZZZAFXaIFqmFGxPB6hIsYKvB3FmQCC0NvSXyDquadW9X7bBA7BO7VfX_jOKCkK_1MC1FZdU9n8rppu190Gk-z5dEWegHHtKy3vb12t4NR9CkA2uQgolnii8fNbie-3Z6zAdMXAZXkIcFu43Wn4TGwuzWK25IThcMNsPbLFFI4r0zo9E20IsH4gcJQiE_vFUzukzCsbppaiSAWBdSgES9K-QskWacZIWOg"
-            )
+            assertThat(token.idToken).isEqualTo(loginTokenInfo.idToken)
+            assertThat(token.deviceSecret).isEqualTo("exampleDeviceSecret")
+            assertThat(token.issuedTokenType).isEqualTo("urn:ietf:params:oauth:token-type:access_token")
+            assertThat(token.oidcConfiguration).isSameInstanceAs(oktaRule.configuration)
+        }
+
+    @Test fun testLoginResumeError(): Unit =
+        runTest {
+            val webAuthenticationProvider = mock<WebAuthenticationProvider>()
+            val webAuthentication = WebAuthentication(oktaRule.configuration, webAuthenticationProvider)
+            val context = mock<Context>()
+
+            val redirectCoordinator = DefaultRedirectCoordinator(this)
+            webAuthentication.redirectCoordinator = redirectCoordinator
+            webAuthentication.authorizationCodeFlow =
+                authorizationCodeFlowStub(
+                    resumeResult = Result.failure(AuthorizationCodeFlow.ResumeException("state mismatch", "state_mismatch"))
+                )
+
+            val initializeCountDownLatch = CountDownLatch(1)
+            redirectCoordinator.initializerContinuationListeningCallback = {
+                initializeCountDownLatch.countDown()
+            }
+            val redirectCountDownLatch = CountDownLatch(1)
+            redirectCoordinator.redirectContinuationListeningCallback = {
+                redirectCountDownLatch.countDown()
+            }
+            val loginResultDeferred =
+                async(Dispatchers.IO) {
+                    webAuthentication.login(context, "unitTest:/login")
+                }
+            assertThat(initializeCountDownLatch.await(1, TimeUnit.SECONDS)).isTrue()
+            redirectCoordinator.runInitializationFunction()
+
+            assertThat(redirectCountDownLatch.await(1, TimeUnit.SECONDS)).isTrue()
+            redirectCoordinator.emit(Uri.parse("unitTest:/login?state=bad-state&code=ExampleCode"))
+
+            val exception = (loginResultDeferred.await() as OAuth2ClientResult.Error<Token>).exception
+            assertThat(exception).isInstanceOf(AuthorizationCodeFlow.ResumeException::class.java)
+        }
+
+    @Test fun testLogoutResumeError(): Unit =
+        runTest {
+            val webAuthenticationProvider = mock<WebAuthenticationProvider>()
+            val webAuthentication = WebAuthentication(oktaRule.configuration, webAuthenticationProvider)
+            val context = mock<Context>()
+
+            val redirectCoordinator = DefaultRedirectCoordinator(this)
+            webAuthentication.redirectCoordinator = redirectCoordinator
+            webAuthentication.redirectEndSessionFlow =
+                redirectEndSessionFlowStub(
+                    resumeResult = Result.failure(RuntimeException("state mismatch"))
+                )
+
+            val initializeCountDownLatch = CountDownLatch(1)
+            redirectCoordinator.initializerContinuationListeningCallback = {
+                initializeCountDownLatch.countDown()
+            }
+            val redirectCountDownLatch = CountDownLatch(1)
+            redirectCoordinator.redirectContinuationListeningCallback = {
+                redirectCountDownLatch.countDown()
+            }
+            val logoutResultDeferred =
+                async(Dispatchers.IO) {
+                    webAuthentication.logoutOfBrowser(context, "unitTest:/logout", "ExampleIdToken")
+                }
+            assertThat(initializeCountDownLatch.await(1, TimeUnit.SECONDS)).isTrue()
+            redirectCoordinator.runInitializationFunction()
+
+            assertThat(redirectCountDownLatch.await(1, TimeUnit.SECONDS)).isTrue()
+            redirectCoordinator.emit(Uri.parse("unitTest:/logout?state=bad-state"))
+
+            val exception = (logoutResultDeferred.await() as OAuth2ClientResult.Error<Unit>).exception
+            assertThat(exception).isInstanceOf(RuntimeException::class.java)
+        }
+
+    @Test fun testLoginMalformedUrl_ReturnsError(): Unit =
+        runTest {
+            val webAuthenticationProvider = mock<WebAuthenticationProvider>()
+            val webAuthentication = WebAuthentication(webAuthenticationProvider)
+            val context = mock<Context>()
+
+            val redirectCoordinator = DefaultRedirectCoordinator(this)
+            webAuthentication.redirectCoordinator = redirectCoordinator
+            webAuthentication.authorizationCodeFlow =
+                authorizationCodeFlowStub(
+                    startResult =
+                        Result.success(
+                            AuthorizationCodeFlowContext(
+                                url = "not a valid url",
+                                redirectUrl = "unitTest:/login",
+                                codeVerifier = "cv",
+                                state = "s",
+                                nonce = "n",
+                                maxAge = null
+                            )
+                        )
+                )
+
+            val initializeCountDownLatch = CountDownLatch(1)
+            redirectCoordinator.initializerContinuationListeningCallback = {
+                initializeCountDownLatch.countDown()
+            }
+            val loginResultDeferred =
+                async(Dispatchers.IO) {
+                    webAuthentication.login(context, "unitTest:/login")
+                }
+            assertThat(initializeCountDownLatch.await(1, TimeUnit.SECONDS)).isTrue()
+            redirectCoordinator.runInitializationFunction()
+
+            val exception = (loginResultDeferred.await() as OAuth2ClientResult.Error<Token>).exception
+            assertThat(exception).isInstanceOf(IllegalArgumentException::class.java)
+        }
+
+    @Test fun testLogoutMalformedUrl_ReturnsError(): Unit =
+        runTest {
+            val webAuthenticationProvider = mock<WebAuthenticationProvider>()
+            val webAuthentication = WebAuthentication(webAuthenticationProvider)
+            val context = mock<Context>()
+
+            val redirectCoordinator = DefaultRedirectCoordinator(this)
+            webAuthentication.redirectCoordinator = redirectCoordinator
+            webAuthentication.redirectEndSessionFlow =
+                redirectEndSessionFlowStub(
+                    startResult =
+                        Result.success(
+                            RedirectEndSessionFlowContext(
+                                url = "not a valid url",
+                                redirectUrl = "unitTest:/logout",
+                                state = "s"
+                            )
+                        )
+                )
+
+            val initializeCountDownLatch = CountDownLatch(1)
+            redirectCoordinator.initializerContinuationListeningCallback = {
+                initializeCountDownLatch.countDown()
+            }
+            val logoutResultDeferred =
+                async(Dispatchers.IO) {
+                    webAuthentication.logoutOfBrowser(context, "unitTest:/logout", "ExampleIdToken")
+                }
+            assertThat(initializeCountDownLatch.await(1, TimeUnit.SECONDS)).isTrue()
+            redirectCoordinator.runInitializationFunction()
+
+            val exception = (logoutResultDeferred.await() as OAuth2ClientResult.Error<Unit>).exception
+            assertThat(exception).isInstanceOf(IllegalArgumentException::class.java)
         }
 
     @Test fun testLoginInitializationCancellation(): Unit =
@@ -96,6 +313,7 @@ class WebAuthenticationTest {
 
             val redirectCoordinator = DefaultRedirectCoordinator(this)
             webAuthentication.redirectCoordinator = redirectCoordinator
+            webAuthentication.authorizationCodeFlow = authorizationCodeFlowStub()
 
             val initializeCountDownLatch = CountDownLatch(1)
             redirectCoordinator.initializerContinuationListeningCallback = {
@@ -120,6 +338,7 @@ class WebAuthenticationTest {
 
             val redirectCoordinator = DefaultRedirectCoordinator(this)
             webAuthentication.redirectCoordinator = redirectCoordinator
+            webAuthentication.authorizationCodeFlow = authorizationCodeFlowStub()
 
             val initializeCountDownLatch = CountDownLatch(1)
             redirectCoordinator.initializerContinuationListeningCallback = {
@@ -145,15 +364,16 @@ class WebAuthenticationTest {
 
     @Test fun testLoginAuthorizationCodeFlowError(): Unit =
         runTest {
-            oktaRule.enqueue(path("/.well-known/openid-configuration")) { response ->
-                response.setResponseCode(503)
-            }
             val webAuthenticationProvider = mock<WebAuthenticationProvider>()
             val webAuthentication = WebAuthentication(oktaRule.configuration, webAuthenticationProvider)
             val context = mock<Context>()
 
             val redirectCoordinator = DefaultRedirectCoordinator(this)
             webAuthentication.redirectCoordinator = redirectCoordinator
+            webAuthentication.authorizationCodeFlow =
+                authorizationCodeFlowStub(
+                    startResult = Result.failure(IllegalStateException("OIDC Endpoints not available."))
+                )
 
             val initializeCountDownLatch = CountDownLatch(1)
             redirectCoordinator.initializerContinuationListeningCallback = {
@@ -167,7 +387,7 @@ class WebAuthenticationTest {
             redirectCoordinator.runInitializationFunction()
 
             val exception = (loginResultDeferred.await() as OAuth2ClientResult.Error<Token>).exception
-            assertThat(exception).isInstanceOf(OAuth2ClientResult.Error.OidcEndpointsNotAvailableException::class.java)
+            assertThat(exception).isInstanceOf(IllegalStateException::class.java)
         }
 
     @Test fun testLogout(): Unit =
@@ -178,6 +398,7 @@ class WebAuthenticationTest {
 
             val redirectCoordinator = DefaultRedirectCoordinator(this)
             webAuthentication.redirectCoordinator = redirectCoordinator
+            webAuthentication.redirectEndSessionFlow = redirectEndSessionFlowStub()
 
             val initializeCountDownLatch = CountDownLatch(1)
             redirectCoordinator.initializerContinuationListeningCallback = {
@@ -210,6 +431,7 @@ class WebAuthenticationTest {
 
             val redirectCoordinator = DefaultRedirectCoordinator(this)
             webAuthentication.redirectCoordinator = redirectCoordinator
+            webAuthentication.redirectEndSessionFlow = redirectEndSessionFlowStub()
 
             val initializeCountDownLatch = CountDownLatch(1)
             redirectCoordinator.initializerContinuationListeningCallback = {
@@ -234,6 +456,7 @@ class WebAuthenticationTest {
 
             val redirectCoordinator = DefaultRedirectCoordinator(this)
             webAuthentication.redirectCoordinator = redirectCoordinator
+            webAuthentication.redirectEndSessionFlow = redirectEndSessionFlowStub()
 
             val initializeCountDownLatch = CountDownLatch(1)
             redirectCoordinator.initializerContinuationListeningCallback = {
@@ -259,15 +482,16 @@ class WebAuthenticationTest {
 
     @Test fun testLogoutEndSessionRedirectFlowError(): Unit =
         runTest {
-            oktaRule.enqueue(path("/.well-known/openid-configuration")) { response ->
-                response.setResponseCode(503)
-            }
             val webAuthenticationProvider = mock<WebAuthenticationProvider>()
             val webAuthentication = WebAuthentication(oktaRule.configuration, webAuthenticationProvider)
             val context = mock<Context>()
 
             val redirectCoordinator = DefaultRedirectCoordinator(this)
             webAuthentication.redirectCoordinator = redirectCoordinator
+            webAuthentication.redirectEndSessionFlow =
+                redirectEndSessionFlowStub(
+                    startResult = Result.failure(IllegalStateException("OIDC Endpoints not available."))
+                )
 
             val initializeCountDownLatch = CountDownLatch(1)
             redirectCoordinator.initializerContinuationListeningCallback = {
@@ -281,6 +505,6 @@ class WebAuthenticationTest {
             redirectCoordinator.runInitializationFunction()
 
             val exception = (logoutResultDeferred.await() as OAuth2ClientResult.Error<Unit>).exception
-            assertThat(exception).isInstanceOf(OAuth2ClientResult.Error.OidcEndpointsNotAvailableException::class.java)
+            assertThat(exception).isInstanceOf(IllegalStateException::class.java)
         }
 }


### PR DESCRIPTION
- Replace Android-only AuthorizationCodeFlow / RedirectEndSessionFlow imports with the KMP interfaces (com.okta.oauth2.kmp.*) in WebAuthentication
- Use lazy-initialized backing fields so tests can inject stubs before the KMP client creation (which requires HTTPS URLs) is triggered
- Bridge Result<TokenInfo> → OAuth2ClientResult<Token> via a private toToken() helper that builds a Token from the TokenInfo fields + client.configuration
- Fix parameter order in logoutOfBrowser: KMP start() takes (idToken, redirectUrl) whereas the old Android overload took (redirectUrl, idToken)
- Pass uri.toString() to KMP resume() directly instead of the Android compat extension, keeping the call-site free of extra imports
- Update WebAuthenticationTest to stub the KMP flow interfaces instead of making real HTTP calls to the mock server; error tests now expect IllegalStateException (what the KMP impl throws for missing endpoints)
- Update sample app to show a toast on browser sign in errors.

Add KMP OAuth2Client constructor to WebAuthentication; deprecate Android-only path

- Refactor WebAuthentication to a private primary constructor that stores flow factories and a derived OidcConfiguration, decoupling it from any specific client type
- Add preferred constructor taking com.okta.authfoundation.client.kmp.OAuth2Client: creates flows via the KMP companion invoke (no AndroidCompatExtensions bridge), derives OidcConfiguration from KMP config for the Token bridge
- Deprecate the three Android-only constructors (no-arg, OidcConfiguration, OAuth2Client) with ReplaceWith pointing to the KMP constructor
- Update API dump to include the new KMP constructor alongside the deprecated ones
- Show real exception message in BrowserViewModel error state and add a toast in BrowserFragment so login errors are visible in the sample app
- Fix app content rendering under status bar on Android 15
- Update sample app to use KMP OAuth2Client constructor for WebAuthentication

RESOLVES: OKTA-1163828