### PR TITLE
Deprecate EventCoordinator and migrate biometric/retry to typed APIs

### DIFF
--- a/auth-foundation/api/jvm/auth-foundation.api
+++ b/auth-foundation/api/jvm/auth-foundation.api
@@ -289,6 +289,7 @@ public final class com/okta/authfoundation/client/OAuth2ClientBuilder {
 	public final fun getIdTokenValidator ()Lcom/okta/authfoundation/client/kmp/IdTokenValidator;
 	public final fun getIoDispatcher ()Lkotlin/coroutines/CoroutineContext;
 	public final fun getJson ()Lkotlinx/serialization/json/Json;
+	public final fun getRateLimitRetryCallback ()Lkotlin/jvm/functions/Function1;
 	public final fun setAccessTokenValidator (Lcom/okta/authfoundation/client/kmp/AccessTokenValidator;)V
 	public final fun setAcrValues (Ljava/lang/String;)V
 	public final fun setApiExecutor (Lcom/okta/authfoundation/api/http/ApiExecutor;)V
@@ -302,6 +303,7 @@ public final class com/okta/authfoundation/client/OAuth2ClientBuilder {
 	public final fun setIdTokenValidator (Lcom/okta/authfoundation/client/kmp/IdTokenValidator;)V
 	public final fun setIoDispatcher (Lkotlin/coroutines/CoroutineContext;)V
 	public final fun setJson (Lkotlinx/serialization/json/Json;)V
+	public final fun setRateLimitRetryCallback (Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class com/okta/authfoundation/client/OAuth2ClientBuilder$Companion {
@@ -324,6 +326,7 @@ public final class com/okta/authfoundation/client/OAuth2ClientConfiguration {
 	public final fun getIdTokenValidator ()Lcom/okta/authfoundation/client/kmp/IdTokenValidator;
 	public final fun getIssuerUrl ()Ljava/lang/String;
 	public final fun getJson ()Lkotlinx/serialization/json/Json;
+	public final fun getRateLimitRetryCallback ()Lkotlin/jvm/functions/Function1;
 }
 
 public abstract class com/okta/authfoundation/client/OAuth2ClientResult {
@@ -557,6 +560,34 @@ public final class com/okta/authfoundation/client/kmp/IdTokenValidator$Parameter
 	public final fun getNonce ()Ljava/lang/String;
 }
 
+public final class com/okta/authfoundation/client/kmp/MaxRetries {
+	public static final synthetic fun box-impl (I)Lcom/okta/authfoundation/client/kmp/MaxRetries;
+	public static fun constructor-impl (I)I
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (ILjava/lang/Object;)Z
+	public static final fun equals-impl0 (II)Z
+	public final fun getValue ()I
+	public fun hashCode ()I
+	public static fun hashCode-impl (I)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (I)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()I
+}
+
+public final class com/okta/authfoundation/client/kmp/MinDelaySeconds {
+	public static final synthetic fun box-impl (J)Lcom/okta/authfoundation/client/kmp/MinDelaySeconds;
+	public static fun constructor-impl (J)J
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (JLjava/lang/Object;)Z
+	public static final fun equals-impl0 (JJ)Z
+	public final fun getValue ()J
+	public fun hashCode ()I
+	public static fun hashCode-impl (J)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (J)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()J
+}
+
 public final class com/okta/authfoundation/client/kmp/OAuth2Client {
 	public static final field Companion Lcom/okta/authfoundation/client/kmp/OAuth2Client$Companion;
 	public final fun deviceAuthorizationRequest-gIAlu-s (Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -575,6 +606,19 @@ public final class com/okta/authfoundation/client/kmp/OAuth2Client {
 
 public final class com/okta/authfoundation/client/kmp/OAuth2Client$Companion {
 	public final fun createFromConfiguration (Lcom/okta/authfoundation/client/OAuth2ClientConfiguration;)Lcom/okta/authfoundation/client/kmp/OAuth2Client;
+}
+
+public final class com/okta/authfoundation/client/kmp/RateLimitRetryConfig {
+	public synthetic fun <init> (IJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-KHxJZ0A ()I
+	public final fun component2-Klur8Ro ()J
+	public final fun copy-HXtXcCM (IJ)Lcom/okta/authfoundation/client/kmp/RateLimitRetryConfig;
+	public static synthetic fun copy-HXtXcCM$default (Lcom/okta/authfoundation/client/kmp/RateLimitRetryConfig;IJILjava/lang/Object;)Lcom/okta/authfoundation/client/kmp/RateLimitRetryConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMaxRetries-KHxJZ0A ()I
+	public final fun getMinDelaySeconds-Klur8Ro ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/okta/authfoundation/client/kmp/events/RateLimitExceededEvent : com/okta/authfoundation/events/TokenEvent {
@@ -712,6 +756,12 @@ public final class com/okta/authfoundation/credential/kmp/BearerTokenPluginConfi
 
 public final class com/okta/authfoundation/credential/kmp/BearerTokenPluginKt {
 	public static final fun getBearerTokenPlugin ()Lio/ktor/client/plugins/api/ClientPlugin;
+}
+
+public final class com/okta/authfoundation/credential/kmp/BiometricKeyInvalidatedException : java/lang/Exception {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun getKeyAlias ()Ljava/lang/String;
+	public final fun getTokenId ()Ljava/lang/String;
 }
 
 public abstract interface class com/okta/authfoundation/credential/kmp/Credential : com/okta/authfoundation/credential/CredentialIdentifier {

--- a/auth-foundation/src/androidHostTest/kotlin/com/okta/authfoundation/BiometricDecryptionActivityTest.kt
+++ b/auth-foundation/src/androidHostTest/kotlin/com/okta/authfoundation/BiometricDecryptionActivityTest.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation
+
+import androidx.biometric.BiometricPrompt
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+@RunWith(AndroidJUnit4::class)
+class BiometricDecryptionActivityTest {
+    @After
+    fun tearDown() = unmockkAll()
+
+    /**
+     * Regression test: onAuthenticationFailed() previously called resumeWithException()
+     * which propagated a fatal exception on the main thread. Verify it is now a no-op for
+     * the coroutine — the prompt stays open for retry.
+     */
+    @Test
+    fun onAuthenticationFailed_DoesNotResumeCoroutine_PromptRemainsOpen() {
+        val continuationResumed = AtomicBoolean(false)
+        val callback = buildCallbackWithContinuation { continuationResumed.set(true) }
+
+        callback.onAuthenticationFailed()
+
+        assertFalse(continuationResumed.get())
+    }
+
+    @Test
+    fun onAuthenticationFailed_ThenSucceeded_CompletesSuccessfully() {
+        val result = AtomicReference<Result<Unit>>()
+        val callback = buildCallbackWithContinuation { result.set(it) }
+
+        callback.onAuthenticationFailed()
+        callback.onAuthenticationSucceeded(mockk(relaxed = true))
+
+        assertTrue(assertNotNull(result.get()).isSuccess)
+    }
+
+    @Test
+    fun onAuthenticationFailed_ThenError_TerminatesWithBiometricException() {
+        val result = AtomicReference<Result<Unit>>()
+        val callback = buildCallbackWithContinuation { result.set(it) }
+
+        callback.onAuthenticationFailed()
+        callback.onAuthenticationError(BiometricPrompt.ERROR_USER_CANCELED, "Cancelled")
+
+        val r = assertNotNull(result.get())
+        assertTrue(r.isFailure)
+        val ex = assertIs<BiometricAuthenticationException>(r.exceptionOrNull())
+        assertIs<BiometricExceptionDetails.OnAuthenticationError>(ex.biometricExceptionDetails)
+    }
+
+    private fun buildCallbackWithContinuation(onResume: (Result<Unit>) -> Unit): BiometricPrompt.AuthenticationCallback {
+        val continuation =
+            object : Continuation<Unit> {
+                override val context = EmptyCoroutineContext
+
+                override fun resumeWith(result: Result<Unit>) = onResume(result)
+            }
+
+        setStaticBiometricAction(continuation)
+
+        return BiometricDecryptionActivity.createAuthenticationCallback(finish = {})
+    }
+
+    private fun setStaticBiometricAction(continuation: Continuation<Unit>) {
+        val unlockInstance =
+            Class
+                .forName("com.okta.authfoundation.BiometricDecryptionActivity\$BiometricAction\$Unlock")
+                .declaredConstructors[0]
+                .also { it.isAccessible = true }
+                .newInstance(continuation)
+
+        BiometricDecryptionActivity::class.java
+            .getDeclaredField("biometricAction")
+            .also { it.isAccessible = true }
+            .set(null, unlockInstance)
+    }
+}

--- a/auth-foundation/src/androidHostTest/kotlin/com/okta/authfoundation/credential/BiometricKeyInvalidatedTest.kt
+++ b/auth-foundation/src/androidHostTest/kotlin/com/okta/authfoundation/credential/BiometricKeyInvalidatedTest.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.credential
+
+import android.security.keystore.KeyPermanentlyInvalidatedException
+import androidx.biometric.BiometricPrompt
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import com.okta.authfoundation.credential.kmp.BiometricKeyInvalidatedException
+import com.okta.authfoundation.credential.storage.TokenDatabase
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.test.assertFailsWith
+
+@RunWith(AndroidJUnit4::class)
+class BiometricKeyInvalidatedTest {
+    private val token = createToken(id = "testTokenId")
+    private val tokenMetadata =
+        Token.Metadata(id = "testTokenId", tags = emptyMap(), payloadData = null)
+
+    private lateinit var database: TokenDatabase
+    private lateinit var roomTokenStorage: RoomTokenStorage
+
+    @Before
+    fun setup() {
+        database =
+            Room
+                .inMemoryDatabaseBuilder(
+                    ApplicationProvider.getApplicationContext(),
+                    TokenDatabase::class.java
+                ).allowMainThreadQueries()
+                .build()
+        roomTokenStorage = RoomTokenStorage(database, BiometricFailingEncryptionHandler())
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+
+    @Test
+    fun getToken_ThrowsBiometricKeyInvalidatedException_WhenKeyInvalidated() =
+        runTest {
+            roomTokenStorage.add(token, tokenMetadata, Credential.Security.standard)
+
+            val exception =
+                assertFailsWith<BiometricKeyInvalidatedException> {
+                    roomTokenStorage.getToken("testTokenId", null)
+                }
+
+            assertThat(exception.tokenId).isEqualTo("testTokenId")
+            assertThat(exception.keyAlias).isNotEmpty()
+        }
+
+    @Test
+    fun getToken_AutoDeletesTokenByDefault_WhenKeyInvalidated() =
+        runTest {
+            roomTokenStorage.add(token, tokenMetadata, Credential.Security.standard)
+            assertThat(roomTokenStorage.allIds()).isEqualTo(listOf("testTokenId"))
+
+            assertFailsWith<BiometricKeyInvalidatedException> {
+                roomTokenStorage.getToken("testTokenId", null)
+            }
+
+            // Token must be auto-deleted (backward compat: deleteInvalidatedToken = true by default)
+            assertThat(roomTokenStorage.allIds()).isEmpty()
+        }
+}
+
+/**
+ * A [TokenEncryptionHandler] that encrypts normally but simulates biometric key invalidation
+ * by throwing [KeyPermanentlyInvalidatedException] on every [decrypt] call.
+ */
+private class BiometricFailingEncryptionHandler : TokenEncryptionHandler {
+    override fun generateKey(security: Credential.Security) = Unit
+
+    override suspend fun encrypt(
+        token: Token,
+        security: Credential.Security,
+    ): TokenEncryptionHandler.EncryptionResult {
+        val serialized = Json.encodeToString(Token.serializer(), token)
+        return TokenEncryptionHandler.EncryptionResult(serialized.toByteArray(), emptyMap())
+    }
+
+    override suspend fun decrypt(
+        encryptedToken: ByteArray,
+        encryptionExtras: Map<String, String>,
+        security: Credential.Security,
+        promptInfo: BiometricPrompt.PromptInfo?,
+    ): Token = throw KeyPermanentlyInvalidatedException()
+}

--- a/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/AuthFoundationDefaults.kt
+++ b/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/AuthFoundationDefaults.kt
@@ -59,7 +59,21 @@ object AuthFoundationDefaults {
     /** The CoroutineDispatcher which should be used for compute bound tasks. */
     var computeDispatcher: CoroutineContext by NoSetAfterGetWithLazyDefaultFactory { getComputeDispatcher() }
 
-    /** The default EventCoordinator. */
+    /**
+     * The default EventCoordinator.
+     *
+     * @deprecated EventCoordinator is deprecated. Configure rate-limit retry via
+     * [com.okta.authfoundation.client.OAuth2ClientConfiguration.rateLimitRetryCallback] and
+     * observe events via [com.okta.authfoundation.client.kmp.OAuth2Client.events] or
+     * [com.okta.authfoundation.credential.kmp.TokenCredentialManager.events] SharedFlow.
+     */
+    @Deprecated(
+        message =
+            "EventCoordinator is deprecated. Configure rate-limit retry via " +
+                "OAuth2ClientConfiguration.rateLimitRetryCallback and observe events via " +
+                "OAuth2Client.events or TokenCredentialManager.events SharedFlow instead.",
+        level = DeprecationLevel.WARNING
+    )
     var eventCoordinator: EventCoordinator by NoSetAfterGetWithLazyDefaultFactory { getEventCoordinator() }
 
     /** The default OidcClock. */

--- a/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/BiometricDecryptionActivity.kt
+++ b/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/BiometricDecryptionActivity.kt
@@ -25,6 +25,8 @@ import androidx.biometric.BiometricPrompt
 import androidx.biometric.BiometricPrompt.AuthenticationCallback
 import androidx.biometric.BiometricPrompt.PromptInfo
 import androidx.core.content.ContextCompat
+import com.okta.authfoundation.api.log.LogLevel
+import com.okta.authfoundation.api.log.getDefaultAuthFoundationLogger
 import com.okta.authfoundation.client.ApplicationContextHolder
 import com.okta.authfoundation.util.runCatchingCancellable
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -34,6 +36,8 @@ import javax.crypto.Cipher
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
+
+private val logger = getDefaultAuthFoundationLogger()
 
 class BiometricDecryptionActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -75,9 +79,45 @@ class BiometricDecryptionActivity : AppCompatActivity() {
 
     private fun biometricPrompt(): BiometricPrompt {
         val executor = ContextCompat.getMainExecutor(this)
-        return BiometricPrompt(
-            this,
-            executor,
+        return BiometricPrompt(this, executor, createAuthenticationCallback(::finish))
+    }
+
+    private sealed interface BiometricAction {
+        fun resumeWithException(exception: Exception)
+
+        class Unlock(
+            val continuation: Continuation<Unit>,
+        ) : BiometricAction {
+            override fun resumeWithException(exception: Exception) {
+                continuation.resumeWithException(exception)
+            }
+        }
+
+        class Decrypt(
+            val cipher: Cipher,
+            val encryptedData: ByteArray,
+            val continuation: Continuation<ByteArray>,
+        ) : BiometricAction {
+            override fun resumeWithException(exception: Exception) {
+                continuation.resumeWithException(exception)
+            }
+        }
+    }
+
+    internal companion object {
+        private lateinit var promptInfo: PromptInfo
+        private lateinit var biometricAction: BiometricAction
+        private val accessMutex = Mutex()
+
+        private fun startActivity() {
+            val intent = Intent()
+            intent.setClass(ApplicationContextHolder.appContext, BiometricDecryptionActivity::class.java)
+            intent.action = BiometricDecryptionActivity::class.java.name
+            intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS
+            ApplicationContextHolder.appContext.startActivity(intent)
+        }
+
+        internal fun createAuthenticationCallback(finish: () -> Unit): AuthenticationCallback =
             object : AuthenticationCallback() {
                 override fun onAuthenticationError(
                     errorCode: Int,
@@ -115,52 +155,12 @@ class BiometricDecryptionActivity : AppCompatActivity() {
                 }
 
                 override fun onAuthenticationFailed() {
-                    biometricAction.resumeWithException(
-                        BiometricAuthenticationException(
-                            "Unexpected Biometric error",
-                            BiometricExceptionDetails.OnAuthenticationFailed
-                        )
+                    logger.write(
+                        "Biometric attempt not recognized; prompt remains open for retry.",
+                        logLevel = LogLevel.WARN
                     )
-                    finish()
                 }
             }
-        )
-    }
-
-    private sealed interface BiometricAction {
-        fun resumeWithException(exception: Exception)
-
-        class Unlock(
-            val continuation: Continuation<Unit>,
-        ) : BiometricAction {
-            override fun resumeWithException(exception: Exception) {
-                continuation.resumeWithException(exception)
-            }
-        }
-
-        class Decrypt(
-            val cipher: Cipher,
-            val encryptedData: ByteArray,
-            val continuation: Continuation<ByteArray>,
-        ) : BiometricAction {
-            override fun resumeWithException(exception: Exception) {
-                continuation.resumeWithException(exception)
-            }
-        }
-    }
-
-    internal companion object {
-        private lateinit var promptInfo: PromptInfo
-        private lateinit var biometricAction: BiometricAction
-        private val accessMutex = Mutex()
-
-        private fun startActivity() {
-            val intent = Intent()
-            intent.setClass(ApplicationContextHolder.appContext, BiometricDecryptionActivity::class.java)
-            intent.action = BiometricDecryptionActivity::class.java.name
-            intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS
-            ApplicationContextHolder.appContext.startActivity(intent)
-        }
 
         internal suspend fun biometricUnlock(promptInfo: PromptInfo): Result<Unit> =
             accessMutex.withLock {

--- a/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/client/OidcConfiguration.kt
+++ b/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/client/OidcConfiguration.kt
@@ -50,7 +50,21 @@ class OidcConfiguration private constructor(
     @property:InternalAuthFoundationApi val computeDispatcher: CoroutineContext = AuthFoundationDefaults.computeDispatcher,
     /** The OidcClock which is used for all time related functions in the SDK. */
     @property:InternalAuthFoundationApi val clock: OidcClock = AuthFoundationDefaults.clock,
-    /** The EventCoordinator which the OAuth2Client should emit events to. */
+    /**
+     * The EventCoordinator which the OAuth2Client should emit events to.
+     *
+     * @deprecated EventCoordinator is deprecated. Configure rate-limit retry via
+     * [com.okta.authfoundation.client.OAuth2ClientConfiguration.rateLimitRetryCallback] and
+     * observe events via [com.okta.authfoundation.client.kmp.OAuth2Client.events] or
+     * [com.okta.authfoundation.credential.kmp.TokenCredentialManager.events] SharedFlow.
+     */
+    @Deprecated(
+        message =
+            "EventCoordinator is deprecated. Configure rate-limit retry via " +
+                "OAuth2ClientConfiguration.rateLimitRetryCallback and observe events via " +
+                "OAuth2Client.events or TokenCredentialManager.events SharedFlow instead.",
+        level = DeprecationLevel.WARNING
+    )
     @Transient @property:InternalAuthFoundationApi val eventCoordinator: EventCoordinator = AuthFoundationDefaults.eventCoordinator,
     /** The IdTokenValidator used to validate the Id Token Jwt when tokens are minted. */
     @property:InternalAuthFoundationApi val idTokenValidator: IdTokenValidator = AuthFoundationDefaults.idTokenValidator,

--- a/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/client/internal/NetworkUtils.kt
+++ b/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/client/internal/NetworkUtils.kt
@@ -113,6 +113,9 @@ internal suspend fun <T> OidcConfiguration.internalPerformRequest(
     }
 }
 
+// Deprecated: Configure retry via OAuth2ClientConfiguration.rateLimitRetryCallback on the KMP
+// OAuth2Client instead. This loop is preserved for Android backward compatibility and will be
+// removed in a future major release alongside EventCoordinator removal (Phase 5).
 private suspend fun OidcConfiguration.executeRequest(
     request: Request,
     ignoreRateLimit: (Response) -> Boolean = { false },

--- a/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/credential/CredentialDataSource.kt
+++ b/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/credential/CredentialDataSource.kt
@@ -15,12 +15,12 @@
  */
 package com.okta.authfoundation.credential
 
-import android.security.keystore.KeyPermanentlyInvalidatedException
 import androidx.biometric.BiometricPrompt
 import com.okta.authfoundation.AuthFoundationDefaults
 import com.okta.authfoundation.InternalAuthFoundationApi
 import com.okta.authfoundation.client.OidcConfiguration
 import com.okta.authfoundation.credential.events.CredentialCreatedEvent
+import com.okta.authfoundation.credential.kmp.BiometricKeyInvalidatedException
 import com.okta.authfoundation.jwt.JwtParser
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -98,7 +98,7 @@ class CredentialDataSource(
             val token =
                 try {
                     storage.getToken(id, promptInfo)
-                } catch (ex: KeyPermanentlyInvalidatedException) {
+                } catch (ex: BiometricKeyInvalidatedException) {
                     return null
                 }
             credentialsCache[id] =

--- a/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/credential/RoomTokenStorage.kt
+++ b/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/credential/RoomTokenStorage.kt
@@ -25,6 +25,7 @@ import com.okta.authfoundation.client.ApplicationContextHolder
 import com.okta.authfoundation.client.EncryptionTokenProvider
 import com.okta.authfoundation.credential.events.BiometricKeyInvalidatedEvent
 import com.okta.authfoundation.credential.events.BiometricTokenInvalidatedEvent
+import com.okta.authfoundation.credential.kmp.BiometricKeyInvalidatedException
 import com.okta.authfoundation.credential.storage.TokenDatabase
 import com.okta.authfoundation.credential.storage.TokenEntity
 import com.okta.authfoundation.credential.storage.migration.V1ToV2StorageMigrator
@@ -174,7 +175,7 @@ class RoomTokenStorage(
                     }
                 }
             }
-            throw ex
+            throw BiometricKeyInvalidatedException(tokenEntity.id, tokenEntity.keyAlias)
         }
 
     private fun Credential.Security.biometricTimeout(): Int? =

--- a/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/credential/events/BiometricKeyInvalidatedEvent.kt
+++ b/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/credential/events/BiometricKeyInvalidatedEvent.kt
@@ -22,7 +22,23 @@ import com.okta.authfoundation.events.CredentialEvent
 /**
  * Emitted when [KeyPermanentlyInvalidatedException] is thrown when trying to use an invalidated biometric
  * key while fetching a [Token].
+ *
+ * @deprecated Use [Result.failure] with
+ * [com.okta.authfoundation.credential.kmp.BiometricKeyInvalidatedException] returned from
+ * [com.okta.authfoundation.credential.kmp.TokenStorage.getToken] instead. On Android the
+ * invalidated token is auto-deleted by default. For async notification on the KMP path, observe
+ * [com.okta.authfoundation.credential.kmp.TokenCredentialManager.events] and filter for
+ * [com.okta.authfoundation.credential.events.TokenStorageAccessErrorEvent] where
+ * `exception is` [com.okta.authfoundation.credential.kmp.BiometricKeyInvalidatedException].
  */
+@Deprecated(
+    message =
+        "Use Result.failure(BiometricKeyInvalidatedException) from TokenStorage.getToken() instead. " +
+            "On Android, the invalidated token is auto-deleted by default. " +
+            "For async notification on the KMP path, observe TokenCredentialManager.events and " +
+            "filter for TokenStorageAccessErrorEvent where exception is BiometricKeyInvalidatedException.",
+    level = DeprecationLevel.WARNING
+)
 class BiometricKeyInvalidatedEvent internal constructor(
     /**
      * The key with [keyAlias] that got invalidated.

--- a/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/credential/events/BiometricTokenInvalidatedEvent.kt
+++ b/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/credential/events/BiometricTokenInvalidatedEvent.kt
@@ -20,7 +20,19 @@ import com.okta.authfoundation.events.CredentialEvent
 
 /**
  * Emitted when the key of a biometric secured [Token] is invalidated.
+ *
+ * @deprecated Use [Result.failure] with
+ * [com.okta.authfoundation.credential.kmp.BiometricKeyInvalidatedException] returned from
+ * [com.okta.authfoundation.credential.kmp.TokenStorage.getToken] instead. Check the exception's
+ * [com.okta.authfoundation.credential.kmp.BiometricKeyInvalidatedException.tokenId] and call
+ * `storage.remove(tokenId)` explicitly if deletion is desired.
  */
+@Deprecated(
+    message =
+        "Use Result.failure(BiometricKeyInvalidatedException) from TokenStorage.getToken() instead. " +
+            "Inspect the exception's tokenId and call storage.remove(tokenId) explicitly if deletion is desired.",
+    level = DeprecationLevel.WARNING
+)
 class BiometricTokenInvalidatedEvent internal constructor(
     /**
      * The id of the invalidated [Token].

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/OAuth2ClientBuilder.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/OAuth2ClientBuilder.kt
@@ -26,6 +26,7 @@ import com.okta.authfoundation.client.kmp.DefaultIdTokenValidator
 import com.okta.authfoundation.client.kmp.DeviceSecretValidator
 import com.okta.authfoundation.client.kmp.IdTokenValidator
 import com.okta.authfoundation.client.kmp.OAuth2Client
+import com.okta.authfoundation.client.kmp.RateLimitRetryConfig
 import com.okta.authfoundation.util.CoalescingOrchestrator
 import io.ktor.http.URLProtocol
 import io.ktor.http.Url
@@ -130,6 +131,24 @@ class OAuth2ClientBuilder private constructor(
      */
     var endpointOverrides: OAuth2EndpointOverrides? = null
 
+    /**
+     * Optional callback invoked when an HTTP 429 rate-limit response is received.
+     *
+     * Return a [RateLimitRetryConfig] to retry the request, or `null` to surface the failure
+     * immediately. When null (the default), 429 responses are never retried.
+     *
+     * The [retryCount] parameter is 0-based: 0 on the first retry opportunity.
+     *
+     * Example:
+     * ```kotlin
+     * rateLimitRetryCallback = { retryCount ->
+     *     if (retryCount < 3) RateLimitRetryConfig(MaxRetries(3), MinDelaySeconds(1L))
+     *     else null
+     * }
+     * ```
+     */
+    var rateLimitRetryCallback: ((retryCount: Int) -> RateLimitRetryConfig?)? = null
+
     companion object {
         /**
          * Creates an [OAuth2Client] with the given parameters and optional customization.
@@ -223,6 +242,7 @@ class OAuth2ClientBuilder private constructor(
             idTokenValidator = idTokenValidator,
             accessTokenValidator = accessTokenValidator,
             deviceSecretValidator = deviceSecretValidator,
-            endpointOverrides = endpointOverrides
+            endpointOverrides = endpointOverrides,
+            rateLimitRetryCallback = rateLimitRetryCallback
         )
 }

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/OAuth2ClientConfiguration.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/OAuth2ClientConfiguration.kt
@@ -22,6 +22,7 @@ import com.okta.authfoundation.client.kmp.DefaultDeviceSecretValidator
 import com.okta.authfoundation.client.kmp.DefaultIdTokenValidator
 import com.okta.authfoundation.client.kmp.DeviceSecretValidator
 import com.okta.authfoundation.client.kmp.IdTokenValidator
+import com.okta.authfoundation.client.kmp.RateLimitRetryConfig
 import kotlinx.serialization.json.Json
 
 /**
@@ -69,4 +70,23 @@ class OAuth2ClientConfiguration internal constructor(
     val deviceSecretValidator: DeviceSecretValidator = DefaultDeviceSecretValidator(),
     /** Optional per-endpoint URL overrides. Non-null fields win over discovery results. */
     val endpointOverrides: OAuth2EndpointOverrides? = null,
+    /**
+     * Optional callback invoked when an HTTP 429 rate-limit response is received.
+     *
+     * The callback receives the current [retryCount] (0-based: 0 on first retry opportunity) and
+     * returns a [RateLimitRetryConfig] to retry, or `null` to stop retrying and surface the
+     * failure to the caller. When this callback is `null` (the default), 429 responses are never
+     * retried and are surfaced as [com.okta.authfoundation.client.OAuth2ClientResult.Error]
+     * immediately.
+     *
+     * If the callback throws, the exception propagates to the caller without retrying.
+     *
+     * ```kotlin
+     * rateLimitRetryCallback = { retryCount ->
+     *     if (retryCount < 3) RateLimitRetryConfig(MaxRetries(3), MinDelaySeconds(1L))
+     *     else null
+     * }
+     * ```
+     */
+    val rateLimitRetryCallback: ((retryCount: Int) -> RateLimitRetryConfig?)? = null,
 )

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/kmp/OAuth2Client.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/kmp/OAuth2Client.kt
@@ -39,10 +39,12 @@ import com.okta.authfoundation.jwt.SerializableJwks
 import com.okta.authfoundation.util.CoalescingOrchestrator
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.serialization.json.JsonObject
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * A cross-platform OAuth2 client for interacting with an Okta Authorization Server.
@@ -113,18 +115,20 @@ class OAuth2Client internal constructor(
                     ?: throw OAuth2ClientResult.Error.OidcEndpointsNotAvailableException()
 
             val result =
-                performJsonGetRequest(
-                    apiExecutor = configuration.apiExecutor,
-                    json = configuration.json,
-                    url = endpoint,
-                    deserializer = JsonObject.serializer(),
-                    headers =
-                        mapOf(
-                            "Accept" to listOf("application/json"),
-                            "Authorization" to listOf("Bearer $accessToken")
-                        ),
-                    onRateLimitExceeded = { event -> _events.tryEmit(event) }
-                )
+                withRateLimitRetry {
+                    performJsonGetRequest(
+                        apiExecutor = configuration.apiExecutor,
+                        json = configuration.json,
+                        url = endpoint,
+                        deserializer = JsonObject.serializer(),
+                        headers =
+                            mapOf(
+                                "Accept" to listOf("application/json"),
+                                "Authorization" to listOf("Bearer $accessToken")
+                            ),
+                        onRateLimitExceeded = { event -> _events.tryEmit(event) }
+                    )
+                }
             when (result) {
                 is OAuth2ClientResult.Success -> {
                     val claimsProvider =
@@ -224,14 +228,16 @@ class OAuth2Client internal constructor(
                     ?: throw OAuth2ClientResult.Error.OidcEndpointsNotAvailableException()
 
             val result =
-                performJsonFormPost(
-                    apiExecutor = configuration.apiExecutor,
-                    json = configuration.json,
-                    url = endpoints.tokenEndpoint,
-                    formParams = formParams,
-                    deserializer = OAuth2TokenResponse.serializer(),
-                    onRateLimitExceeded = { event -> _events.tryEmit(event) }
-                )
+                withRateLimitRetry {
+                    performJsonFormPost(
+                        apiExecutor = configuration.apiExecutor,
+                        json = configuration.json,
+                        url = endpoints.tokenEndpoint,
+                        formParams = formParams,
+                        deserializer = OAuth2TokenResponse.serializer(),
+                        onRateLimitExceeded = { event -> _events.tryEmit(event) }
+                    )
+                }
             when (result) {
                 is OAuth2ClientResult.Success -> {
                     val tokenInfo = result.result.toTokenInfo(configuration.clientId, configuration.issuerUrl)
@@ -269,12 +275,14 @@ class OAuth2Client internal constructor(
                 )
 
             val result =
-                performFormPost(
-                    apiExecutor = configuration.apiExecutor,
-                    url = endpoint,
-                    formParams = formParams,
-                    onRateLimitExceeded = { event -> _events.tryEmit(event) }
-                )
+                withRateLimitRetry {
+                    performFormPost(
+                        apiExecutor = configuration.apiExecutor,
+                        url = endpoint,
+                        formParams = formParams,
+                        onRateLimitExceeded = { event -> _events.tryEmit(event) }
+                    )
+                }
             when (result) {
                 is OAuth2ClientResult.Success -> _events.tryEmit(TokenRevokedEvent(token))
                 is OAuth2ClientResult.Error -> throw result.exception
@@ -309,14 +317,16 @@ class OAuth2Client internal constructor(
                 )
 
             val result =
-                performJsonFormPost(
-                    apiExecutor = configuration.apiExecutor,
-                    json = configuration.json,
-                    url = endpoint,
-                    formParams = formParams,
-                    deserializer = JsonObject.serializer(),
-                    onRateLimitExceeded = { event -> _events.tryEmit(event) }
-                )
+                withRateLimitRetry {
+                    performJsonFormPost(
+                        apiExecutor = configuration.apiExecutor,
+                        json = configuration.json,
+                        url = endpoint,
+                        formParams = formParams,
+                        deserializer = JsonObject.serializer(),
+                        onRateLimitExceeded = { event -> _events.tryEmit(event) }
+                    )
+                }
             when (result) {
                 is OAuth2ClientResult.Success -> IntrospectInfo.fromJsonObject(result.result, configuration.json)
                 is OAuth2ClientResult.Error -> throw result.exception
@@ -343,14 +353,16 @@ class OAuth2Client internal constructor(
                     ?: throw OAuth2ClientResult.Error.OidcEndpointsNotAvailableException()
 
             val result =
-                performJsonFormPost(
-                    apiExecutor = configuration.apiExecutor,
-                    json = configuration.json,
-                    url = endpoint,
-                    formParams = formParams,
-                    deserializer = SerializableDeviceAuthorizationResponse.serializer(),
-                    onRateLimitExceeded = { event -> _events.tryEmit(event) }
-                )
+                withRateLimitRetry {
+                    performJsonFormPost(
+                        apiExecutor = configuration.apiExecutor,
+                        json = configuration.json,
+                        url = endpoint,
+                        formParams = formParams,
+                        deserializer = SerializableDeviceAuthorizationResponse.serializer(),
+                        onRateLimitExceeded = { event -> _events.tryEmit(event) }
+                    )
+                }
             when (result) {
                 is OAuth2ClientResult.Success -> result.result.toDeviceAuthorizationInfo()
                 is OAuth2ClientResult.Error -> throw result.exception
@@ -456,18 +468,51 @@ class OAuth2Client internal constructor(
                 }
 
             val result =
-                performJsonGetRequest(
-                    apiExecutor = configuration.apiExecutor,
-                    json = configuration.json,
-                    url = url,
-                    deserializer = SerializableJwks.serializer(),
-                    onRateLimitExceeded = { event -> _events.tryEmit(event) }
-                )
+                withRateLimitRetry {
+                    performJsonGetRequest(
+                        apiExecutor = configuration.apiExecutor,
+                        json = configuration.json,
+                        url = url,
+                        deserializer = SerializableJwks.serializer(),
+                        onRateLimitExceeded = { event -> _events.tryEmit(event) }
+                    )
+                }
             when (result) {
                 is OAuth2ClientResult.Success -> result.result.toJwks()
                 is OAuth2ClientResult.Error -> throw result.exception
             }
         }
+
+    /**
+     * Wraps a network call with optional rate-limit retry logic.
+     *
+     * When [OAuth2ClientConfiguration.rateLimitRetryCallback] is null (the default), [block] is
+     * executed once with no retry. When set, HTTP 429 failures invoke the callback with the current
+     * retry count (0-based: 0 on the first retry opportunity). There are two independent stop
+     * conditions — whichever triggers first surfaces the 429 failure to the caller:
+     *
+     * 1. The callback returns `null` — stops immediately, no delay.
+     * 2. `retryCount >= config.maxRetries.value` — stops after the configured number of attempts.
+     *
+     * When neither condition applies, the next attempt is delayed by
+     * `max(retryAfterHeader, config.minDelaySeconds.value)` seconds. If the callback throws,
+     * the exception propagates to the caller without retrying.
+     */
+    private suspend fun <T> withRateLimitRetry(block: suspend () -> OAuth2ClientResult<T>): OAuth2ClientResult<T> {
+        val retryCallback = configuration.rateLimitRetryCallback ?: return block()
+        var retryCount = 0
+        while (true) {
+            val result = block()
+            val rateLimitEx =
+                ((result as? OAuth2ClientResult.Error<T>)?.exception as? OAuth2ClientResult.Error.RateLimitException)
+                    ?: return result
+            val config = retryCallback(retryCount) ?: return result
+            if (retryCount >= config.maxRetries.value) return result
+            val delaySeconds = maxOf(rateLimitEx.retryAfterSeconds ?: 0L, config.minDelaySeconds.value)
+            delay(delaySeconds.seconds)
+            retryCount++
+        }
+    }
 
     companion object {
         /**

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/kmp/RateLimitRetryConfig.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/kmp/RateLimitRetryConfig.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.client.kmp
+
+/**
+ * A non-negative count of retry attempts, enforced at construction time.
+ *
+ * @param value the number of retries; must be >= 0.
+ */
+@JvmInline
+value class MaxRetries(
+    val value: Int,
+) {
+    init {
+        require(value >= 0) { "maxRetries must be >= 0, was $value" }
+    }
+}
+
+/**
+ * A non-negative minimum delay in seconds between retry attempts, enforced at construction time.
+ *
+ * @param value the delay in seconds; must be >= 0.
+ */
+@JvmInline
+value class MinDelaySeconds(
+    val value: Long,
+) {
+    init {
+        require(value >= 0) { "minDelaySeconds must be >= 0, was $value" }
+    }
+}
+
+/**
+ * Configuration returned by [OAuth2ClientConfiguration.rateLimitRetryCallback] to control
+ * retry behavior after an HTTP 429 rate-limit response.
+ *
+ * Return this from the callback to retry; return `null` to stop retrying and surface the failure.
+ *
+ * @param maxRetries the maximum number of retry attempts after the initial 429 response.
+ * @param minDelaySeconds the minimum wait time in seconds before each retry attempt. The actual
+ *   delay is `max(retryAfterHeader, minDelaySeconds.value)`.
+ */
+data class RateLimitRetryConfig(
+    val maxRetries: MaxRetries,
+    val minDelaySeconds: MinDelaySeconds,
+)

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/credential/kmp/BiometricKeyInvalidatedException.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/credential/kmp/BiometricKeyInvalidatedException.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.credential.kmp
+
+/**
+ * Thrown when the biometric key protecting a stored token has been permanently invalidated —
+ * for example, after the user enrolls a new biometric on the device.
+ *
+ * On the Android platform, this is surfaced as [Result.failure] from
+ * [TokenStorage.getToken] instead of the platform-specific
+ * `KeyPermanentlyInvalidatedException`.
+ *
+ * On Android, the invalidated token is **auto-deleted by default** for backward compatibility
+ * (matching the legacy `BiometricTokenInvalidatedEvent.deleteInvalidatedToken = true` default).
+ * Callers can inspect [tokenId] and [keyAlias] for logging or custom logic; deletion is no
+ * longer required unless the app has suppressed the legacy event's default behavior.
+ *
+ * @param tokenId the ID of the token whose biometric key was invalidated.
+ * @param keyAlias the Android keystore alias of the invalidated key.
+ */
+class BiometricKeyInvalidatedException(
+    val tokenId: String,
+    val keyAlias: String,
+) : Exception("Biometric key invalidated for token $tokenId (alias: $keyAlias)")

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/credential/kmp/CredentialDataSource.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/credential/kmp/CredentialDataSource.kt
@@ -173,7 +173,10 @@ internal class CredentialDataSource(
         }
         val token =
             wrapStorageOperation {
-                storage.getToken(id).getOrNull()
+                storage.getToken(id).getOrElse { e ->
+                    if (e is BiometricKeyInvalidatedException) throw e
+                    null
+                }
             } ?: return null
         if (token is TokenData) {
             cacheMutex.withLock { cache[id] = token }
@@ -210,6 +213,7 @@ internal class CredentialDataSource(
         try {
             operation()
         } catch (e: Exception) {
+            if (e is BiometricKeyInvalidatedException) throw e
             if (eventsFlow != null || onStorageError != null) {
                 val shouldRetry = onStorageError?.invoke(e) == true
                 // Async broadcast for observability — observers cannot influence the retry decision.

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/credential/kmp/TokenStorage.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/credential/kmp/TokenStorage.kt
@@ -77,7 +77,12 @@ interface TokenStorage {
      * Retrieves and decrypts the token with [id].
      *
      * @param id id of the token to be retrieved.
-     * @return [Result.success] with the token, or [Result.failure] with [NoSuchElementException] if not found.
+     * @return [Result.success] with the token, or [Result.failure] with:
+     * - [NoSuchElementException] if the token is not found.
+     * - [com.okta.authfoundation.credential.kmp.BiometricKeyInvalidatedException] (Android only)
+     *   if the biometric key protecting the token has been permanently invalidated. On Android the
+     *   token is auto-deleted by default for backward compatibility; inspect the exception for
+     *   logging or custom handling.
      */
     suspend fun getToken(id: String): Result<TokenInfo>
 }

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/events/EventCoordinator.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/events/EventCoordinator.kt
@@ -19,7 +19,19 @@ import com.okta.authfoundation.InternalAuthFoundationApi
 
 /**
  * A centralized coordinator of events emitted throughout Auth Foundation and other Okta SDKs.
+ *
+ * @deprecated [EventCoordinator] is deprecated. Use [com.okta.authfoundation.client.kmp.OAuth2Client.events]
+ * or [com.okta.authfoundation.credential.kmp.TokenCredentialManager.events] SharedFlow to observe SDK events.
+ * Configure retry behavior via [com.okta.authfoundation.client.OAuth2ClientConfiguration.rateLimitRetryCallback].
+ * This class will be removed in a future major release.
  */
+@Deprecated(
+    message =
+        "EventCoordinator is deprecated. Use OAuth2Client.events or TokenCredentialManager.events SharedFlow " +
+            "to observe events. Configure rate-limit retry via OAuth2ClientConfiguration.rateLimitRetryCallback. " +
+            "This class will be removed in a future major release.",
+    level = DeprecationLevel.WARNING
+)
 class EventCoordinator(
     /**
      * A list of [EventHandler]s that should be invoked when an event is emitted.

--- a/auth-foundation/src/commonTest/kotlin/com/okta/authfoundation/client/kmp/RateLimitRetryTest.kt
+++ b/auth-foundation/src/commonTest/kotlin/com/okta/authfoundation/client/kmp/RateLimitRetryTest.kt
@@ -1,0 +1,349 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.client.kmp
+
+import com.okta.authfoundation.InternalAuthFoundationApi
+import com.okta.authfoundation.api.http.ApiExecutor
+import com.okta.authfoundation.api.http.ApiRequest
+import com.okta.authfoundation.api.http.ApiResponse
+import com.okta.authfoundation.client.Cache
+import com.okta.authfoundation.client.OAuth2ClientBuilder
+import com.okta.authfoundation.client.OAuth2ClientConfiguration
+import com.okta.authfoundation.client.OAuth2ClientResult
+import com.okta.authfoundation.client.OidcClock
+import com.okta.authfoundation.client.internal.OAuth2Endpoints
+import com.okta.authfoundation.util.CoalescingOrchestrator
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(InternalAuthFoundationApi::class)
+class RateLimitRetryTest {
+    private val testEndpoints =
+        OAuth2Endpoints(
+            issuer = "https://example.okta.com",
+            authorizationEndpoint = "https://example.okta.com/v1/authorize",
+            tokenEndpoint = "https://example.okta.com/v1/token",
+            userInfoEndpoint = "https://example.okta.com/v1/userinfo",
+            jwksUri = "https://example.okta.com/v1/keys",
+            introspectionEndpoint = "https://example.okta.com/v1/introspect",
+            revocationEndpoint = "https://example.okta.com/v1/revoke",
+            endSessionEndpoint = "https://example.okta.com/v1/logout",
+            deviceAuthorizationEndpoint = null
+        )
+
+    private val noOpCache =
+        object : Cache {
+            override fun get(key: String): String? = null
+
+            override fun set(
+                key: String,
+                value: String,
+            ) {}
+
+            override fun clear() {}
+        }
+
+    private val testClock = OidcClock { 1_000_000L }
+
+    private fun createClientWithExecutor(
+        executor: ApiExecutor,
+        retryCallback: ((Int) -> RateLimitRetryConfig?)? = null,
+    ): OAuth2Client {
+        val config =
+            OAuth2ClientConfiguration(
+                clientId = "test-client",
+                defaultScope = "openid",
+                issuerUrl = "https://example.okta.com",
+                apiExecutor = executor,
+                clock = testClock,
+                json = Json { ignoreUnknownKeys = true },
+                cache = noOpCache,
+                authorizationServerId = null,
+                clientSecret = null,
+                acrValues = null,
+                rateLimitRetryCallback = retryCallback
+            )
+        return OAuth2Client(
+            config,
+            CoalescingOrchestrator(
+                factory = { OAuth2ClientResult.Success(testEndpoints) },
+                keepDataInMemory = { true }
+            )
+        )
+    }
+
+    @Test
+    fun builder_WithNoCallback_ConfigurationCallbackIsNull() {
+        val client =
+            OAuth2ClientBuilder
+                .create(
+                    issuerUrl = "https://example.okta.com",
+                    clientId = "client-id",
+                    scope = listOf("openid")
+                ).getOrThrow()
+
+        assertNull(client.configuration.rateLimitRetryCallback)
+    }
+
+    @Test
+    fun builder_WithCallback_ConfigurationCallbackIsSet() {
+        val callback: (Int) -> RateLimitRetryConfig? = { _ -> RateLimitRetryConfig(MaxRetries(3), MinDelaySeconds(1L)) }
+
+        val client =
+            OAuth2ClientBuilder
+                .create(
+                    issuerUrl = "https://example.okta.com",
+                    clientId = "client-id",
+                    scope = listOf("openid")
+                ) {
+                    rateLimitRetryCallback = callback
+                }.getOrThrow()
+
+        assertNotNull(client.configuration.rateLimitRetryCallback)
+        assertEquals(
+            RateLimitRetryConfig(MaxRetries(3), MinDelaySeconds(1L)),
+            client.configuration.rateLimitRetryCallback!!.invoke(0)
+        )
+    }
+
+    @Test
+    fun builder_WithCallback_RetriesOn429() =
+        runTest {
+            var requestCount = 0
+            val executor =
+                object : ApiExecutor {
+                    override suspend fun execute(request: ApiRequest): Result<ApiResponse> {
+                        requestCount++
+                        return if (requestCount == 1) {
+                            Result.success(
+                                object : ApiResponse {
+                                    override val statusCode = 429
+                                    override val body = byteArrayOf()
+                                    override val headers: Map<String, List<String>> = emptyMap()
+                                    override val contentLength = 0L
+                                    override val contentType = "application/json"
+                                }
+                            )
+                        } else {
+                            Result.success(
+                                object : ApiResponse {
+                                    override val statusCode = 200
+                                    override val body = """{"active":true}""".toByteArray()
+                                    override val headers: Map<String, List<String>> = emptyMap()
+                                    override val contentLength = 15L
+                                    override val contentType = "application/json"
+                                }
+                            )
+                        }
+                    }
+                }
+
+            val client =
+                OAuth2ClientBuilder
+                    .create(
+                        issuerUrl = "https://example.okta.com",
+                        clientId = "client-id",
+                        scope = listOf("openid")
+                    ) {
+                        apiExecutor = executor
+                        rateLimitRetryCallback = { _ -> RateLimitRetryConfig(MaxRetries(3), MinDelaySeconds(0L)) }
+                    }.getOrThrow()
+
+            // Inject pre-resolved endpoints so the test doesn't make a network discovery call
+            @OptIn(InternalAuthFoundationApi::class)
+            val clientWithEndpoints =
+                OAuth2Client(
+                    client.configuration,
+                    CoalescingOrchestrator(
+                        factory = { OAuth2ClientResult.Success(testEndpoints) },
+                        keepDataInMemory = { true }
+                    )
+                )
+
+            val result = clientWithEndpoints.introspectToken("access_token", "exampleToken")
+
+            assertTrue(result.isSuccess, "Should succeed after retry")
+            assertEquals(2, requestCount, "Should have made 2 requests: 1 failed + 1 retry")
+        }
+
+    @Test
+    fun rateLimitRetryConfig_HoldsCorrectValues() {
+        val config = RateLimitRetryConfig(MaxRetries(3), MinDelaySeconds(1L))
+        assertEquals(3, config.maxRetries.value)
+        assertEquals(1L, config.minDelaySeconds.value)
+    }
+
+    @Test
+    fun rateLimitRetryConfig_ThrowsOnNegativeMaxRetries() {
+        val ex =
+            kotlin.test.assertFailsWith<IllegalArgumentException> {
+                MaxRetries(-1)
+            }
+        assertTrue(ex.message!!.contains("-1"))
+    }
+
+    @Test
+    fun rateLimitRetryConfig_ThrowsOnNegativeMinDelaySeconds() {
+        val ex =
+            kotlin.test.assertFailsWith<IllegalArgumentException> {
+                MinDelaySeconds(-1L)
+            }
+        assertTrue(ex.message!!.contains("-1"))
+    }
+
+    @Test
+    fun withNoRetryCallback_Returns429Immediately_WithOneRequest() =
+        runTest {
+            var requestCount = 0
+            val executor =
+                object : ApiExecutor {
+                    override suspend fun execute(request: ApiRequest): Result<ApiResponse> {
+                        requestCount++
+                        return Result.success(
+                            object : ApiResponse {
+                                override val statusCode = 429
+                                override val body = byteArrayOf()
+                                override val headers: Map<String, List<String>> = emptyMap()
+                                override val contentLength = 0L
+                                override val contentType = "application/json"
+                            }
+                        )
+                    }
+                }
+
+            val client = createClientWithExecutor(executor, retryCallback = null)
+            val result = client.introspectToken("access_token", "exampleToken")
+
+            assertTrue(result.isFailure)
+            assertEquals(1, requestCount, "Without callback, should not retry — exactly 1 request expected")
+        }
+
+    @Test
+    fun withRetryCallback_RetriesOnce_WhenFirstCall429SecondCallSucceeds() =
+        runTest {
+            var requestCount = 0
+            val executor =
+                object : ApiExecutor {
+                    override suspend fun execute(request: ApiRequest): Result<ApiResponse> {
+                        requestCount++
+                        return if (requestCount == 1) {
+                            Result.success(
+                                object : ApiResponse {
+                                    override val statusCode = 429
+                                    override val body = byteArrayOf()
+                                    override val headers: Map<String, List<String>> = emptyMap()
+                                    override val contentLength = 0L
+                                    override val contentType = "application/json"
+                                }
+                            )
+                        } else {
+                            Result.success(
+                                object : ApiResponse {
+                                    override val statusCode = 200
+                                    override val body = """{"active":true}""".toByteArray()
+                                    override val headers: Map<String, List<String>> = emptyMap()
+                                    override val contentLength = 15L
+                                    override val contentType = "application/json"
+                                }
+                            )
+                        }
+                    }
+                }
+
+            val client =
+                createClientWithExecutor(
+                    executor,
+                    retryCallback = { _ -> RateLimitRetryConfig(MaxRetries(3), MinDelaySeconds(0L)) }
+                )
+            val result = client.introspectToken("access_token", "exampleToken")
+
+            assertTrue(result.isSuccess, "Should succeed after retry, but got: ${result.exceptionOrNull()}")
+            assertEquals(2, requestCount, "Should have made exactly 2 requests (1 failed + 1 retry)")
+        }
+
+    @Test
+    fun withRetryCallback_StopsRetrying_WhenCallbackReturnsNull() =
+        runTest {
+            var requestCount = 0
+            var callbackCount = 0
+            val executor =
+                object : ApiExecutor {
+                    override suspend fun execute(request: ApiRequest): Result<ApiResponse> {
+                        requestCount++
+                        return Result.success(
+                            object : ApiResponse {
+                                override val statusCode = 429
+                                override val body = byteArrayOf()
+                                override val headers: Map<String, List<String>> = emptyMap()
+                                override val contentLength = 0L
+                                override val contentType = "application/json"
+                            }
+                        )
+                    }
+                }
+
+            val client =
+                createClientWithExecutor(
+                    executor,
+                    retryCallback = { _ ->
+                        callbackCount++
+                        if (callbackCount >= 2) {
+                            null
+                        } else {
+                            RateLimitRetryConfig(MaxRetries(10), MinDelaySeconds(0L))
+                        }
+                    }
+                )
+            val result = client.introspectToken("access_token", "exampleToken")
+
+            assertTrue(result.isFailure)
+            assertEquals(2, requestCount, "Should have made 2 requests before callback returned null")
+        }
+
+    @Test
+    fun withRetryCallback_PropagatesException_WhenCallbackThrows() =
+        runTest {
+            val callbackException = IllegalStateException("callback exploded")
+            val executor =
+                object : ApiExecutor {
+                    override suspend fun execute(request: ApiRequest): Result<ApiResponse> =
+                        Result.success(
+                            object : ApiResponse {
+                                override val statusCode = 429
+                                override val body = byteArrayOf()
+                                override val headers: Map<String, List<String>> = emptyMap()
+                                override val contentLength = 0L
+                                override val contentType = "application/json"
+                            }
+                        )
+                }
+
+            val client =
+                createClientWithExecutor(
+                    executor,
+                    retryCallback = { _ -> throw callbackException }
+                )
+            val result = client.introspectToken("access_token", "exampleToken")
+
+            assertTrue(result.isFailure)
+            assertEquals(callbackException, result.exceptionOrNull(), "Callback exception must propagate unchanged")
+        }
+}


### PR DESCRIPTION
Replace BiometricTokenInvalidatedEvent mutable-read-back with typed exception.
- Add BiometricKeyInvalidatedException (KMP commonMain) carrying tokenId and keyAlias
- RoomTokenStorage keeps backward-compat auto-delete loop; replaces final throw with BiometricKeyInvalidatedException so callers receive a typed Result.failure
- Android CredentialDataSource.getCredential() catches BiometricKeyInvalidatedException (previously caught KeyPermanentlyInvalidatedException) for zero behavioral regression
- @Deprecated added to BiometricTokenInvalidatedEvent and BiometricKeyInvalidatedEvent

Add opt-in KMP retry loop for HTTP 429 responses.
- Add RateLimitRetryConfig data class and rateLimitRetryCallback to OAuth2ClientConfiguration
- Expose rateLimitRetryCallback on OAuth2ClientBuilder (only public construction path)
- OAuth2Client.withRateLimitRetry() wraps all perform* calls; no retry when callback is null
- NetworkUtils Android retry loop preserved (backward compat); annotated with deprecation comment

Deprecate remaining EventCoordinator plumbing.
- @Deprecated on EventCoordinator class, OidcConfiguration.eventCoordinator, AuthFoundationDefaults.eventCoordinator (all DeprecationLevel.WARNING; no removal)

Tests: BiometricKeyInvalidatedTest (exception type, auto-delete preservation), RateLimitRetryTest (builder wiring, no-retry default, retry-to-success, callback stop)

Fix BiometricDecryptionActivity crash on authentication failure

onAuthenticationFailed() is a soft, retryable callback — the biometric prompt stays open. Previously it called resumeWithException() which threw a fatal exception back through Dispatchers.Main.immediate to the main thread looper.

Replace the throw with a WARN log. Extract the AuthenticationCallback creation to an internal companion factory (createAuthenticationCallback(finish)) so the behavior can be unit-tested without launching the Activity.

Add BiometricDecryptionActivityTest covering:
- failed attempt does not resume the coroutine (regression guard)
- failed attempt followed by success completes the flow
- failed attempt followed by onAuthenticationError terminates with BiometricAuthenticationException

RESOLVES: OKTA-1227922