### PR TITLE
Roll out ABI validation across all Android/KMP modules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,7 @@ jobs:
       - android/restore_gradle_cache
       - run:
           name: Run API Check
-          command: ./gradlew checkLegacyAbi --no-daemon
+          command: ./gradlew :checkLegacyAbi --no-daemon
       - android/save_gradle_cache
 
 workflows:

--- a/auth-foundation/api/auth-foundation.api
+++ b/auth-foundation/api/auth-foundation.api
@@ -1,9 +1,3 @@
-public abstract interface class com/okta/authfoundation/events/CredentialEvent : com/okta/authfoundation/events/Event {
-}
-
-public abstract interface class com/okta/authfoundation/events/TokenEvent : com/okta/authfoundation/events/Event {
-}
-
 public final class com/okta/authfoundation/AuthFoundation {
 	public static final field INSTANCE Lcom/okta/authfoundation/AuthFoundation;
 	public final fun initializeAndroidContext (Landroid/content/Context;)V
@@ -268,23 +262,51 @@ public abstract interface class com/okta/authfoundation/api/http/ApiResponse {
 	public abstract fun getStatusCode ()I
 }
 
-public abstract interface class com/okta/authfoundation/api/http/log/AuthFoundationLogger {
-	public abstract fun write (Ljava/lang/String;Ljava/lang/Throwable;Lcom/okta/authfoundation/api/http/log/LogLevel;)V
-	public static synthetic fun write$default (Lcom/okta/authfoundation/api/http/log/AuthFoundationLogger;Ljava/lang/String;Ljava/lang/Throwable;Lcom/okta/authfoundation/api/http/log/LogLevel;ILjava/lang/Object;)V
+public final class com/okta/authfoundation/api/http/KtorHttpExecutor : com/okta/authfoundation/api/http/ApiExecutor {
+	public fun <init> ()V
+	public fun <init> (Lio/ktor/client/HttpClient;)V
+	public synthetic fun <init> (Lio/ktor/client/HttpClient;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun execute-gIAlu-s (Lcom/okta/authfoundation/api/http/ApiRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getHttpClient ()Lio/ktor/client/HttpClient;
 }
 
-public final class com/okta/authfoundation/api/http/log/AuthFoundationLogger$DefaultImpls {
-	public static synthetic fun write$default (Lcom/okta/authfoundation/api/http/log/AuthFoundationLogger;Ljava/lang/String;Ljava/lang/Throwable;Lcom/okta/authfoundation/api/http/log/LogLevel;ILjava/lang/Object;)V
+public final class com/okta/authfoundation/api/http/KtorHttpExecutorKt {
+	public static final field CONNECT_TIMEOUT_MILLIS J
+	public static final field REQUEST_TIMEOUT_MILLIS J
 }
 
-public final class com/okta/authfoundation/api/http/log/LogLevel : java/lang/Enum {
-	public static final field DEBUG Lcom/okta/authfoundation/api/http/log/LogLevel;
-	public static final field ERROR Lcom/okta/authfoundation/api/http/log/LogLevel;
-	public static final field INFO Lcom/okta/authfoundation/api/http/log/LogLevel;
-	public static final field WARN Lcom/okta/authfoundation/api/http/log/LogLevel;
+public final class com/okta/authfoundation/api/http/KtorHttpExecutor_androidKt {
+	public static final fun getHttpClientEngine ()Lio/ktor/client/HttpClient;
+}
+
+public final class com/okta/authfoundation/api/log/AndroidAuthFoundationLogger : com/okta/authfoundation/api/log/AuthFoundationLogger {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun write (Ljava/lang/String;Ljava/lang/Throwable;Lcom/okta/authfoundation/api/log/LogLevel;)V
+}
+
+public final class com/okta/authfoundation/api/log/AndroidAuthFoundationLogger_androidKt {
+	public static final fun getDefaultAuthFoundationLogger ()Lcom/okta/authfoundation/api/log/AuthFoundationLogger;
+}
+
+public abstract interface class com/okta/authfoundation/api/log/AuthFoundationLogger {
+	public abstract fun write (Ljava/lang/String;Ljava/lang/Throwable;Lcom/okta/authfoundation/api/log/LogLevel;)V
+	public static synthetic fun write$default (Lcom/okta/authfoundation/api/log/AuthFoundationLogger;Ljava/lang/String;Ljava/lang/Throwable;Lcom/okta/authfoundation/api/log/LogLevel;ILjava/lang/Object;)V
+}
+
+public final class com/okta/authfoundation/api/log/AuthFoundationLogger$DefaultImpls {
+	public static synthetic fun write$default (Lcom/okta/authfoundation/api/log/AuthFoundationLogger;Ljava/lang/String;Ljava/lang/Throwable;Lcom/okta/authfoundation/api/log/LogLevel;ILjava/lang/Object;)V
+}
+
+public final class com/okta/authfoundation/api/log/LogLevel : java/lang/Enum {
+	public static final field DEBUG Lcom/okta/authfoundation/api/log/LogLevel;
+	public static final field ERROR Lcom/okta/authfoundation/api/log/LogLevel;
+	public static final field INFO Lcom/okta/authfoundation/api/log/LogLevel;
+	public static final field WARN Lcom/okta/authfoundation/api/log/LogLevel;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
-	public static fun valueOf (Ljava/lang/String;)Lcom/okta/authfoundation/api/http/log/LogLevel;
-	public static fun values ()[Lcom/okta/authfoundation/api/http/log/LogLevel;
+	public static fun valueOf (Ljava/lang/String;)Lcom/okta/authfoundation/api/log/LogLevel;
+	public static fun values ()[Lcom/okta/authfoundation/api/log/LogLevel;
 }
 
 public abstract interface class com/okta/authfoundation/claims/ClaimsProvider {
@@ -336,6 +358,7 @@ public final class com/okta/authfoundation/client/ApplicationContextHolder {
 }
 
 public abstract interface class com/okta/authfoundation/client/Cache {
+	public abstract fun clear ()V
 	public abstract fun get (Ljava/lang/String;)Ljava/lang/String;
 	public abstract fun set (Ljava/lang/String;Ljava/lang/String;)V
 }
@@ -378,12 +401,6 @@ public final class com/okta/authfoundation/client/IdTokenValidator$Parameters {
 	public final fun getNonce ()Ljava/lang/String;
 }
 
-public final class com/okta/authfoundation/client/NoOpCache : com/okta/authfoundation/client/Cache {
-	public fun <init> ()V
-	public fun get (Ljava/lang/String;)Ljava/lang/String;
-	public fun set (Ljava/lang/String;Ljava/lang/String;)V
-}
-
 public final class com/okta/authfoundation/client/OAuth2Client {
 	public static final field Companion Lcom/okta/authfoundation/client/OAuth2Client$Companion;
 	public final fun endpointNotAvailableError ()Lcom/okta/authfoundation/client/OAuth2ClientResult$Error;
@@ -392,6 +409,7 @@ public final class com/okta/authfoundation/client/OAuth2Client {
 	public final fun getUserInfo (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun introspectToken (Lcom/okta/authfoundation/credential/TokenType;Lcom/okta/authfoundation/credential/Token;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun jwks (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun refreshToken (Lcom/okta/authfoundation/credential/Token;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun refreshToken (Lcom/okta/authfoundation/credential/Token;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun revokeToken (Lcom/okta/authfoundation/credential/RevokeTokenType;Lcom/okta/authfoundation/credential/Token;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun tokenRequest (Lokhttp3/Request;Ljava/lang/String;Ljava/lang/Integer;Lcom/okta/authfoundation/credential/Token;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -402,6 +420,62 @@ public final class com/okta/authfoundation/client/OAuth2Client$Companion {
 	public final fun create (Lcom/okta/authfoundation/client/OidcConfiguration;Lcom/okta/authfoundation/client/OidcEndpoints;)Lcom/okta/authfoundation/client/OAuth2Client;
 	public final fun createFromConfiguration (Lcom/okta/authfoundation/client/OidcConfiguration;)Lcom/okta/authfoundation/client/OAuth2Client;
 	public final fun getDefault ()Lcom/okta/authfoundation/client/OAuth2Client;
+}
+
+public final class com/okta/authfoundation/client/OAuth2ClientBuilder {
+	public static final field Companion Lcom/okta/authfoundation/client/OAuth2ClientBuilder$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAccessTokenValidator ()Lcom/okta/authfoundation/client/kmp/AccessTokenValidator;
+	public final fun getAcrValues ()Ljava/lang/String;
+	public final fun getApiExecutor ()Lcom/okta/authfoundation/api/http/ApiExecutor;
+	public final fun getAuthorizationServerId ()Ljava/lang/String;
+	public final fun getCache ()Lcom/okta/authfoundation/client/Cache;
+	public final fun getClientSecret ()Ljava/lang/String;
+	public final fun getClock ()Lcom/okta/authfoundation/client/OidcClock;
+	public final fun getComputeDispatcher ()Lkotlin/coroutines/CoroutineContext;
+	public final fun getDeviceSecretValidator ()Lcom/okta/authfoundation/client/kmp/DeviceSecretValidator;
+	public final fun getEndpointOverrides ()Lcom/okta/authfoundation/client/OAuth2EndpointOverrides;
+	public final fun getIdTokenValidator ()Lcom/okta/authfoundation/client/kmp/IdTokenValidator;
+	public final fun getIoDispatcher ()Lkotlin/coroutines/CoroutineContext;
+	public final fun getJson ()Lkotlinx/serialization/json/Json;
+	public final fun getRateLimitRetryCallback ()Lkotlin/jvm/functions/Function1;
+	public final fun setAccessTokenValidator (Lcom/okta/authfoundation/client/kmp/AccessTokenValidator;)V
+	public final fun setAcrValues (Ljava/lang/String;)V
+	public final fun setApiExecutor (Lcom/okta/authfoundation/api/http/ApiExecutor;)V
+	public final fun setAuthorizationServerId (Ljava/lang/String;)V
+	public final fun setCache (Lcom/okta/authfoundation/client/Cache;)V
+	public final fun setClientSecret (Ljava/lang/String;)V
+	public final fun setClock (Lcom/okta/authfoundation/client/OidcClock;)V
+	public final fun setComputeDispatcher (Lkotlin/coroutines/CoroutineContext;)V
+	public final fun setDeviceSecretValidator (Lcom/okta/authfoundation/client/kmp/DeviceSecretValidator;)V
+	public final fun setEndpointOverrides (Lcom/okta/authfoundation/client/OAuth2EndpointOverrides;)V
+	public final fun setIdTokenValidator (Lcom/okta/authfoundation/client/kmp/IdTokenValidator;)V
+	public final fun setIoDispatcher (Lkotlin/coroutines/CoroutineContext;)V
+	public final fun setJson (Lkotlinx/serialization/json/Json;)V
+	public final fun setRateLimitRetryCallback (Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class com/okta/authfoundation/client/OAuth2ClientBuilder$Companion {
+	public final fun create-BWLJW6A (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static synthetic fun create-BWLJW6A$default (Lcom/okta/authfoundation/client/OAuth2ClientBuilder$Companion;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/okta/authfoundation/client/OAuth2ClientConfiguration {
+	public final fun getAccessTokenValidator ()Lcom/okta/authfoundation/client/kmp/AccessTokenValidator;
+	public final fun getAcrValues ()Ljava/lang/String;
+	public final fun getApiExecutor ()Lcom/okta/authfoundation/api/http/ApiExecutor;
+	public final fun getAuthorizationServerId ()Ljava/lang/String;
+	public final fun getCache ()Lcom/okta/authfoundation/client/Cache;
+	public final fun getClientId ()Ljava/lang/String;
+	public final fun getClientSecret ()Ljava/lang/String;
+	public final fun getClock ()Lcom/okta/authfoundation/client/OidcClock;
+	public final fun getDefaultScope ()Ljava/lang/String;
+	public final fun getDeviceSecretValidator ()Lcom/okta/authfoundation/client/kmp/DeviceSecretValidator;
+	public final fun getEndpointOverrides ()Lcom/okta/authfoundation/client/OAuth2EndpointOverrides;
+	public final fun getIdTokenValidator ()Lcom/okta/authfoundation/client/kmp/IdTokenValidator;
+	public final fun getIssuerUrl ()Ljava/lang/String;
+	public final fun getJson ()Lkotlinx/serialization/json/Json;
+	public final fun getRateLimitRetryCallback ()Lkotlin/jvm/functions/Function1;
 }
 
 public abstract class com/okta/authfoundation/client/OAuth2ClientResult {
@@ -422,9 +496,28 @@ public final class com/okta/authfoundation/client/OAuth2ClientResult$Error$HttpR
 public final class com/okta/authfoundation/client/OAuth2ClientResult$Error$OidcEndpointsNotAvailableException : java/lang/Exception {
 }
 
+public final class com/okta/authfoundation/client/OAuth2ClientResult$Error$RateLimitException : java/lang/Exception {
+	public final fun getRequestUrl ()Ljava/lang/String;
+	public final fun getRetryAfterSeconds ()Ljava/lang/Long;
+}
+
 public final class com/okta/authfoundation/client/OAuth2ClientResult$Success : com/okta/authfoundation/client/OAuth2ClientResult {
 	public fun <init> (Ljava/lang/Object;)V
 	public final fun getResult ()Ljava/lang/Object;
+}
+
+public final class com/okta/authfoundation/client/OAuth2EndpointOverrides {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAuthorizationEndpoint ()Ljava/lang/String;
+	public final fun getDeviceAuthorizationEndpoint ()Ljava/lang/String;
+	public final fun getEndSessionEndpoint ()Ljava/lang/String;
+	public final fun getIntrospectionEndpoint ()Ljava/lang/String;
+	public final fun getJwksUri ()Ljava/lang/String;
+	public final fun getRevocationEndpoint ()Ljava/lang/String;
+	public final fun getTokenEndpoint ()Ljava/lang/String;
+	public final fun getUserInfoEndpoint ()Ljava/lang/String;
 }
 
 public abstract interface class com/okta/authfoundation/client/OidcClock {
@@ -434,6 +527,7 @@ public abstract interface class com/okta/authfoundation/client/OidcClock {
 public final class com/okta/authfoundation/client/OidcConfiguration {
 	public static final field Companion Lcom/okta/authfoundation/client/OidcConfiguration$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/okta/authfoundation/client/OAuth2EndpointOverrides;)V
 	public final fun getAccessTokenValidator ()Lcom/okta/authfoundation/client/AccessTokenValidator;
 	public final fun getCacheFactory ()Lkotlin/jvm/functions/Function1;
 	public final fun getClientId ()Ljava/lang/String;
@@ -442,6 +536,7 @@ public final class com/okta/authfoundation/client/OidcConfiguration {
 	public final fun getDefaultScope ()Ljava/lang/String;
 	public final fun getDeviceSecretValidator ()Lcom/okta/authfoundation/client/DeviceSecretValidator;
 	public final fun getDiscoveryUrl ()Ljava/lang/String;
+	public final fun getEndpointOverrides ()Lcom/okta/authfoundation/client/OAuth2EndpointOverrides;
 	public final fun getEventCoordinator ()Lcom/okta/authfoundation/events/EventCoordinator;
 	public final fun getIdTokenValidator ()Lcom/okta/authfoundation/client/IdTokenValidator;
 	public final fun getIoDispatcher ()Lkotlin/coroutines/CoroutineContext;
@@ -478,6 +573,56 @@ public final class com/okta/authfoundation/client/OidcEndpoints {
 	public final fun getRevocationEndpoint ()Lokhttp3/HttpUrl;
 	public final fun getTokenEndpoint ()Lokhttp3/HttpUrl;
 	public final fun getUserInfoEndpoint ()Lokhttp3/HttpUrl;
+}
+
+public abstract interface class com/okta/authfoundation/client/TokenInfo {
+	public abstract fun getAccessToken ()Ljava/lang/String;
+	public abstract fun getClientId ()Ljava/lang/String;
+	public abstract fun getDeviceSecret ()Ljava/lang/String;
+	public abstract fun getExpiresIn ()I
+	public abstract fun getId ()Ljava/lang/String;
+	public abstract fun getIdToken ()Ljava/lang/String;
+	public abstract fun getIssuedTokenType ()Ljava/lang/String;
+	public abstract fun getIssuerUrl ()Ljava/lang/String;
+	public abstract fun getRefreshToken ()Ljava/lang/String;
+	public abstract fun getScope ()Ljava/lang/String;
+	public abstract fun getTokenType ()Ljava/lang/String;
+}
+
+public final class com/okta/authfoundation/client/dto/DeviceAuthorizationInfo {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;II)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()I
+	public final fun component6 ()I
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;II)Lcom/okta/authfoundation/client/dto/DeviceAuthorizationInfo;
+	public static synthetic fun copy$default (Lcom/okta/authfoundation/client/dto/DeviceAuthorizationInfo;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IIILjava/lang/Object;)Lcom/okta/authfoundation/client/dto/DeviceAuthorizationInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeviceCode ()Ljava/lang/String;
+	public final fun getExpiresIn ()I
+	public final fun getInterval ()I
+	public final fun getUserCode ()Ljava/lang/String;
+	public final fun getVerificationUri ()Ljava/lang/String;
+	public final fun getVerificationUriComplete ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/okta/authfoundation/client/dto/IntrospectInfo {
+	public synthetic fun <init> (ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getActive ()Z
+}
+
+public final class com/okta/authfoundation/client/dto/IntrospectInfo$Active : com/okta/authfoundation/client/dto/IntrospectInfo, com/okta/authfoundation/claims/ClaimsProvider {
+	public fun availableClaims ()Ljava/util/Set;
+	public fun deserializeClaim (Ljava/lang/String;Lkotlinx/serialization/DeserializationStrategy;)Ljava/lang/Object;
+	public fun deserializeClaims (Lkotlinx/serialization/DeserializationStrategy;)Ljava/lang/Object;
+}
+
+public final class com/okta/authfoundation/client/dto/IntrospectInfo$Inactive : com/okta/authfoundation/client/dto/IntrospectInfo {
+	public static final field INSTANCE Lcom/okta/authfoundation/client/dto/IntrospectInfo$Inactive;
 }
 
 public abstract class com/okta/authfoundation/client/dto/OidcIntrospectInfo {
@@ -532,9 +677,181 @@ public final class com/okta/authfoundation/client/internal/NetworkUtilsKt {
 	public static synthetic fun performRequest$default (Lcom/okta/authfoundation/client/OAuth2Client;Lkotlinx/serialization/DeserializationStrategy;Lokhttp3/Request;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
+public final class com/okta/authfoundation/client/internal/OAuth2Endpoints {
+	public static final field Companion Lcom/okta/authfoundation/client/internal/OAuth2Endpoints$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun getAuthorizationEndpoint ()Ljava/lang/String;
+	public final fun getDeviceAuthorizationEndpoint ()Ljava/lang/String;
+	public final fun getEndSessionEndpoint ()Ljava/lang/String;
+	public final fun getIntrospectionEndpoint ()Ljava/lang/String;
+	public final fun getIssuer ()Ljava/lang/String;
+	public final fun getJwksUri ()Ljava/lang/String;
+	public final fun getRevocationEndpoint ()Ljava/lang/String;
+	public final fun getTokenEndpoint ()Ljava/lang/String;
+	public final fun getUserInfoEndpoint ()Ljava/lang/String;
+	public final fun merge (Lcom/okta/authfoundation/client/OAuth2EndpointOverrides;)Lcom/okta/authfoundation/client/internal/OAuth2Endpoints;
+}
+
+public final class com/okta/authfoundation/client/internal/OAuth2Endpoints$Companion {
+	public final fun allFieldsNonNull (Lcom/okta/authfoundation/client/OAuth2EndpointOverrides;)Z
+}
+
 public final class com/okta/authfoundation/client/internal/SdkVersionsRegistry {
 	public static final field INSTANCE Lcom/okta/authfoundation/client/internal/SdkVersionsRegistry;
 	public final fun register (Ljava/lang/String;)V
+}
+
+public abstract interface class com/okta/authfoundation/client/kmp/AccessTokenValidator {
+	public abstract fun validate (Ljava/lang/String;Lcom/okta/authfoundation/jwt/Jwt;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/okta/authfoundation/client/kmp/AccessTokenValidator$Error : java/lang/IllegalStateException {
+	public fun <init> (Ljava/lang/String;)V
+}
+
+public final class com/okta/authfoundation/client/kmp/DefaultAccessTokenValidator : com/okta/authfoundation/client/kmp/AccessTokenValidator {
+	public fun <init> ()V
+	public fun validate (Ljava/lang/String;Lcom/okta/authfoundation/jwt/Jwt;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/okta/authfoundation/client/kmp/DefaultDeviceSecretValidator : com/okta/authfoundation/client/kmp/DeviceSecretValidator {
+	public fun <init> ()V
+	public fun validate (Ljava/lang/String;Lcom/okta/authfoundation/jwt/Jwt;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/okta/authfoundation/client/kmp/DefaultIdTokenValidator : com/okta/authfoundation/client/kmp/IdTokenValidator {
+	public fun <init> ()V
+	public fun <init> (I)V
+	public synthetic fun <init> (IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getIssuedAtGracePeriodInSeconds ()I
+	public fun validate (Ljava/lang/String;Ljava/lang/String;Lcom/okta/authfoundation/jwt/Jwt;Lcom/okta/authfoundation/client/OidcClock;Lcom/okta/authfoundation/client/kmp/IdTokenValidator$Parameters;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/okta/authfoundation/client/kmp/DeviceSecretValidator {
+	public abstract fun validate (Ljava/lang/String;Lcom/okta/authfoundation/jwt/Jwt;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/okta/authfoundation/client/kmp/DeviceSecretValidator$Error : java/lang/IllegalStateException {
+	public fun <init> (Ljava/lang/String;)V
+}
+
+public abstract interface class com/okta/authfoundation/client/kmp/IdTokenValidator {
+	public abstract fun validate (Ljava/lang/String;Ljava/lang/String;Lcom/okta/authfoundation/jwt/Jwt;Lcom/okta/authfoundation/client/OidcClock;Lcom/okta/authfoundation/client/kmp/IdTokenValidator$Parameters;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun validate$default (Lcom/okta/authfoundation/client/kmp/IdTokenValidator;Ljava/lang/String;Ljava/lang/String;Lcom/okta/authfoundation/jwt/Jwt;Lcom/okta/authfoundation/client/OidcClock;Lcom/okta/authfoundation/client/kmp/IdTokenValidator$Parameters;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/okta/authfoundation/client/kmp/IdTokenValidator$DefaultImpls {
+	public static synthetic fun validate$default (Lcom/okta/authfoundation/client/kmp/IdTokenValidator;Ljava/lang/String;Ljava/lang/String;Lcom/okta/authfoundation/jwt/Jwt;Lcom/okta/authfoundation/client/OidcClock;Lcom/okta/authfoundation/client/kmp/IdTokenValidator$Parameters;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/okta/authfoundation/client/kmp/IdTokenValidator$Error : java/lang/IllegalStateException {
+	public static final field Companion Lcom/okta/authfoundation/client/kmp/IdTokenValidator$Error$Companion;
+	public static final field EXPIRED Ljava/lang/String;
+	public static final field INVALID_AUDIENCE Ljava/lang/String;
+	public static final field INVALID_ISSUER Ljava/lang/String;
+	public static final field INVALID_JWT_ALGORITHM Ljava/lang/String;
+	public static final field INVALID_JWT_SIGNATURE Ljava/lang/String;
+	public static final field INVALID_SUBJECT Ljava/lang/String;
+	public static final field ISSUED_AT_THRESHOLD_NOT_SATISFIED Ljava/lang/String;
+	public static final field ISSUER_NOT_HTTPS Ljava/lang/String;
+	public static final field MAX_AGE_NOT_SATISFIED Ljava/lang/String;
+	public static final field NONCE_MISMATCH Ljava/lang/String;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getIdentifier ()Ljava/lang/String;
+}
+
+public final class com/okta/authfoundation/client/kmp/IdTokenValidator$Error$Companion {
+}
+
+public final class com/okta/authfoundation/client/kmp/IdTokenValidator$Parameters {
+	public fun <init> (Ljava/lang/String;Ljava/lang/Integer;)V
+	public final fun getMaxAge ()Ljava/lang/Integer;
+	public final fun getNonce ()Ljava/lang/String;
+}
+
+public final class com/okta/authfoundation/client/kmp/MaxRetries {
+	public static final synthetic fun box-impl (I)Lcom/okta/authfoundation/client/kmp/MaxRetries;
+	public static fun constructor-impl (I)I
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (ILjava/lang/Object;)Z
+	public static final fun equals-impl0 (II)Z
+	public final fun getValue ()I
+	public fun hashCode ()I
+	public static fun hashCode-impl (I)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (I)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()I
+}
+
+public final class com/okta/authfoundation/client/kmp/MinDelaySeconds {
+	public static final synthetic fun box-impl (J)Lcom/okta/authfoundation/client/kmp/MinDelaySeconds;
+	public static fun constructor-impl (J)J
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (JLjava/lang/Object;)Z
+	public static final fun equals-impl0 (JJ)Z
+	public final fun getValue ()J
+	public fun hashCode ()I
+	public static fun hashCode-impl (J)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (J)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()J
+}
+
+public final class com/okta/authfoundation/client/kmp/OAuth2Client {
+	public static final field Companion Lcom/okta/authfoundation/client/kmp/OAuth2Client$Companion;
+	public final fun deviceAuthorizationRequest-gIAlu-s (Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun endpointsOrNull (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getConfiguration ()Lcom/okta/authfoundation/client/OAuth2ClientConfiguration;
+	public final fun getEvents ()Lkotlinx/coroutines/flow/SharedFlow;
+	public final fun getUserInfo-gIAlu-s (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun introspectToken-0E7RQCE (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun jwks-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun refreshToken-0E7RQCE (Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun refreshToken-gIAlu-s (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun revokeToken-gIAlu-s (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun tokenRequest-BWLJW6A (Ljava/util/Map;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun tokenRequest-BWLJW6A$default (Lcom/okta/authfoundation/client/kmp/OAuth2Client;Ljava/util/Map;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/okta/authfoundation/client/kmp/OAuth2Client$Companion {
+	public final fun createFromConfiguration (Lcom/okta/authfoundation/client/OAuth2ClientConfiguration;)Lcom/okta/authfoundation/client/kmp/OAuth2Client;
+}
+
+public final class com/okta/authfoundation/client/kmp/RateLimitRetryConfig {
+	public synthetic fun <init> (IJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-KHxJZ0A ()I
+	public final fun component2-Klur8Ro ()J
+	public final fun copy-HXtXcCM (IJ)Lcom/okta/authfoundation/client/kmp/RateLimitRetryConfig;
+	public static synthetic fun copy-HXtXcCM$default (Lcom/okta/authfoundation/client/kmp/RateLimitRetryConfig;IJILjava/lang/Object;)Lcom/okta/authfoundation/client/kmp/RateLimitRetryConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMaxRetries-KHxJZ0A ()I
+	public final fun getMinDelaySeconds-Klur8Ro ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/okta/authfoundation/client/kmp/events/RateLimitExceededEvent : com/okta/authfoundation/events/TokenEvent {
+	public final fun getRequestUrl ()Ljava/lang/String;
+	public final fun getResponseHeaders ()Ljava/util/Map;
+	public final fun getRetryAfterSeconds ()Ljava/lang/Long;
+}
+
+public final class com/okta/authfoundation/client/kmp/events/TokenCreatedEvent : com/okta/authfoundation/events/TokenEvent {
+	public final fun getTokenInfo ()Lcom/okta/authfoundation/client/TokenInfo;
+}
+
+public final class com/okta/authfoundation/credential/AndroidBiometricAuthenticator : com/okta/authfoundation/credential/BiometricAuthenticator {
+	public fun <init> (Landroidx/biometric/BiometricPrompt$PromptInfo;Ljava/security/KeyStore;)V
+	public fun decrypt-0E7RQCE ([BLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun decrypt-BWLJW6A ([BLjava/lang/String;[BLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun unlock-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/okta/authfoundation/credential/BiometricAuthenticator {
+	public abstract fun decrypt-0E7RQCE ([BLjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun decrypt-BWLJW6A ([BLjava/lang/String;[BLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun unlock-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class com/okta/authfoundation/credential/BiometricInvocationException : java/lang/IllegalStateException {
@@ -542,14 +859,14 @@ public final class com/okta/authfoundation/credential/BiometricInvocationExcepti
 	public fun getMessage ()Ljava/lang/String;
 }
 
-public final class com/okta/authfoundation/credential/Credential {
+public final class com/okta/authfoundation/credential/Credential : com/okta/authfoundation/credential/CredentialIdentifier {
 	public static final field Companion Lcom/okta/authfoundation/credential/Credential$Companion;
 	public final fun accessTokenInterceptor ()Lokhttp3/Interceptor;
 	public final fun delete ()V
 	public final fun deleteAsync (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAccessTokenIfValid ()Ljava/lang/String;
-	public final fun getId ()Ljava/lang/String;
+	public fun getId ()Ljava/lang/String;
 	public final fun getTags ()Ljava/util/Map;
 	public final fun getToken ()Lcom/okta/authfoundation/credential/Token;
 	public final fun getTokenFlow ()Lkotlinx/coroutines/flow/Flow;
@@ -558,6 +875,7 @@ public final class com/okta/authfoundation/credential/Credential {
 	public fun hashCode ()I
 	public final fun idToken ()Lcom/okta/authfoundation/jwt/Jwt;
 	public final fun introspectToken (Lcom/okta/authfoundation/credential/TokenType;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun refreshToken (Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun refreshToken (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun revokeAllTokens (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun revokeToken (Lcom/okta/authfoundation/credential/RevokeTokenType;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -666,6 +984,10 @@ public final class com/okta/authfoundation/credential/CredentialDataSource$Compa
 	public final fun getInstance (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public abstract interface class com/okta/authfoundation/credential/CredentialIdentifier {
+	public abstract fun getId ()Ljava/lang/String;
+}
+
 public final class com/okta/authfoundation/credential/DefaultTokenEncryptionHandler : com/okta/authfoundation/credential/TokenEncryptionHandler {
 	public fun <init> ()V
 	public fun <init> (Ljava/security/KeyStore;Ljava/security/KeyPairGenerator;)V
@@ -720,19 +1042,22 @@ public final class com/okta/authfoundation/credential/RoomTokenStorage$Companion
 	public final fun getInstance (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public final class com/okta/authfoundation/credential/Token {
+public final class com/okta/authfoundation/credential/Token : com/okta/authfoundation/client/TokenInfo {
 	public static final field Companion Lcom/okta/authfoundation/credential/Token$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/okta/authfoundation/client/OidcConfiguration;)V
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getAccessToken ()Ljava/lang/String;
-	public final fun getDeviceSecret ()Ljava/lang/String;
-	public final fun getExpiresIn ()I
-	public final fun getIdToken ()Ljava/lang/String;
-	public final fun getIssuedTokenType ()Ljava/lang/String;
+	public fun getAccessToken ()Ljava/lang/String;
+	public fun getClientId ()Ljava/lang/String;
+	public fun getDeviceSecret ()Ljava/lang/String;
+	public fun getExpiresIn ()I
+	public fun getId ()Ljava/lang/String;
+	public fun getIdToken ()Ljava/lang/String;
+	public fun getIssuedTokenType ()Ljava/lang/String;
+	public fun getIssuerUrl ()Ljava/lang/String;
 	public final fun getOidcConfiguration ()Lcom/okta/authfoundation/client/OidcConfiguration;
-	public final fun getRefreshToken ()Ljava/lang/String;
-	public final fun getScope ()Ljava/lang/String;
-	public final fun getTokenType ()Ljava/lang/String;
+	public fun getRefreshToken ()Ljava/lang/String;
+	public fun getScope ()Ljava/lang/String;
+	public fun getTokenType ()Ljava/lang/String;
 	public fun hashCode ()I
 }
 
@@ -797,6 +1122,27 @@ public final class com/okta/authfoundation/credential/TokenEncryptionHandler$Enc
 	public final fun getEncryptionExtras ()Ljava/util/Map;
 }
 
+public final class com/okta/authfoundation/credential/TokenMetadata {
+	public fun <init> (Ljava/lang/String;Ljava/util/Map;Lcom/okta/authfoundation/jwt/Jwt;Lkotlinx/serialization/json/Json;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Map;Lcom/okta/authfoundation/jwt/Jwt;Lkotlinx/serialization/json/Json;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/Map;Lkotlinx/serialization/json/JsonObject;Lkotlinx/serialization/json/Json;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Map;Lkotlinx/serialization/json/JsonObject;Lkotlinx/serialization/json/Json;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun component3 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun component4 ()Lkotlinx/serialization/json/Json;
+	public final fun copy (Ljava/lang/String;Ljava/util/Map;Lkotlinx/serialization/json/JsonObject;Lkotlinx/serialization/json/Json;)Lcom/okta/authfoundation/credential/TokenMetadata;
+	public static synthetic fun copy$default (Lcom/okta/authfoundation/credential/TokenMetadata;Ljava/lang/String;Ljava/util/Map;Lkotlinx/serialization/json/JsonObject;Lkotlinx/serialization/json/Json;ILjava/lang/Object;)Lcom/okta/authfoundation/credential/TokenMetadata;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getClaimsProvider ()Lcom/okta/authfoundation/claims/ClaimsProvider;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getJson ()Lkotlinx/serialization/json/Json;
+	public final fun getPayloadData ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getTags ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract interface class com/okta/authfoundation/credential/TokenStorage {
 	public abstract fun add (Lcom/okta/authfoundation/credential/Token;Lcom/okta/authfoundation/credential/Token$Metadata;Lcom/okta/authfoundation/credential/Credential$Security;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun add$default (Lcom/okta/authfoundation/credential/TokenStorage;Lcom/okta/authfoundation/credential/Token;Lcom/okta/authfoundation/credential/Token$Metadata;Lcom/okta/authfoundation/credential/Credential$Security;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
@@ -836,29 +1182,29 @@ public final class com/okta/authfoundation/credential/events/BiometricTokenInval
 }
 
 public final class com/okta/authfoundation/credential/events/CredentialCreatedEvent : com/okta/authfoundation/events/CredentialEvent {
-	public final fun getCredential ()Lcom/okta/authfoundation/credential/Credential;
+	public final fun getCredentialIdentifier ()Lcom/okta/authfoundation/credential/CredentialIdentifier;
 }
 
 public final class com/okta/authfoundation/credential/events/CredentialDeletedEvent : com/okta/authfoundation/events/CredentialEvent {
-	public final fun getCredential ()Lcom/okta/authfoundation/credential/Credential;
+	public final fun getCredentialIdentifier ()Lcom/okta/authfoundation/credential/CredentialIdentifier;
 }
 
 public final class com/okta/authfoundation/credential/events/CredentialStoredAfterRemovedEvent : com/okta/authfoundation/events/CredentialEvent {
-	public final fun getCredential ()Lcom/okta/authfoundation/credential/Credential;
+	public final fun getCredentialIdentifier ()Lcom/okta/authfoundation/credential/CredentialIdentifier;
 }
 
 public final class com/okta/authfoundation/credential/events/CredentialStoredEvent : com/okta/authfoundation/events/CredentialEvent {
-	public final fun getCredential ()Lcom/okta/authfoundation/credential/Credential;
+	public final fun getCredentialIdentifier ()Lcom/okta/authfoundation/credential/CredentialIdentifier;
 	public final fun getTags ()Ljava/util/Map;
-	public final fun getToken ()Lcom/okta/authfoundation/credential/Token;
+	public final fun getToken ()Lcom/okta/authfoundation/client/TokenInfo;
 }
 
 public final class com/okta/authfoundation/credential/events/DefaultCredentialChangedEvent : com/okta/authfoundation/events/CredentialEvent {
-	public final fun getCredential ()Lcom/okta/authfoundation/credential/Credential;
+	public final fun getCredentialIdentifier ()Lcom/okta/authfoundation/credential/CredentialIdentifier;
 }
 
 public final class com/okta/authfoundation/credential/events/NoAccessTokenAvailableEvent : com/okta/authfoundation/events/CredentialEvent {
-	public final fun getCredential ()Lcom/okta/authfoundation/credential/Credential;
+	public final fun getCredential ()Lcom/okta/authfoundation/credential/CredentialIdentifier;
 }
 
 public final class com/okta/authfoundation/credential/events/TokenStorageAccessErrorEvent : com/okta/authfoundation/events/CredentialEvent {
@@ -866,6 +1212,189 @@ public final class com/okta/authfoundation/credential/events/TokenStorageAccessE
 	public final fun getShouldClearStorageAndTryAgain ()Z
 	public final fun setShouldClearStorageAndTryAgain (Z)V
 	public final fun withShouldClearStorageAndTryAgain (Z)Lcom/okta/authfoundation/credential/events/TokenStorageAccessErrorEvent;
+}
+
+public final class com/okta/authfoundation/credential/kmp/BearerTokenPluginConfig {
+	public fun <init> ()V
+	public final fun getAccessTokenProvider ()Lkotlin/jvm/functions/Function1;
+	public final fun getCredential ()Lcom/okta/authfoundation/credential/kmp/Credential;
+	public final fun getEventsFlow ()Lkotlinx/coroutines/flow/MutableSharedFlow;
+	public final fun setAccessTokenProvider (Lkotlin/jvm/functions/Function1;)V
+	public final fun setCredential (Lcom/okta/authfoundation/credential/kmp/Credential;)V
+	public final fun setEventsFlow (Lkotlinx/coroutines/flow/MutableSharedFlow;)V
+}
+
+public final class com/okta/authfoundation/credential/kmp/BearerTokenPluginKt {
+	public static final fun getBearerTokenPlugin ()Lio/ktor/client/plugins/api/ClientPlugin;
+}
+
+public final class com/okta/authfoundation/credential/kmp/BiometricKeyInvalidatedException : java/lang/Exception {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun getKeyAlias ()Ljava/lang/String;
+	public final fun getTokenId ()Ljava/lang/String;
+}
+
+public abstract interface class com/okta/authfoundation/credential/kmp/Credential : com/okta/authfoundation/credential/CredentialIdentifier {
+	public abstract fun accessTokenIfNotExpired ()Ljava/lang/String;
+	public abstract fun deleteAsync-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getId ()Ljava/lang/String;
+	public abstract fun getTags ()Ljava/util/Map;
+	public abstract fun getToken ()Lcom/okta/authfoundation/client/TokenInfo;
+	public abstract fun getTokenFlow ()Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getUserInfo-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun idToken-d1pmJ48 ()Ljava/lang/Object;
+	public abstract fun introspectToken-gIAlu-s (Lcom/okta/authfoundation/credential/TokenType;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun refreshIfExpired-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun refreshToken-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun refreshToken-gIAlu-s (Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun revokeAllTokens-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun revokeToken-gIAlu-s (Lcom/okta/authfoundation/credential/RevokeTokenType;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun scope ()Ljava/lang/String;
+	public abstract fun setTagsAsync-gIAlu-s (Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/okta/authfoundation/credential/kmp/Credential$DefaultImpls {
+	public static fun refreshToken-gIAlu-s (Lcom/okta/authfoundation/credential/kmp/Credential;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/okta/authfoundation/credential/kmp/CredentialImpl : com/okta/authfoundation/credential/kmp/Credential {
+	public fun accessTokenIfNotExpired ()Ljava/lang/String;
+	public fun deleteAsync-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getId ()Ljava/lang/String;
+	public fun getTags ()Ljava/util/Map;
+	public synthetic fun getToken ()Lcom/okta/authfoundation/client/TokenInfo;
+	public fun getToken ()Lcom/okta/authfoundation/credential/kmp/TokenData;
+	public fun getTokenFlow ()Lkotlinx/coroutines/flow/Flow;
+	public fun getUserInfo-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun idToken-d1pmJ48 ()Ljava/lang/Object;
+	public fun introspectToken-gIAlu-s (Lcom/okta/authfoundation/credential/TokenType;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun refreshIfExpired-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun refreshToken-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun refreshToken-gIAlu-s (Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun revokeAllTokens-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun revokeToken-gIAlu-s (Lcom/okta/authfoundation/credential/RevokeTokenType;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun scope ()Ljava/lang/String;
+	public fun setTagsAsync-gIAlu-s (Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/okta/authfoundation/credential/kmp/DefaultCredentialIdStore {
+	public abstract fun clearDefaultCredentialId-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getDefaultCredentialId-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun setDefaultCredentialId-gIAlu-s (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/okta/authfoundation/credential/kmp/EncryptionResult {
+	public fun <init> ([BLjava/util/Map;)V
+	public synthetic fun <init> ([BLjava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()[B
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy ([BLjava/util/Map;)Lcom/okta/authfoundation/credential/kmp/EncryptionResult;
+	public static synthetic fun copy$default (Lcom/okta/authfoundation/credential/kmp/EncryptionResult;[BLjava/util/Map;ILjava/lang/Object;)Lcom/okta/authfoundation/credential/kmp/EncryptionResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCiphertext ()[B
+	public final fun getEncryptionExtras ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/okta/authfoundation/credential/kmp/TokenCredentialManager {
+	public fun <init> (Lcom/okta/authfoundation/client/kmp/OAuth2Client;Lcom/okta/authfoundation/credential/kmp/TokenStorage;Lcom/okta/authfoundation/credential/kmp/DefaultCredentialIdStore;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lcom/okta/authfoundation/client/kmp/OAuth2Client;Lcom/okta/authfoundation/credential/kmp/TokenStorage;Lcom/okta/authfoundation/credential/kmp/DefaultCredentialIdStore;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun allIds-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun find-gIAlu-s (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun findByCredential (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun get-gIAlu-s (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getClient ()Lcom/okta/authfoundation/client/kmp/OAuth2Client;
+	public final fun getDefault-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getDefaultIdStore ()Lcom/okta/authfoundation/credential/kmp/DefaultCredentialIdStore;
+	public final fun getEvents ()Lkotlinx/coroutines/flow/SharedFlow;
+	public final fun getOnStorageError ()Lkotlin/jvm/functions/Function1;
+	public final fun metadata-gIAlu-s (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun setDefault-gIAlu-s (Lcom/okta/authfoundation/credential/kmp/Credential;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun setMetadata-gIAlu-s (Lcom/okta/authfoundation/credential/TokenMetadata;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun store-0E7RQCE (Lcom/okta/authfoundation/credential/kmp/TokenData;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun store-0E7RQCE$default (Lcom/okta/authfoundation/credential/kmp/TokenCredentialManager;Lcom/okta/authfoundation/credential/kmp/TokenData;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/okta/authfoundation/credential/kmp/TokenData : com/okta/authfoundation/client/TokenInfo {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/okta/authfoundation/client/OAuth2ClientConfiguration;J)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/okta/authfoundation/client/OAuth2ClientConfiguration;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun accessTokenIfNotExpired ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/okta/authfoundation/credential/kmp/TokenData;
+	public static synthetic fun copy$default (Lcom/okta/authfoundation/credential/kmp/TokenData;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/okta/authfoundation/credential/kmp/TokenData;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAccessToken ()Ljava/lang/String;
+	public fun getClientId ()Ljava/lang/String;
+	public final fun getConfiguration ()Lcom/okta/authfoundation/client/OAuth2ClientConfiguration;
+	public fun getDeviceSecret ()Ljava/lang/String;
+	public fun getExpiresIn ()I
+	public fun getId ()Ljava/lang/String;
+	public fun getIdToken ()Ljava/lang/String;
+	public final fun getIssuedAt ()J
+	public fun getIssuedTokenType ()Ljava/lang/String;
+	public fun getIssuerUrl ()Ljava/lang/String;
+	public fun getRefreshToken ()Ljava/lang/String;
+	public fun getScope ()Ljava/lang/String;
+	public fun getTokenType ()Ljava/lang/String;
+	public fun hashCode ()I
+}
+
+public abstract interface class com/okta/authfoundation/credential/kmp/TokenEncryptionHandler {
+	public abstract fun decrypt ([BLjava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun encrypt ([BLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/okta/authfoundation/credential/kmp/TokenStorage {
+	public abstract fun add-0E7RQCE (Lcom/okta/authfoundation/client/TokenInfo;Lcom/okta/authfoundation/credential/TokenMetadata;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun allIds-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getToken-gIAlu-s (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun metadata-gIAlu-s (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun remove-gIAlu-s (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun replace-gIAlu-s (Lcom/okta/authfoundation/client/TokenInfo;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun setMetadata-gIAlu-s (Lcom/okta/authfoundation/credential/TokenMetadata;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/okta/authfoundation/credential/kmp/storage/RoomDefaultCredentialIdStore : com/okta/authfoundation/credential/kmp/DefaultCredentialIdStore {
+	public static final field DEFAULT_CREDENTIAL_KEY Ljava/lang/String;
+	public fun <init> (Lcom/okta/authfoundation/credential/kmp/storage/TokenDatabase;)V
+	public fun clearDefaultCredentialId-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getDefaultCredentialId-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setDefaultCredentialId-gIAlu-s (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/okta/authfoundation/credential/kmp/storage/RoomTokenStorage : com/okta/authfoundation/credential/kmp/TokenStorage {
+	public fun <init> (Lcom/okta/authfoundation/credential/kmp/storage/TokenDatabase;Lcom/okta/authfoundation/credential/kmp/TokenEncryptionHandler;Lcom/okta/authfoundation/client/OAuth2ClientConfiguration;)V
+	public fun add-0E7RQCE (Lcom/okta/authfoundation/client/TokenInfo;Lcom/okta/authfoundation/credential/TokenMetadata;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun allIds-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getToken-gIAlu-s (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun metadata-gIAlu-s (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun remove-gIAlu-s (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun replace-gIAlu-s (Lcom/okta/authfoundation/client/TokenInfo;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setMetadata-gIAlu-s (Lcom/okta/authfoundation/credential/TokenMetadata;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract class com/okta/authfoundation/credential/kmp/storage/TokenDatabase : androidx/room/RoomDatabase {
+	public static final field Companion Lcom/okta/authfoundation/credential/kmp/storage/TokenDatabase$Companion;
+	public fun <init> ()V
+}
+
+public final class com/okta/authfoundation/credential/kmp/storage/TokenDatabase$Companion {
+}
+
+public final class com/okta/authfoundation/credential/kmp/storage/TokenDatabaseConstructor : androidx/room/RoomDatabaseConstructor {
+	public static final field INSTANCE Lcom/okta/authfoundation/credential/kmp/storage/TokenDatabaseConstructor;
+	public synthetic fun initialize ()Landroidx/room/RoomDatabase;
+	public fun initialize ()Lcom/okta/authfoundation/credential/kmp/storage/TokenDatabase;
+}
+
+public final class com/okta/authfoundation/credential/kmp/storage/TokenDatabase_Impl : com/okta/authfoundation/credential/kmp/storage/TokenDatabase {
+	public fun <init> ()V
+	public fun clearAllTables ()V
+	public fun createAutoMigrations (Ljava/util/Map;)Ljava/util/List;
+	public synthetic fun createOpenDelegate ()Landroidx/room/RoomOpenDelegateMarker;
+	public fun getRequiredAutoMigrationSpecClasses ()Ljava/util/Set;
 }
 
 public abstract class com/okta/authfoundation/credential/storage/TokenDatabase : androidx/room/RoomDatabase {
@@ -907,6 +1436,14 @@ public final class com/okta/authfoundation/credential/storage/typeconverters/Str
 	public final fun convertToObject (Ljava/lang/String;)Ljava/util/Map;
 }
 
+public final class com/okta/authfoundation/crypto/CryptoProvider_androidKt {
+	public static final fun secureRandomBytes (I)[B
+	public static final fun sha256Digest ([B)[B
+}
+
+public abstract interface class com/okta/authfoundation/events/CredentialEvent : com/okta/authfoundation/events/Event {
+}
+
 public abstract interface class com/okta/authfoundation/events/Event {
 }
 
@@ -918,6 +1455,9 @@ public final class com/okta/authfoundation/events/EventCoordinator {
 
 public abstract interface class com/okta/authfoundation/events/EventHandler {
 	public abstract fun onEvent (Lcom/okta/authfoundation/events/Event;)V
+}
+
+public abstract interface class com/okta/authfoundation/events/TokenEvent : com/okta/authfoundation/events/Event {
 }
 
 public final class com/okta/authfoundation/jwt/Jwks {
@@ -938,12 +1478,7 @@ public final class com/okta/authfoundation/jwt/Jwt : com/okta/authfoundation/cla
 }
 
 public final class com/okta/authfoundation/jwt/JwtParser {
-	public static final field Companion Lcom/okta/authfoundation/jwt/JwtParser$Companion;
 	public final fun parse (Ljava/lang/String;)Lcom/okta/authfoundation/jwt/Jwt;
-}
-
-public final class com/okta/authfoundation/jwt/JwtParser$Companion {
-	public final fun create ()Lcom/okta/authfoundation/jwt/JwtParser;
 }
 
 public final class com/okta/authfoundation/util/AesEncryptionHandler {
@@ -952,7 +1487,7 @@ public final class com/okta/authfoundation/util/AesEncryptionHandler {
 	public fun <init> (Landroid/security/keystore/KeyGenParameterSpec;)V
 	public synthetic fun <init> (Landroid/security/keystore/KeyGenParameterSpec;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun decryptString-IoAF18A (Ljava/lang/String;)Ljava/lang/Object;
-	public final fun encryptString (Ljava/lang/String;)Ljava/lang/String;
+	public final fun encryptString-IoAF18A (Ljava/lang/String;)Ljava/lang/Object;
 	public final fun resetEncryptionKey ()V
 }
 
@@ -963,13 +1498,7 @@ public final class com/okta/authfoundation/util/AndroidKeystoreUtil {
 	public static final field INSTANCE Lcom/okta/authfoundation/util/AndroidKeystoreUtil;
 	public final fun deleteKey (Ljava/lang/String;)V
 	public final fun getKeyStore ()Ljava/security/KeyStore;
-	public final fun getOrCreateAesKey (Landroid/security/keystore/KeyGenParameterSpec;)Ljava/security/Key;
+	public final fun getOrCreateAesKey-IoAF18A (Landroid/security/keystore/KeyGenParameterSpec;)Ljava/lang/Object;
 	public final fun getRsaKeyPairGenerator ()Ljava/security/KeyPairGenerator;
-}
-
-public final class com/okta/authfoundation/util/CoalescingOrchestrator {
-	public fun <init> (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;)V
-	public synthetic fun <init> (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun get (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 

--- a/auth-foundation/api/jvm/auth-foundation.api
+++ b/auth-foundation/api/jvm/auth-foundation.api
@@ -275,7 +275,6 @@ public abstract interface class com/okta/authfoundation/client/Cache {
 
 public final class com/okta/authfoundation/client/OAuth2ClientBuilder {
 	public static final field Companion Lcom/okta/authfoundation/client/OAuth2ClientBuilder$Companion;
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAccessTokenValidator ()Lcom/okta/authfoundation/client/kmp/AccessTokenValidator;
 	public final fun getAcrValues ()Ljava/lang/String;
 	public final fun getApiExecutor ()Lcom/okta/authfoundation/api/http/ApiExecutor;
@@ -462,7 +461,6 @@ public final class com/okta/authfoundation/client/internal/OAuth2Endpoints$Compa
 
 public final class com/okta/authfoundation/client/jvm/AuthFoundationResult {
 	public static final field Companion Lcom/okta/authfoundation/client/jvm/AuthFoundationResult$Companion;
-	public synthetic fun <init> (Ljava/lang/Object;Ljava/lang/Throwable;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun exceptionOrNull ()Ljava/lang/Throwable;
 	public static final fun failure (Ljava/lang/Throwable;)Lcom/okta/authfoundation/client/jvm/AuthFoundationResult;
 	public final fun getOrNull ()Ljava/lang/Object;
@@ -905,7 +903,6 @@ public abstract interface class com/okta/authfoundation/credential/kmp/TokenStor
 }
 
 public final class com/okta/authfoundation/credential/kmp/storage/RoomDefaultCredentialIdStore : com/okta/authfoundation/credential/kmp/DefaultCredentialIdStore {
-	public static final field DEFAULT_CREDENTIAL_KEY Ljava/lang/String;
 	public fun <init> (Lcom/okta/authfoundation/credential/kmp/storage/TokenDatabase;)V
 	public fun clearDefaultCredentialId-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getDefaultCredentialId-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/auth-foundation/build.gradle.kts
+++ b/auth-foundation/build.gradle.kts
@@ -1,5 +1,5 @@
-import org.gradle.api.tasks.compile.JavaCompile
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
@@ -10,8 +10,8 @@ plugins {
     kotlin("plugin.serialization") version libs.versions.kotlin.get()
     id("com.vanniktech.maven.publish.base")
     id("spotless")
-    id("binary-compatibility-validator")
     id("androidx.room")
+    id("binary-compat-validation")
 }
 
 // KMP androidLibrary does not generate BuildConfigs so we generate a BuildInfo.kt file instead.
@@ -37,7 +37,7 @@ val generateBuildInfoTask =
     }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.okta.authfoundation"
         compileSdk = COMPILE_SDK
         minSdk = MIN_SDK
@@ -187,6 +187,25 @@ kotlin {
             }
         }
     }
+
+    // Only validates the jvm target; KGP's ABI validation filters for KotlinAndroidTarget, but the androidLibrary
+    // target here is a KotlinMultiplatformAndroidLibraryTargetImpl (AGP's KMP android plugin), so it's silently skipped.
+    // The android target's own ABI is covered separately below, via binary-compat-validation.
+    @OptIn(ExperimentalAbiValidation::class)
+    abiValidation {
+        filters {
+            exclude {
+                byNames.add("com.okta.authfoundation.BuildInfo")
+            }
+        }
+    }
+}
+
+binaryCompatValidationExtension {
+    taskNamePrefix.set("android")
+    kotlinCompileTaskName.set("compileAndroidMain")
+    javaCompileTaskName.set("")
+    ignoredClasses.add("com.okta.authfoundation.BuildInfo")
 }
 
 java {
@@ -203,8 +222,4 @@ dependencies {
     add("kspAndroid", libs.room.compiler)
     add("kspJvm", libs.room.compiler)
     coreLibraryDesugaring(libs.core.library.desugaring)
-}
-
-apiValidation {
-    ignoredClasses.add("com.okta.authfoundation.BuildInfo")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,8 @@ plugins {
     alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.androidx.navigation.safeargs) apply false
-    alias(libs.plugins.kotlinx.binary.compatibility.validator) apply false
+    // No apply-false declaration here: buildSrc's own dependency on this artifact (for
+    // AndroidBcvBridgePlugin) already puts it on the classpath for every subproject.
     alias(libs.plugins.androidx.room) apply false
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.kotlin.multiplatform) apply false
@@ -76,7 +77,14 @@ tasks.register("checkLegacyAbi") {
 gradle.projectsEvaluated {
     tasks.named("checkLegacyAbi").configure {
         subprojects.forEach { subproject ->
-            subproject.tasks.findByName("apiCheck")?.let { dependsOn(it) }
+            // checkKotlinAbi: KGP's built-in ABI validation (auth-foundation/oauth2's jvm target).
+            // androidApiCheck: binary-compat-validation, for KMP android targets KGP's validator can't see.
+            // releaseApiCheck: binary-compat-validation, for Android-only modules on AGP built-in Kotlin.
+            listOfNotNull(
+                subproject.tasks.findByName("checkKotlinAbi"),
+                subproject.tasks.findByName("androidApiCheck"),
+                subproject.tasks.findByName("releaseApiCheck")
+            ).forEach { dependsOn(it) }
         }
     }
 }
@@ -84,8 +92,8 @@ gradle.projectsEvaluated {
 subprojects {
     plugins.withId("com.vanniktech.maven.publish.base") {
         configure<MavenPublishBaseExtension> {
-            val snapshot = project.properties["snapshot"]?.toString()?.toBoolean() ?: false
-            val automaticRelease = if (snapshot) false else project.properties["automaticRelease"]?.toString()?.toBoolean() ?: false
+            val snapshot = project.findProperty("snapshot")?.toString()?.toBoolean() ?: false
+            val automaticRelease = if (snapshot) false else project.findProperty("automaticRelease")?.toString()?.toBoolean() ?: false
 
             publishToMavenCentral(automaticRelease)
             if (project.hasProperty("signAllPublications")) signAllPublications()

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -14,4 +14,18 @@ dependencies {
     //noinspection UseTomlInstead
     implementation("com.diffplug.spotless:spotless-plugin-gradle:8.8.0")
     implementation("org.owasp:dependency-check-gradle:12.2.0")
+    // Pinned exactly to the version applied elsewhere in the project (gradle/libs.versions.toml).
+    // BinaryCompatValidationPlugin depends on kotlinx.validation.KotlinApiBuildTask/KotlinApiCompareTask,
+    // which are BCV-internal types, not public API - bumping this requires re-verifying that plugin.
+    //noinspection UseTomlInstead
+    implementation("org.jetbrains.kotlinx:binary-compatibility-validator:0.18.1")
+}
+
+gradlePlugin {
+    plugins {
+        create("binaryCompatValidation") {
+            id = "binary-compat-validation"
+            implementationClass = "BinaryCompatValidationPlugin"
+        }
+    }
 }

--- a/buildSrc/src/main/kotlin/ApiDumpTask.kt
+++ b/buildSrc/src/main/kotlin/ApiDumpTask.kt
@@ -1,0 +1,30 @@
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+
+/**
+ * Copies a freshly built BCV API dump over the committed file, mirroring the standalone
+ * binary-compatibility-validator plugin's own `apiDump` task.
+ */
+@DisableCachingByDefault
+abstract class ApiDumpTask : DefaultTask() {
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.NONE)
+    abstract val generatedApiFile: RegularFileProperty
+
+    @get:OutputFile
+    abstract val committedApiFile: RegularFileProperty
+
+    @TaskAction
+    fun dump() {
+        val generated = generatedApiFile.get().asFile
+        val committed = committedApiFile.get().asFile
+        committed.parentFile?.mkdirs()
+        generated.copyTo(committed, overwrite = true)
+    }
+}

--- a/buildSrc/src/main/kotlin/BinaryCompatValidationExtension.kt
+++ b/buildSrc/src/main/kotlin/BinaryCompatValidationExtension.kt
@@ -1,0 +1,33 @@
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
+
+/**
+ * Configuration for the `BinaryCompatValidationExtension { }` block.
+ *
+ * Defaults match a plain AGP library module's `release` variant. Modules whose public API
+ * comes from a differently-named compile task (e.g. a KMP target's `compileAndroidMain`) should
+ * override [kotlinCompileTaskName] and [taskNamePrefix] directly instead of [variant].
+ */
+abstract class BinaryCompatValidationExtension {
+    /** Used to derive default task names below and to name the tasks this plugin registers. */
+    abstract val variant: Property<String>
+
+    /** Name of the registered `<prefix>ApiBuild`/`<prefix>ApiCheck`/`<prefix>ApiDump` tasks. Defaults to [variant]. */
+    abstract val taskNamePrefix: Property<String>
+
+    /** Compile task whose output classes make up the public API. Defaults to `compile<Variant>Kotlin`. */
+    abstract val kotlinCompileTaskName: Property<String>
+
+    /**
+     * Java compile task to additionally include, if any. Defaults to `compile<Variant>JavaWithJavac`.
+     * Set to an empty string for Kotlin-only source sets (e.g. KMP targets), where no such task exists.
+     */
+    abstract val javaCompileTaskName: Property<String>
+
+    /** The committed API dump the check task verifies against and the dump task writes to. Defaults to `api/<module>.api`. */
+    abstract val apiFile: RegularFileProperty
+
+    /** Fully qualified class names to exclude from the dump, e.g. a generated BuildConfig class. */
+    abstract val ignoredClasses: SetProperty<String>
+}

--- a/buildSrc/src/main/kotlin/BinaryCompatValidationPlugin.kt
+++ b/buildSrc/src/main/kotlin/BinaryCompatValidationPlugin.kt
@@ -1,0 +1,82 @@
+import kotlinx.validation.KotlinApiBuildTask
+import kotlinx.validation.KotlinApiCompareTask
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.kotlin.dsl.named
+import org.gradle.kotlin.dsl.register
+import org.gradle.language.base.plugins.LifecycleBasePlugin
+
+/**
+ * Registers Kotlin Binary Compatibility Validator (BCV) API dump and check tasks by hand, for
+ * targets the standalone `binary-compatibility-validator` plugin can't see.
+ *
+ * BCV only creates its `apiDump`/`apiCheck` tasks when it detects the standalone `kotlin-android`,
+ * `kotlin`, or `kotlin-multiplatform` plugin applied via `pluginManager.withPlugin(...)`. Two of
+ * our targets never trigger that:
+ *  - Our four Android-only modules use AGP 9's built-in Kotlin, which applies none of those IDs
+ *  - auth-foundation/oauth2's KMP `android` target compiles via AGP's own
+ *    `com.android.kotlin.multiplatform.library` plugin, whose target class KGP's newer built-in
+ *    `abiValidation` doesn't recognize either (it filters for `KotlinAndroidTarget`).
+ *
+ * This plugin keeps whichever Kotlin set up a module already has and registers BCV's own task
+ * types directly, fed by the relevant compile task's output classes
+ *
+ * [KotlinApiBuildTask] and [KotlinApiCompareTask] are BCV-internal, not public API, so this is
+ * pinned to the exact BCV version below. This is a stopgap until Android support lands in KGP's
+ * built-in ABI validation (tracked upstream, unscheduled, in KT-78025).
+ */
+class BinaryCompatValidationPlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+        val ext = project.extensions.create("binaryCompatValidationExtension", BinaryCompatValidationExtension::class.java)
+        ext.variant.convention("release")
+        ext.taskNamePrefix.convention(ext.variant)
+        ext.kotlinCompileTaskName.convention(ext.variant.map { "compile${it.replaceFirstChar(Char::uppercase)}Kotlin" })
+        ext.javaCompileTaskName.convention(ext.variant.map { "compile${it.replaceFirstChar(Char::uppercase)}JavaWithJavac" })
+        ext.apiFile.convention(project.layout.projectDirectory.file("api/${project.name}.api"))
+
+        // Defer until the compile tasks this reads from have been registered.
+        project.afterEvaluate {
+            val prefix = ext.taskNamePrefix.get()
+
+            // KotlinApiBuildTask runs inside an isolated classloader worker, which needs its own
+            // classpath - it doesn't inherit the plugin's. BCV's own POM only declares java-diff-utils;
+            // ASM (ClassNode) and kotlin-metadata-jvm (reading @Metadata for Kotlin visibility) are
+            // needed at runtime too but aren't declared, so add them explicitly.
+            val bcvRuntimeClasspath =
+                project.configurations.detachedConfiguration(
+                    project.dependencies.create("org.jetbrains.kotlinx:binary-compatibility-validator:0.18.1"),
+                    project.dependencies.create("org.jetbrains.kotlin:kotlin-metadata-jvm:2.1.0"),
+                    project.dependencies.create("org.ow2.asm:asm:9.7"),
+                    project.dependencies.create("org.ow2.asm:asm-tree:9.7")
+                )
+
+            val apiBuild =
+                project.tasks.register<KotlinApiBuildTask>("${prefix}ApiBuild") {
+                    inputClassesDirs.from(project.tasks.named(ext.kotlinCompileTaskName.get()).map { it.outputs.files })
+                    val javaTaskName = ext.javaCompileTaskName.get()
+                    if (javaTaskName.isNotBlank() && project.tasks.findByName(javaTaskName) != null) {
+                        inputClassesDirs.from(project.tasks.named(javaTaskName).map { it.outputs.files })
+                    }
+                    ignoredClasses.set(ext.ignoredClasses)
+                    runtimeClasspath.from(bcvRuntimeClasspath)
+                    outputApiFile.set(project.layout.buildDirectory.file("bcv/$prefix/${project.name}.api"))
+                }
+
+            val apiCheck =
+                project.tasks.register<KotlinApiCompareTask>("${prefix}ApiCheck") {
+                    projectApiFile.set(ext.apiFile)
+                    generatedApiFile.set(apiBuild.flatMap { it.outputApiFile })
+                }
+
+            project.tasks.register<ApiDumpTask>("${prefix}ApiDump") {
+                group = "verification"
+                description = "Updates the committed BCV API dump for the $prefix target."
+                generatedApiFile.set(apiBuild.flatMap { it.outputApiFile })
+                committedApiFile.set(ext.apiFile)
+            }
+
+            project.tasks.named<Task>(LifecycleBasePlugin.CHECK_TASK_NAME).configure { dependsOn(apiCheck) }
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/spotless.gradle.kts
+++ b/buildSrc/src/main/kotlin/spotless.gradle.kts
@@ -26,7 +26,7 @@ spotless {
         ktlint("1.8.0")
             .customRuleSets(
                 listOf(
-                    "io.nlopez.compose.rules:ktlint:0.5.3"
+                    "io.nlopez.compose.rules:ktlint:0.6.3"
                 )
             )
         licenseHeaderFile("${rootDir}/config/license", KotlinConstants.LICENSE_HEADER_DELIMITER)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,6 @@ authFoundation = "2.0.5"
 bouncycastle = "1.85"
 commonsIo = "2.22.0"
 commons-lang3 = "3.20.0"
-compatibilityValidator = "0.18.1"
 coreKtx = "1.19.0"
 coreLibraryDesugaring = "2.1.5"
 coroutines = "1.11.0"
@@ -37,7 +36,6 @@ json = "20260719"
 jsoup = "1.22.2"
 junit = "4.13.2"
 kotlin = "2.4.10"
-kotlinBinaryCompatibility = "0.18.1"
 kotlinSerialization = "1.11.0"
 kotlinxDatetime = "0.8.0"
 koverGradlePlugin = "0.9.9"
@@ -131,7 +129,6 @@ jjwt-impl = { module = "io.jsonwebtoken:jjwt-impl", version.ref = "jjwtApi" }
 json = { module = "org.json:json", version.ref = "json" }
 jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }
 junit = { module = "junit:junit", version.ref = "junit" }
-kotlin-binary-compatibility-plugin = { module = "org.jetbrains.kotlinx:binary-compatibility-validator", version.ref = "kotlinBinaryCompatibility" }
 kotlin-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinSerialization" }
 kotlin-serialization-okio = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json-okio", version.ref = "kotlinSerialization" }
@@ -234,7 +231,6 @@ google-services = { id = "com.google.gms.google-services", version.ref = "google
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "koverGradlePlugin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
-kotlinx-binary-compatibility-validator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "compatibilityValidator" }
 sonarqube = { id = "org.sonarqube", version.ref = "sonarqubeGradlePlugin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }

--- a/legacy-token-migration/build.gradle.kts
+++ b/legacy-token-migration/build.gradle.kts
@@ -6,7 +6,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
     id("com.android.library")
     alias(libs.plugins.dokka)
-    id("binary-compatibility-validator")
+    id("binary-compat-validation")
     id("spotless")
     id("com.vanniktech.maven.publish.base")
 }
@@ -51,7 +51,7 @@ androidComponents {
     }
 }
 
-apiValidation {
+binaryCompatValidationExtension {
     ignoredClasses.add("com.okta.legacytokenmigration.BuildConfig")
 }
 

--- a/native-authentication/api/native-authentication.api
+++ b/native-authentication/api/native-authentication.api
@@ -1,11 +1,3 @@
-public final class com/okta/nativeauthentication/BuildConfig {
-	public static final field BUILD_TYPE Ljava/lang/String;
-	public static final field DEBUG Z
-	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
-	public static final field SDK_VERSION Ljava/lang/String;
-	public fun <init> ()V
-}
-
 public final class com/okta/nativeauthentication/NativeAuthenticationClient {
 	public static final field Companion Lcom/okta/nativeauthentication/NativeAuthenticationClient$Companion;
 }

--- a/native-authentication/build.gradle.kts
+++ b/native-authentication/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
     alias(libs.plugins.android.library)
     kotlin("plugin.serialization") version libs.versions.kotlin.get()
-    id("binary-compatibility-validator")
+    id("binary-compat-validation")
     id("spotless")
 }
 
@@ -43,6 +43,10 @@ kotlin {
         jvmTarget = JvmTarget.fromTarget(JVM_TARGET)
         freeCompilerArgs.add("-opt-in=com.okta.authfoundation.InternalAuthFoundationApi")
     }
+}
+
+binaryCompatValidationExtension {
+    ignoredClasses.add("com.okta.nativeauthentication.BuildConfig")
 }
 
 dependencies {

--- a/oauth2/api/oauth2.api
+++ b/oauth2/api/oauth2.api
@@ -103,3 +103,168 @@ public final class com/okta/oauth2/TokenExchangeFlow {
 public final class com/okta/oauth2/TokenExchangeFlow$Companion {
 }
 
+public final class com/okta/oauth2/kmp/AndroidCompatExtensionsKt {
+	public static final fun AuthorizationCodeFlow (Lcom/okta/authfoundation/client/OAuth2Client;)Lcom/okta/oauth2/kmp/AuthorizationCodeFlow;
+	public static final fun DeviceAuthorizationFlow (Lcom/okta/authfoundation/client/OAuth2Client;)Lcom/okta/oauth2/kmp/DeviceAuthorizationFlow;
+	public static final fun RedirectEndSessionFlow (Lcom/okta/authfoundation/client/OAuth2Client;)Lcom/okta/oauth2/kmp/RedirectEndSessionFlow;
+	public static final fun ResourceOwnerFlow (Lcom/okta/authfoundation/client/OAuth2Client;)Lcom/okta/oauth2/kmp/ResourceOwnerFlow;
+	public static final fun SessionTokenFlow (Lcom/okta/authfoundation/client/OAuth2Client;)Lcom/okta/oauth2/kmp/SessionTokenFlow;
+	public static final fun TokenExchangeFlow (Lcom/okta/authfoundation/client/OAuth2Client;)Lcom/okta/oauth2/kmp/TokenExchangeFlow;
+	public static final fun resume (Lcom/okta/oauth2/kmp/AuthorizationCodeFlow;Landroid/net/Uri;Lcom/okta/oauth2/kmp/AuthorizationCodeFlowContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun resume (Lcom/okta/oauth2/kmp/RedirectEndSessionFlow;Landroid/net/Uri;Lcom/okta/oauth2/kmp/RedirectEndSessionFlowContext;)Ljava/lang/Object;
+}
+
+public abstract interface class com/okta/oauth2/kmp/AuthorizationCodeFlow {
+	public static final field Companion Lcom/okta/oauth2/kmp/AuthorizationCodeFlow$Companion;
+	public abstract fun resume-0E7RQCE (Ljava/lang/String;Lcom/okta/oauth2/kmp/AuthorizationCodeFlowContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun start-BWLJW6A (Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun start-BWLJW6A$default (Lcom/okta/oauth2/kmp/AuthorizationCodeFlow;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/okta/oauth2/kmp/AuthorizationCodeFlow$Companion {
+	public final fun invoke (Lcom/okta/authfoundation/client/kmp/OAuth2Client;)Lcom/okta/oauth2/kmp/AuthorizationCodeFlow;
+}
+
+public final class com/okta/oauth2/kmp/AuthorizationCodeFlow$DefaultImpls {
+	public static synthetic fun start-BWLJW6A$default (Lcom/okta/oauth2/kmp/AuthorizationCodeFlow;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/okta/oauth2/kmp/AuthorizationCodeFlow$MissingResultCodeException : java/lang/Exception {
+	public fun <init> ()V
+}
+
+public final class com/okta/oauth2/kmp/AuthorizationCodeFlow$RedirectSchemeMismatchException : java/lang/Exception {
+	public fun <init> ()V
+}
+
+public final class com/okta/oauth2/kmp/AuthorizationCodeFlow$ResumeException : java/lang/Exception {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun getErrorId ()Ljava/lang/String;
+}
+
+public final class com/okta/oauth2/kmp/AuthorizationCodeFlowContext {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;)Lcom/okta/oauth2/kmp/AuthorizationCodeFlowContext;
+	public static synthetic fun copy$default (Lcom/okta/oauth2/kmp/AuthorizationCodeFlowContext;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)Lcom/okta/oauth2/kmp/AuthorizationCodeFlowContext;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRedirectUrl ()Ljava/lang/String;
+	public final fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/okta/oauth2/kmp/BrowserRedirectHandler {
+	public abstract fun handleRedirect (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/okta/oauth2/kmp/DeviceAuthorizationFlow {
+	public static final field Companion Lcom/okta/oauth2/kmp/DeviceAuthorizationFlow$Companion;
+	public abstract fun resume-gIAlu-s (Lcom/okta/oauth2/kmp/DeviceAuthorizationFlowContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun start-gIAlu-s (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun start-gIAlu-s$default (Lcom/okta/oauth2/kmp/DeviceAuthorizationFlow;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/okta/oauth2/kmp/DeviceAuthorizationFlow$Companion {
+	public final fun invoke (Lcom/okta/authfoundation/client/kmp/OAuth2Client;)Lcom/okta/oauth2/kmp/DeviceAuthorizationFlow;
+}
+
+public final class com/okta/oauth2/kmp/DeviceAuthorizationFlow$DefaultImpls {
+	public static synthetic fun start-gIAlu-s$default (Lcom/okta/oauth2/kmp/DeviceAuthorizationFlow;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/okta/oauth2/kmp/DeviceAuthorizationFlow$TimeoutException : java/lang/Exception {
+	public fun <init> ()V
+}
+
+public final class com/okta/oauth2/kmp/DeviceAuthorizationFlowContext {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;I)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()I
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;I)Lcom/okta/oauth2/kmp/DeviceAuthorizationFlowContext;
+	public static synthetic fun copy$default (Lcom/okta/oauth2/kmp/DeviceAuthorizationFlowContext;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;IILjava/lang/Object;)Lcom/okta/oauth2/kmp/DeviceAuthorizationFlowContext;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getExpiresIn ()I
+	public final fun getUserCode ()Ljava/lang/String;
+	public final fun getVerificationUri ()Ljava/lang/String;
+	public final fun getVerificationUriComplete ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/okta/oauth2/kmp/RedirectEndSessionFlow {
+	public static final field Companion Lcom/okta/oauth2/kmp/RedirectEndSessionFlow$Companion;
+	public abstract fun resume-gIAlu-s (Ljava/lang/String;Lcom/okta/oauth2/kmp/RedirectEndSessionFlowContext;)Ljava/lang/Object;
+	public abstract fun start-BWLJW6A (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun start-BWLJW6A$default (Lcom/okta/oauth2/kmp/RedirectEndSessionFlow;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/okta/oauth2/kmp/RedirectEndSessionFlow$Companion {
+	public final fun invoke (Lcom/okta/authfoundation/client/kmp/OAuth2Client;)Lcom/okta/oauth2/kmp/RedirectEndSessionFlow;
+}
+
+public final class com/okta/oauth2/kmp/RedirectEndSessionFlow$DefaultImpls {
+	public static synthetic fun start-BWLJW6A$default (Lcom/okta/oauth2/kmp/RedirectEndSessionFlow;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/okta/oauth2/kmp/RedirectEndSessionFlow$ResumeException : java/lang/Exception {
+}
+
+public final class com/okta/oauth2/kmp/RedirectEndSessionFlowContext {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/okta/oauth2/kmp/RedirectEndSessionFlowContext;
+	public static synthetic fun copy$default (Lcom/okta/oauth2/kmp/RedirectEndSessionFlowContext;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/okta/oauth2/kmp/RedirectEndSessionFlowContext;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRedirectUrl ()Ljava/lang/String;
+	public final fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/okta/oauth2/kmp/ResourceOwnerFlow {
+	public static final field Companion Lcom/okta/oauth2/kmp/ResourceOwnerFlow$Companion;
+	public abstract fun start-BWLJW6A (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun start-BWLJW6A$default (Lcom/okta/oauth2/kmp/ResourceOwnerFlow;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/okta/oauth2/kmp/ResourceOwnerFlow$Companion {
+	public final fun invoke (Lcom/okta/authfoundation/client/kmp/OAuth2Client;)Lcom/okta/oauth2/kmp/ResourceOwnerFlow;
+}
+
+public final class com/okta/oauth2/kmp/ResourceOwnerFlow$DefaultImpls {
+	public static synthetic fun start-BWLJW6A$default (Lcom/okta/oauth2/kmp/ResourceOwnerFlow;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class com/okta/oauth2/kmp/SessionTokenFlow {
+	public static final field Companion Lcom/okta/oauth2/kmp/SessionTokenFlow$Companion;
+	public abstract fun start-yxL6bBk (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun start-yxL6bBk$default (Lcom/okta/oauth2/kmp/SessionTokenFlow;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/okta/oauth2/kmp/SessionTokenFlow$Companion {
+	public final fun invoke (Lcom/okta/authfoundation/client/kmp/OAuth2Client;)Lcom/okta/oauth2/kmp/SessionTokenFlow;
+}
+
+public final class com/okta/oauth2/kmp/SessionTokenFlow$DefaultImpls {
+	public static synthetic fun start-yxL6bBk$default (Lcom/okta/oauth2/kmp/SessionTokenFlow;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class com/okta/oauth2/kmp/TokenExchangeFlow {
+	public static final field Companion Lcom/okta/oauth2/kmp/TokenExchangeFlow$Companion;
+	public abstract fun start-yxL6bBk (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun start-yxL6bBk$default (Lcom/okta/oauth2/kmp/TokenExchangeFlow;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/okta/oauth2/kmp/TokenExchangeFlow$Companion {
+	public final fun invoke (Lcom/okta/authfoundation/client/kmp/OAuth2Client;)Lcom/okta/oauth2/kmp/TokenExchangeFlow;
+}
+
+public final class com/okta/oauth2/kmp/TokenExchangeFlow$DefaultImpls {
+	public static synthetic fun start-yxL6bBk$default (Lcom/okta/oauth2/kmp/TokenExchangeFlow;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+

--- a/oauth2/build.gradle.kts
+++ b/oauth2/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
@@ -7,7 +8,7 @@ plugins {
     kotlin("plugin.serialization") version libs.versions.kotlin.get()
     id("com.vanniktech.maven.publish.base")
     id("spotless")
-    id("binary-compatibility-validator")
+    id("binary-compat-validation")
 }
 
 // KMP androidLibrary does not generate BuildConfigs so we generate a BuildInfo.kt file instead.
@@ -33,7 +34,7 @@ val generateBuildInfoTask =
     }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.okta.oauth2"
         compileSdk = COMPILE_SDK
         minSdk = MIN_SDK
@@ -144,12 +145,27 @@ kotlin {
             }
         }
     }
+
+    // Only validates the jvm target; KGP's ABI validation filters for KotlinAndroidTarget, but the androidLibrary
+    // target here is a KotlinMultiplatformAndroidLibraryTargetImpl (AGP's KMP android plugin), so it's silently skipped.
+    // The android target's own ABI is covered separately below, via binary-compat-validation.
+    @OptIn(ExperimentalAbiValidation::class)
+    abiValidation {
+        filters {
+            exclude {
+                byNames.add("com.okta.oauth2.BuildInfo")
+            }
+        }
+    }
+}
+
+binaryCompatValidationExtension {
+    taskNamePrefix.set("android")
+    kotlinCompileTaskName.set("compileAndroidMain")
+    javaCompileTaskName.set("")
+    ignoredClasses.add("com.okta.oauth2.BuildInfo")
 }
 
 dependencies {
     coreLibraryDesugaring(libs.core.library.desugaring)
-}
-
-apiValidation {
-    ignoredClasses.add("com.okta.oauth2.BuildInfo")
 }

--- a/okta-direct-auth-shared/build.gradle.kts
+++ b/okta-direct-auth-shared/build.gradle.kts
@@ -70,7 +70,7 @@ val generateAppConfig =
     }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "com.okta.directauth.app"
         compileSdk = COMPILE_SDK
         minSdk = 28

--- a/okta-direct-auth/api/jvm/okta-direct-auth.api
+++ b/okta-direct-auth/api/jvm/okta-direct-auth.api
@@ -1,0 +1,433 @@
+public final class com/okta/directauth/DirectAuthenticationFlowBuilder {
+	public static final field Companion Lcom/okta/directauth/DirectAuthenticationFlowBuilder$Companion;
+	public static final fun create-0E7RQCE (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Ljava/lang/Object;
+	public static final fun create-BWLJW6A (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public final fun getAcrValues ()Ljava/util/List;
+	public final fun getAdditionalParameter ()Ljava/util/Map;
+	public final fun getApiExecutor ()Lcom/okta/authfoundation/api/http/ApiExecutor;
+	public final fun getAuthorizationServerId ()Ljava/lang/String;
+	public final fun getClientSecret ()Ljava/lang/String;
+	public final fun getClock ()Lcom/okta/authfoundation/client/OidcClock;
+	public final fun getDirectAuthenticationIntent ()Lcom/okta/directauth/model/DirectAuthenticationIntent;
+	public final fun getLogger ()Lcom/okta/authfoundation/api/log/AuthFoundationLogger;
+	public final fun getSupportedGrantType ()Ljava/util/List;
+	public final fun setAcrValues (Ljava/util/List;)V
+	public final fun setAdditionalParameter (Ljava/util/Map;)V
+	public final fun setApiExecutor (Lcom/okta/authfoundation/api/http/ApiExecutor;)V
+	public final fun setAuthorizationServerId (Ljava/lang/String;)V
+	public final fun setClientSecret (Ljava/lang/String;)V
+	public final fun setClock (Lcom/okta/authfoundation/client/OidcClock;)V
+	public final fun setDirectAuthenticationIntent (Lcom/okta/directauth/model/DirectAuthenticationIntent;)V
+	public final fun setLogger (Lcom/okta/authfoundation/api/log/AuthFoundationLogger;)V
+	public final fun setSupportedGrantType (Ljava/util/List;)V
+}
+
+public final class com/okta/directauth/DirectAuthenticationFlowBuilder$Companion {
+	public final fun create-0E7RQCE (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Ljava/lang/Object;
+	public final fun create-BWLJW6A (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static synthetic fun create-BWLJW6A$default (Lcom/okta/directauth/DirectAuthenticationFlowBuilder$Companion;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class com/okta/directauth/api/DirectAuthenticationFlow {
+	public abstract fun getAuthenticationState ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun reset ()Lcom/okta/directauth/model/DirectAuthenticationState;
+	public abstract fun start (Ljava/lang/String;Lcom/okta/directauth/model/PrimaryFactor;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/okta/directauth/api/WebAuthnCeremonyHandler {
+	public abstract fun performAssertion-gIAlu-s (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/okta/directauth/http/DirectAuthRequest : com/okta/authfoundation/api/http/ApiFormRequest {
+	public fun headers ()Ljava/util/Map;
+}
+
+public final class com/okta/directauth/http/DirectAuthRequest$DefaultImpls {
+	public static fun headers (Lcom/okta/directauth/http/DirectAuthRequest;)Ljava/util/Map;
+	public static fun query (Lcom/okta/directauth/http/DirectAuthRequest;)Ljava/util/Map;
+}
+
+public abstract interface class com/okta/directauth/http/DirectAuthStartRequest : com/okta/directauth/http/DirectAuthRequest {
+}
+
+public final class com/okta/directauth/http/DirectAuthStartRequest$DefaultImpls {
+	public static fun headers (Lcom/okta/directauth/http/DirectAuthStartRequest;)Ljava/util/Map;
+	public static fun query (Lcom/okta/directauth/http/DirectAuthStartRequest;)Ljava/util/Map;
+}
+
+public abstract class com/okta/directauth/http/DirectAuthTokenRequest : com/okta/directauth/http/DirectAuthStartRequest {
+	public synthetic fun <init> (Lcom/okta/directauth/model/DirectAuthenticationContext;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun contentType ()Ljava/lang/String;
+	public fun headers ()Ljava/util/Map;
+	public fun method ()Lcom/okta/authfoundation/api/http/ApiRequestMethod;
+	public fun query ()Ljava/util/Map;
+	public fun url ()Ljava/lang/String;
+}
+
+public final class com/okta/directauth/http/DirectAuthTokenRequest$MfaOtp : com/okta/directauth/http/DirectAuthTokenRequest {
+	public fun formParameters ()Ljava/util/Map;
+}
+
+public final class com/okta/directauth/http/DirectAuthTokenRequest$Oob : com/okta/directauth/http/DirectAuthTokenRequest {
+	public fun formParameters ()Ljava/util/Map;
+}
+
+public final class com/okta/directauth/http/DirectAuthTokenRequest$OobMfa : com/okta/directauth/http/DirectAuthTokenRequest {
+	public fun formParameters ()Ljava/util/Map;
+}
+
+public final class com/okta/directauth/http/DirectAuthTokenRequest$Otp : com/okta/directauth/http/DirectAuthTokenRequest {
+	public fun formParameters ()Ljava/util/Map;
+}
+
+public final class com/okta/directauth/http/DirectAuthTokenRequest$Password : com/okta/directauth/http/DirectAuthTokenRequest {
+	public fun formParameters ()Ljava/util/Map;
+}
+
+public final class com/okta/directauth/http/DirectAuthTokenRequest$WebAuthn : com/okta/directauth/http/DirectAuthTokenRequest {
+	public fun formParameters ()Ljava/util/Map;
+}
+
+public final class com/okta/directauth/http/DirectAuthTokenRequest$WebAuthnMfa : com/okta/directauth/http/DirectAuthTokenRequest {
+	public fun formParameters ()Ljava/util/Map;
+}
+
+public final class com/okta/directauth/http/InternalErrorCodeKt {
+	public static final field EXCEPTION Ljava/lang/String;
+	public static final field INVALID_RESPONSE Ljava/lang/String;
+	public static final field UNEXPECTED_HTTP_STATUS Ljava/lang/String;
+	public static final field UNSUPPORTED_CONTENT_TYPE Ljava/lang/String;
+}
+
+public abstract interface class com/okta/directauth/http/model/ApiErrorResponse {
+	public static final field Companion Lcom/okta/directauth/http/model/ApiErrorResponse$Companion;
+}
+
+public final class com/okta/directauth/http/model/ApiErrorResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/okta/directauth/http/model/AuthenticatorEnrollment {
+	public static final field Companion Lcom/okta/directauth/http/model/AuthenticatorEnrollment$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lcom/okta/directauth/http/model/AuthenticatorEnrollment;
+	public static synthetic fun copy$default (Lcom/okta/directauth/http/model/AuthenticatorEnrollment;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lcom/okta/directauth/http/model/AuthenticatorEnrollment;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCredentialId ()Ljava/lang/String;
+	public final fun getDisplayName ()Ljava/lang/String;
+	public final fun getProfile ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/okta/directauth/http/model/AuthenticatorEnrollment$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/okta/directauth/http/model/AuthenticatorEnrollment$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/okta/directauth/http/model/AuthenticatorEnrollment;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/okta/directauth/http/model/AuthenticatorEnrollment;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/okta/directauth/http/model/AuthenticatorEnrollment$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/okta/directauth/jvm/DirectAuthResult {
+	public static final field Companion Lcom/okta/directauth/jvm/DirectAuthResult$Companion;
+	public final fun exceptionOrNull ()Ljava/lang/Throwable;
+	public static final fun failure (Ljava/lang/Throwable;)Lcom/okta/directauth/jvm/DirectAuthResult;
+	public final fun getOrNull ()Ljava/lang/Object;
+	public final fun getOrThrow ()Ljava/lang/Object;
+	public final fun isFailure ()Z
+	public final fun isSuccess ()Z
+	public static final fun success (Ljava/lang/Object;)Lcom/okta/directauth/jvm/DirectAuthResult;
+}
+
+public final class com/okta/directauth/jvm/DirectAuthResult$Companion {
+	public final fun failure (Ljava/lang/Throwable;)Lcom/okta/directauth/jvm/DirectAuthResult;
+	public final fun success (Ljava/lang/Object;)Lcom/okta/directauth/jvm/DirectAuthResult;
+}
+
+public final class com/okta/directauth/jvm/DirectAuthenticationFlow : java/io/Closeable {
+	public final fun addStateListener (Ljava/util/function/Consumer;)Ljava/io/Closeable;
+	public fun close ()V
+	public final fun getAuthenticationState ()Lcom/okta/directauth/jvm/DirectAuthenticationState;
+	public final fun removeStateListener (Ljava/util/function/Consumer;)V
+	public final fun reset ()Lcom/okta/directauth/jvm/DirectAuthenticationState;
+	public final fun startAsync (Ljava/lang/String;Lcom/okta/directauth/model/PrimaryFactor;)Ljava/util/concurrent/CompletableFuture;
+}
+
+public final class com/okta/directauth/jvm/DirectAuthenticationFlowBuilder {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public final fun build ()Lcom/okta/directauth/jvm/DirectAuthResult;
+	public final fun setAcrValues (Ljava/util/List;)Lcom/okta/directauth/jvm/DirectAuthenticationFlowBuilder;
+	public final fun setAdditionalParameters (Ljava/util/Map;)Lcom/okta/directauth/jvm/DirectAuthenticationFlowBuilder;
+	public final fun setAuthorizationServerId (Ljava/lang/String;)Lcom/okta/directauth/jvm/DirectAuthenticationFlowBuilder;
+	public final fun setClientSecret (Ljava/lang/String;)Lcom/okta/directauth/jvm/DirectAuthenticationFlowBuilder;
+	public final fun setClock (Lcom/okta/authfoundation/client/OidcClock;)Lcom/okta/directauth/jvm/DirectAuthenticationFlowBuilder;
+	public final fun setIntent (Lcom/okta/directauth/model/DirectAuthenticationIntent;)Lcom/okta/directauth/jvm/DirectAuthenticationFlowBuilder;
+	public final fun setSupportedGrantTypes (Ljava/util/List;)Lcom/okta/directauth/jvm/DirectAuthenticationFlowBuilder;
+}
+
+public abstract class com/okta/directauth/jvm/DirectAuthenticationState {
+	public synthetic fun <init> (Lcom/okta/directauth/model/DirectAuthenticationState;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getState ()Lcom/okta/directauth/model/DirectAuthenticationState;
+}
+
+public final class com/okta/directauth/jvm/DirectAuthenticationState$Authenticated : com/okta/directauth/jvm/DirectAuthenticationState {
+	public final fun getToken ()Lcom/okta/authfoundation/client/TokenInfo;
+}
+
+public final class com/okta/directauth/jvm/DirectAuthenticationState$AuthorizationPending : com/okta/directauth/jvm/DirectAuthenticationState {
+	public final fun getTimestamp ()J
+}
+
+public final class com/okta/directauth/jvm/DirectAuthenticationState$Canceled : com/okta/directauth/jvm/DirectAuthenticationState {
+}
+
+public abstract class com/okta/directauth/jvm/DirectAuthenticationState$Error : com/okta/directauth/jvm/DirectAuthenticationState {
+	public synthetic fun <init> (Lcom/okta/directauth/model/DirectAuthenticationError;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public abstract class com/okta/directauth/jvm/DirectAuthenticationState$Error$HttpError : com/okta/directauth/jvm/DirectAuthenticationState$Error {
+	public synthetic fun <init> (Lcom/okta/directauth/model/DirectAuthenticationError$HttpError;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getHttpStatusCode ()Lio/ktor/http/HttpStatusCode;
+}
+
+public final class com/okta/directauth/jvm/DirectAuthenticationState$Error$HttpError$ApiError : com/okta/directauth/jvm/DirectAuthenticationState$Error$HttpError {
+	public final fun getErrorCauses ()Ljava/util/List;
+	public final fun getErrorCode ()Ljava/lang/String;
+	public final fun getErrorId ()Ljava/lang/String;
+	public final fun getErrorLink ()Ljava/lang/String;
+	public final fun getErrorSummary ()Ljava/lang/String;
+}
+
+public final class com/okta/directauth/jvm/DirectAuthenticationState$Error$HttpError$Oauth2Error : com/okta/directauth/jvm/DirectAuthenticationState$Error$HttpError {
+	public final fun getError ()Ljava/lang/String;
+	public final fun getErrorDescription ()Ljava/lang/String;
+}
+
+public final class com/okta/directauth/jvm/DirectAuthenticationState$Error$InternalError : com/okta/directauth/jvm/DirectAuthenticationState$Error {
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getErrorCode ()Ljava/lang/String;
+	public final fun getThrowable ()Ljava/lang/Throwable;
+}
+
+public final class com/okta/directauth/jvm/DirectAuthenticationState$Idle : com/okta/directauth/jvm/DirectAuthenticationState {
+}
+
+public final class com/okta/directauth/jvm/MfaRequired : com/okta/directauth/jvm/DirectAuthenticationState {
+	public fun <init> (Lcom/okta/directauth/model/DirectAuthenticationState$MfaRequired;)V
+	public final fun challengeAsync (Lcom/okta/directauth/model/SecondaryFactor;)Ljava/util/concurrent/CompletableFuture;
+	public final fun challengeAsync (Lcom/okta/directauth/model/SecondaryFactor;Ljava/util/List;)Ljava/util/concurrent/CompletableFuture;
+	public final fun resumeAsync (Lcom/okta/directauth/model/SecondaryFactor;)Ljava/util/concurrent/CompletableFuture;
+	public final fun resumeAsync (Lcom/okta/directauth/model/SecondaryFactor;Ljava/util/List;)Ljava/util/concurrent/CompletableFuture;
+}
+
+public final class com/okta/directauth/jvm/OobPendingContinuation : com/okta/directauth/jvm/DirectAuthenticationState {
+	public fun <init> (Lcom/okta/directauth/model/DirectAuthContinuation$OobPending;)V
+	public final fun getExpirationInSeconds ()I
+	public final fun proceedAsync ()Ljava/util/concurrent/CompletableFuture;
+}
+
+public final class com/okta/directauth/jvm/PromptContinuation : com/okta/directauth/jvm/DirectAuthenticationState {
+	public fun <init> (Lcom/okta/directauth/model/DirectAuthContinuation$Prompt;)V
+	public final fun getExpirationInSeconds ()I
+	public final fun proceedAsync (Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
+}
+
+public final class com/okta/directauth/jvm/TransferContinuation : com/okta/directauth/jvm/DirectAuthenticationState {
+	public fun <init> (Lcom/okta/directauth/model/DirectAuthContinuation$Transfer;)V
+	public final fun getBindingCode ()Ljava/lang/String;
+	public final fun getExpirationInSeconds ()I
+	public final fun proceedAsync ()Ljava/util/concurrent/CompletableFuture;
+}
+
+public final class com/okta/directauth/jvm/WebAuthnContinuation : com/okta/directauth/jvm/DirectAuthenticationState {
+	public fun <init> (Lcom/okta/directauth/model/DirectAuthContinuation$WebAuthn;)V
+	public final fun challengeData-d1pmJ48 ()Ljava/lang/Object;
+	public final fun getAuthenticatorEnrollment ()Ljava/util/List;
+	public final fun proceedAsync (Lcom/okta/directauth/api/WebAuthnCeremonyHandler;)Ljava/util/concurrent/CompletableFuture;
+	public final fun proceedAsync (Lcom/okta/directauth/model/WebAuthnAssertionResponse;)Ljava/util/concurrent/CompletableFuture;
+}
+
+public abstract class com/okta/directauth/model/DirectAuthContinuation : com/okta/directauth/model/DirectAuthenticationState {
+	public synthetic fun <init> (Lcom/okta/directauth/model/DirectAuthenticationContext;Lcom/okta/directauth/model/MfaContext;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class com/okta/directauth/model/DirectAuthContinuation$OobPending : com/okta/directauth/model/DirectAuthContinuation {
+	public final fun getExpirationInSeconds ()I
+	public final fun proceed (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/okta/directauth/model/DirectAuthContinuation$Prompt : com/okta/directauth/model/DirectAuthContinuation {
+	public final fun getExpirationInSeconds ()I
+	public final fun proceed (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/okta/directauth/model/DirectAuthContinuation$Transfer : com/okta/directauth/model/DirectAuthContinuation {
+	public final fun getBindingCode ()Ljava/lang/String;
+	public final fun getExpirationInSeconds ()I
+	public final fun proceed (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/okta/directauth/model/DirectAuthContinuation$WebAuthn : com/okta/directauth/model/DirectAuthContinuation {
+	public final fun challengeData-d1pmJ48 ()Ljava/lang/Object;
+	public final fun getAuthenticatorEnrollment ()Ljava/util/List;
+	public final fun proceed (Lcom/okta/directauth/api/WebAuthnCeremonyHandler;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun proceed (Lcom/okta/directauth/model/WebAuthnAssertionResponse;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract class com/okta/directauth/model/DirectAuthenticationError : com/okta/directauth/model/DirectAuthenticationState {
+}
+
+public abstract class com/okta/directauth/model/DirectAuthenticationError$HttpError : com/okta/directauth/model/DirectAuthenticationError {
+	public synthetic fun <init> (Lio/ktor/http/HttpStatusCode;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getHttpStatusCode ()Lio/ktor/http/HttpStatusCode;
+}
+
+public final class com/okta/directauth/model/DirectAuthenticationError$HttpError$ApiError : com/okta/directauth/model/DirectAuthenticationError$HttpError {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lio/ktor/http/HttpStatusCode;)V
+	public final fun getErrorCauses ()Ljava/util/List;
+	public final fun getErrorCode ()Ljava/lang/String;
+	public final fun getErrorId ()Ljava/lang/String;
+	public final fun getErrorLink ()Ljava/lang/String;
+	public final fun getErrorSummary ()Ljava/lang/String;
+}
+
+public final class com/okta/directauth/model/DirectAuthenticationError$HttpError$Oauth2Error : com/okta/directauth/model/DirectAuthenticationError$HttpError {
+	public fun <init> (Ljava/lang/String;Lio/ktor/http/HttpStatusCode;Ljava/lang/String;)V
+	public final fun getError ()Ljava/lang/String;
+	public final fun getErrorDescription ()Ljava/lang/String;
+}
+
+public final class com/okta/directauth/model/DirectAuthenticationError$InternalError : com/okta/directauth/model/DirectAuthenticationError {
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getErrorCode ()Ljava/lang/String;
+	public final fun getThrowable ()Ljava/lang/Throwable;
+}
+
+public final class com/okta/directauth/model/DirectAuthenticationIntent : java/lang/Enum {
+	public static final field RECOVERY Lcom/okta/directauth/model/DirectAuthenticationIntent;
+	public static final field SIGN_IN Lcom/okta/directauth/model/DirectAuthenticationIntent;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/okta/directauth/model/DirectAuthenticationIntent;
+	public static fun values ()[Lcom/okta/directauth/model/DirectAuthenticationIntent;
+}
+
+public abstract interface class com/okta/directauth/model/DirectAuthenticationState {
+}
+
+public final class com/okta/directauth/model/DirectAuthenticationState$Authenticated : com/okta/directauth/model/DirectAuthenticationState {
+	public final fun getToken ()Lcom/okta/authfoundation/client/TokenInfo;
+}
+
+public final class com/okta/directauth/model/DirectAuthenticationState$AuthorizationPending : com/okta/directauth/model/DirectAuthenticationState {
+	public final fun getTimestamp ()J
+}
+
+public final class com/okta/directauth/model/DirectAuthenticationState$Canceled : com/okta/directauth/model/DirectAuthenticationState {
+	public static final field INSTANCE Lcom/okta/directauth/model/DirectAuthenticationState$Canceled;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/okta/directauth/model/DirectAuthenticationState$Idle : com/okta/directauth/model/DirectAuthenticationState {
+	public static final field INSTANCE Lcom/okta/directauth/model/DirectAuthenticationState$Idle;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/okta/directauth/model/DirectAuthenticationState$MfaRequired : com/okta/directauth/model/DirectAuthenticationState {
+	public final fun challenge (Lcom/okta/directauth/model/SecondaryFactor;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun challenge (Lcom/okta/directauth/model/SecondaryFactor;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun challenge$default (Lcom/okta/directauth/model/DirectAuthenticationState$MfaRequired;Lcom/okta/directauth/model/SecondaryFactor;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun resume (Lcom/okta/directauth/model/SecondaryFactor;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun resume (Lcom/okta/directauth/model/SecondaryFactor;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun resume$default (Lcom/okta/directauth/model/DirectAuthenticationState$MfaRequired;Lcom/okta/directauth/model/SecondaryFactor;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/okta/directauth/model/OobChannel : java/lang/Enum {
+	public static final field PUSH Lcom/okta/directauth/model/OobChannel;
+	public static final field SMS Lcom/okta/directauth/model/OobChannel;
+	public static final field VOICE Lcom/okta/directauth/model/OobChannel;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/okta/directauth/model/OobChannel;
+	public static fun values ()[Lcom/okta/directauth/model/OobChannel;
+}
+
+public abstract interface class com/okta/directauth/model/PrimaryFactor {
+}
+
+public final class com/okta/directauth/model/PrimaryFactor$Oob : com/okta/directauth/model/SecondaryFactor {
+	public fun <init> (Lcom/okta/directauth/model/OobChannel;)V
+	public final fun component1 ()Lcom/okta/directauth/model/OobChannel;
+	public final fun copy (Lcom/okta/directauth/model/OobChannel;)Lcom/okta/directauth/model/PrimaryFactor$Oob;
+	public static synthetic fun copy$default (Lcom/okta/directauth/model/PrimaryFactor$Oob;Lcom/okta/directauth/model/OobChannel;ILjava/lang/Object;)Lcom/okta/directauth/model/PrimaryFactor$Oob;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChannel ()Lcom/okta/directauth/model/OobChannel;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/okta/directauth/model/PrimaryFactor$Otp : com/okta/directauth/model/SecondaryFactor {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/okta/directauth/model/PrimaryFactor$Otp;
+	public static synthetic fun copy$default (Lcom/okta/directauth/model/PrimaryFactor$Otp;Ljava/lang/String;ILjava/lang/Object;)Lcom/okta/directauth/model/PrimaryFactor$Otp;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPassCode ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/okta/directauth/model/PrimaryFactor$Password : com/okta/directauth/model/PrimaryFactor {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/okta/directauth/model/PrimaryFactor$Password;
+	public static synthetic fun copy$default (Lcom/okta/directauth/model/PrimaryFactor$Password;Ljava/lang/String;ILjava/lang/Object;)Lcom/okta/directauth/model/PrimaryFactor$Password;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPassword ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/okta/directauth/model/PrimaryFactor$WebAuthn : com/okta/directauth/model/SecondaryFactor {
+	public static final field INSTANCE Lcom/okta/directauth/model/PrimaryFactor$WebAuthn;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/okta/directauth/model/SecondaryFactor : com/okta/directauth/model/PrimaryFactor {
+}
+
+public final class com/okta/directauth/model/WebAuthnAssertionResponse {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/okta/directauth/model/WebAuthnAssertionResponse;
+	public static synthetic fun copy$default (Lcom/okta/directauth/model/WebAuthnAssertionResponse;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/okta/directauth/model/WebAuthnAssertionResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAuthenticatorData ()Ljava/lang/String;
+	public final fun getClientDataJSON ()Ljava/lang/String;
+	public final fun getSignature ()Ljava/lang/String;
+	public final fun getUserHandle ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+

--- a/okta-direct-auth/api/okta-direct-auth.api
+++ b/okta-direct-auth/api/okta-direct-auth.api
@@ -1,0 +1,320 @@
+public final class com/okta/directauth/DirectAuthenticationFlowBuilder {
+	public static final field Companion Lcom/okta/directauth/DirectAuthenticationFlowBuilder$Companion;
+	public static final fun create-0E7RQCE (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Ljava/lang/Object;
+	public static final fun create-BWLJW6A (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public final fun getAcrValues ()Ljava/util/List;
+	public final fun getAdditionalParameter ()Ljava/util/Map;
+	public final fun getApiExecutor ()Lcom/okta/authfoundation/api/http/ApiExecutor;
+	public final fun getAuthorizationServerId ()Ljava/lang/String;
+	public final fun getClientSecret ()Ljava/lang/String;
+	public final fun getClock ()Lcom/okta/authfoundation/client/OidcClock;
+	public final fun getDirectAuthenticationIntent ()Lcom/okta/directauth/model/DirectAuthenticationIntent;
+	public final fun getLogger ()Lcom/okta/authfoundation/api/log/AuthFoundationLogger;
+	public final fun getSupportedGrantType ()Ljava/util/List;
+	public final fun setAcrValues (Ljava/util/List;)V
+	public final fun setAdditionalParameter (Ljava/util/Map;)V
+	public final fun setApiExecutor (Lcom/okta/authfoundation/api/http/ApiExecutor;)V
+	public final fun setAuthorizationServerId (Ljava/lang/String;)V
+	public final fun setClientSecret (Ljava/lang/String;)V
+	public final fun setClock (Lcom/okta/authfoundation/client/OidcClock;)V
+	public final fun setDirectAuthenticationIntent (Lcom/okta/directauth/model/DirectAuthenticationIntent;)V
+	public final fun setLogger (Lcom/okta/authfoundation/api/log/AuthFoundationLogger;)V
+	public final fun setSupportedGrantType (Ljava/util/List;)V
+}
+
+public final class com/okta/directauth/DirectAuthenticationFlowBuilder$Companion {
+	public final fun create-0E7RQCE (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Ljava/lang/Object;
+	public final fun create-BWLJW6A (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static synthetic fun create-BWLJW6A$default (Lcom/okta/directauth/DirectAuthenticationFlowBuilder$Companion;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class com/okta/directauth/api/DirectAuthenticationFlow {
+	public abstract fun getAuthenticationState ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun reset ()Lcom/okta/directauth/model/DirectAuthenticationState;
+	public abstract fun start (Ljava/lang/String;Lcom/okta/directauth/model/PrimaryFactor;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/okta/directauth/api/WebAuthnCeremonyHandler {
+	public abstract fun performAssertion-gIAlu-s (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/okta/directauth/http/DirectAuthRequest : com/okta/authfoundation/api/http/ApiFormRequest {
+	public fun headers ()Ljava/util/Map;
+}
+
+public final class com/okta/directauth/http/DirectAuthRequest$DefaultImpls {
+	public static fun headers (Lcom/okta/directauth/http/DirectAuthRequest;)Ljava/util/Map;
+	public static fun query (Lcom/okta/directauth/http/DirectAuthRequest;)Ljava/util/Map;
+}
+
+public abstract interface class com/okta/directauth/http/DirectAuthStartRequest : com/okta/directauth/http/DirectAuthRequest {
+}
+
+public final class com/okta/directauth/http/DirectAuthStartRequest$DefaultImpls {
+	public static fun headers (Lcom/okta/directauth/http/DirectAuthStartRequest;)Ljava/util/Map;
+	public static fun query (Lcom/okta/directauth/http/DirectAuthStartRequest;)Ljava/util/Map;
+}
+
+public abstract class com/okta/directauth/http/DirectAuthTokenRequest : com/okta/directauth/http/DirectAuthStartRequest {
+	public synthetic fun <init> (Lcom/okta/directauth/model/DirectAuthenticationContext;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun contentType ()Ljava/lang/String;
+	public fun headers ()Ljava/util/Map;
+	public fun method ()Lcom/okta/authfoundation/api/http/ApiRequestMethod;
+	public fun query ()Ljava/util/Map;
+	public fun url ()Ljava/lang/String;
+}
+
+public final class com/okta/directauth/http/DirectAuthTokenRequest$MfaOtp : com/okta/directauth/http/DirectAuthTokenRequest {
+	public fun formParameters ()Ljava/util/Map;
+}
+
+public final class com/okta/directauth/http/DirectAuthTokenRequest$Oob : com/okta/directauth/http/DirectAuthTokenRequest {
+	public fun formParameters ()Ljava/util/Map;
+}
+
+public final class com/okta/directauth/http/DirectAuthTokenRequest$OobMfa : com/okta/directauth/http/DirectAuthTokenRequest {
+	public fun formParameters ()Ljava/util/Map;
+}
+
+public final class com/okta/directauth/http/DirectAuthTokenRequest$Otp : com/okta/directauth/http/DirectAuthTokenRequest {
+	public fun formParameters ()Ljava/util/Map;
+}
+
+public final class com/okta/directauth/http/DirectAuthTokenRequest$Password : com/okta/directauth/http/DirectAuthTokenRequest {
+	public fun formParameters ()Ljava/util/Map;
+}
+
+public final class com/okta/directauth/http/DirectAuthTokenRequest$WebAuthn : com/okta/directauth/http/DirectAuthTokenRequest {
+	public fun formParameters ()Ljava/util/Map;
+}
+
+public final class com/okta/directauth/http/DirectAuthTokenRequest$WebAuthnMfa : com/okta/directauth/http/DirectAuthTokenRequest {
+	public fun formParameters ()Ljava/util/Map;
+}
+
+public final class com/okta/directauth/http/InternalErrorCodeKt {
+	public static final field EXCEPTION Ljava/lang/String;
+	public static final field INVALID_RESPONSE Ljava/lang/String;
+	public static final field UNEXPECTED_HTTP_STATUS Ljava/lang/String;
+	public static final field UNSUPPORTED_CONTENT_TYPE Ljava/lang/String;
+}
+
+public abstract interface class com/okta/directauth/http/model/ApiErrorResponse {
+	public static final field Companion Lcom/okta/directauth/http/model/ApiErrorResponse$Companion;
+}
+
+public final class com/okta/directauth/http/model/ApiErrorResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/okta/directauth/http/model/AuthenticatorEnrollment {
+	public static final field Companion Lcom/okta/directauth/http/model/AuthenticatorEnrollment$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lcom/okta/directauth/http/model/AuthenticatorEnrollment;
+	public static synthetic fun copy$default (Lcom/okta/directauth/http/model/AuthenticatorEnrollment;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lcom/okta/directauth/http/model/AuthenticatorEnrollment;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCredentialId ()Ljava/lang/String;
+	public final fun getDisplayName ()Ljava/lang/String;
+	public final fun getProfile ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/okta/directauth/http/model/AuthenticatorEnrollment$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/okta/directauth/http/model/AuthenticatorEnrollment$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/okta/directauth/http/model/AuthenticatorEnrollment;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/okta/directauth/http/model/AuthenticatorEnrollment;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/okta/directauth/http/model/AuthenticatorEnrollment$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class com/okta/directauth/model/DirectAuthContinuation : com/okta/directauth/model/DirectAuthenticationState {
+	public synthetic fun <init> (Lcom/okta/directauth/model/DirectAuthenticationContext;Lcom/okta/directauth/model/MfaContext;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lcom/okta/directauth/model/DirectAuthenticationContext;Lcom/okta/directauth/model/MfaContext;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class com/okta/directauth/model/DirectAuthContinuation$OobPending : com/okta/directauth/model/DirectAuthContinuation {
+	public final fun getExpirationInSeconds ()I
+	public final fun proceed (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/okta/directauth/model/DirectAuthContinuation$Prompt : com/okta/directauth/model/DirectAuthContinuation {
+	public final fun getExpirationInSeconds ()I
+	public final fun proceed (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/okta/directauth/model/DirectAuthContinuation$Transfer : com/okta/directauth/model/DirectAuthContinuation {
+	public final fun getBindingCode ()Ljava/lang/String;
+	public final fun getExpirationInSeconds ()I
+	public final fun proceed (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/okta/directauth/model/DirectAuthContinuation$WebAuthn : com/okta/directauth/model/DirectAuthContinuation {
+	public final fun challengeData-d1pmJ48 ()Ljava/lang/Object;
+	public final fun getAuthenticatorEnrollment ()Ljava/util/List;
+	public final fun proceed (Lcom/okta/directauth/api/WebAuthnCeremonyHandler;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun proceed (Lcom/okta/directauth/model/WebAuthnAssertionResponse;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract class com/okta/directauth/model/DirectAuthenticationError : com/okta/directauth/model/DirectAuthenticationState {
+}
+
+public abstract class com/okta/directauth/model/DirectAuthenticationError$HttpError : com/okta/directauth/model/DirectAuthenticationError {
+	public synthetic fun <init> (Lio/ktor/http/HttpStatusCode;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getHttpStatusCode ()Lio/ktor/http/HttpStatusCode;
+}
+
+public final class com/okta/directauth/model/DirectAuthenticationError$HttpError$ApiError : com/okta/directauth/model/DirectAuthenticationError$HttpError {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lio/ktor/http/HttpStatusCode;)V
+	public final fun getErrorCauses ()Ljava/util/List;
+	public final fun getErrorCode ()Ljava/lang/String;
+	public final fun getErrorId ()Ljava/lang/String;
+	public final fun getErrorLink ()Ljava/lang/String;
+	public final fun getErrorSummary ()Ljava/lang/String;
+}
+
+public final class com/okta/directauth/model/DirectAuthenticationError$HttpError$Oauth2Error : com/okta/directauth/model/DirectAuthenticationError$HttpError {
+	public fun <init> (Ljava/lang/String;Lio/ktor/http/HttpStatusCode;Ljava/lang/String;)V
+	public final fun getError ()Ljava/lang/String;
+	public final fun getErrorDescription ()Ljava/lang/String;
+}
+
+public final class com/okta/directauth/model/DirectAuthenticationError$InternalError : com/okta/directauth/model/DirectAuthenticationError {
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getErrorCode ()Ljava/lang/String;
+	public final fun getThrowable ()Ljava/lang/Throwable;
+}
+
+public final class com/okta/directauth/model/DirectAuthenticationIntent : java/lang/Enum {
+	public static final field RECOVERY Lcom/okta/directauth/model/DirectAuthenticationIntent;
+	public static final field SIGN_IN Lcom/okta/directauth/model/DirectAuthenticationIntent;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/okta/directauth/model/DirectAuthenticationIntent;
+	public static fun values ()[Lcom/okta/directauth/model/DirectAuthenticationIntent;
+}
+
+public abstract interface class com/okta/directauth/model/DirectAuthenticationState {
+}
+
+public final class com/okta/directauth/model/DirectAuthenticationState$Authenticated : com/okta/directauth/model/DirectAuthenticationState {
+	public final fun getToken ()Lcom/okta/authfoundation/client/TokenInfo;
+}
+
+public final class com/okta/directauth/model/DirectAuthenticationState$AuthorizationPending : com/okta/directauth/model/DirectAuthenticationState {
+	public final fun getTimestamp ()J
+}
+
+public final class com/okta/directauth/model/DirectAuthenticationState$Canceled : com/okta/directauth/model/DirectAuthenticationState {
+	public static final field INSTANCE Lcom/okta/directauth/model/DirectAuthenticationState$Canceled;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/okta/directauth/model/DirectAuthenticationState$Idle : com/okta/directauth/model/DirectAuthenticationState {
+	public static final field INSTANCE Lcom/okta/directauth/model/DirectAuthenticationState$Idle;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/okta/directauth/model/DirectAuthenticationState$MfaRequired : com/okta/directauth/model/DirectAuthenticationState {
+	public final fun challenge (Lcom/okta/directauth/model/SecondaryFactor;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun challenge (Lcom/okta/directauth/model/SecondaryFactor;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun challenge$default (Lcom/okta/directauth/model/DirectAuthenticationState$MfaRequired;Lcom/okta/directauth/model/SecondaryFactor;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun resume (Lcom/okta/directauth/model/SecondaryFactor;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun resume (Lcom/okta/directauth/model/SecondaryFactor;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun resume$default (Lcom/okta/directauth/model/DirectAuthenticationState$MfaRequired;Lcom/okta/directauth/model/SecondaryFactor;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/okta/directauth/model/OobChannel : java/lang/Enum {
+	public static final field PUSH Lcom/okta/directauth/model/OobChannel;
+	public static final field SMS Lcom/okta/directauth/model/OobChannel;
+	public static final field VOICE Lcom/okta/directauth/model/OobChannel;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/okta/directauth/model/OobChannel;
+	public static fun values ()[Lcom/okta/directauth/model/OobChannel;
+}
+
+public abstract interface class com/okta/directauth/model/PrimaryFactor {
+}
+
+public final class com/okta/directauth/model/PrimaryFactor$Oob : com/okta/directauth/model/SecondaryFactor {
+	public fun <init> (Lcom/okta/directauth/model/OobChannel;)V
+	public final fun component1 ()Lcom/okta/directauth/model/OobChannel;
+	public final fun copy (Lcom/okta/directauth/model/OobChannel;)Lcom/okta/directauth/model/PrimaryFactor$Oob;
+	public static synthetic fun copy$default (Lcom/okta/directauth/model/PrimaryFactor$Oob;Lcom/okta/directauth/model/OobChannel;ILjava/lang/Object;)Lcom/okta/directauth/model/PrimaryFactor$Oob;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChannel ()Lcom/okta/directauth/model/OobChannel;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/okta/directauth/model/PrimaryFactor$Otp : com/okta/directauth/model/SecondaryFactor {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/okta/directauth/model/PrimaryFactor$Otp;
+	public static synthetic fun copy$default (Lcom/okta/directauth/model/PrimaryFactor$Otp;Ljava/lang/String;ILjava/lang/Object;)Lcom/okta/directauth/model/PrimaryFactor$Otp;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPassCode ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/okta/directauth/model/PrimaryFactor$Password : com/okta/directauth/model/PrimaryFactor {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/okta/directauth/model/PrimaryFactor$Password;
+	public static synthetic fun copy$default (Lcom/okta/directauth/model/PrimaryFactor$Password;Ljava/lang/String;ILjava/lang/Object;)Lcom/okta/directauth/model/PrimaryFactor$Password;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPassword ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/okta/directauth/model/PrimaryFactor$WebAuthn : com/okta/directauth/model/SecondaryFactor {
+	public static final field INSTANCE Lcom/okta/directauth/model/PrimaryFactor$WebAuthn;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/okta/directauth/model/SecondaryFactor : com/okta/directauth/model/PrimaryFactor {
+}
+
+public final class com/okta/directauth/model/WebAuthnAssertionResponse {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/okta/directauth/model/WebAuthnAssertionResponse;
+	public static synthetic fun copy$default (Lcom/okta/directauth/model/WebAuthnAssertionResponse;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/okta/directauth/model/WebAuthnAssertionResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAuthenticatorData ()Ljava/lang/String;
+	public final fun getClientDataJSON ()Ljava/lang/String;
+	public final fun getSignature ()Ljava/lang/String;
+	public final fun getUserHandle ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/okta/directauth/webauthn/AndroidWebAuthnCeremonyHandler : com/okta/directauth/api/WebAuthnCeremonyHandler {
+	public fun <init> (Landroid/app/Activity;)V
+	public fun performAssertion-gIAlu-s (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+

--- a/okta-direct-auth/build.gradle.kts
+++ b/okta-direct-auth/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
+
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.kotlin.multiplatform.library)
@@ -7,6 +9,7 @@ plugins {
     kotlin("plugin.serialization") version libs.versions.kotlin.get()
     id("com.vanniktech.maven.publish.base")
     id("spotless")
+    id("binary-compat-validation")
 }
 
 // KMP androidLibrary does not generate BuildConfigs so we generate a BuildInfo.kt file instead.
@@ -34,7 +37,7 @@ val generateBuildInfoTask =
 kotlin {
     jvm()
 
-    androidLibrary {
+    android {
         namespace = "com.okta.directauth"
         compileSdk = COMPILE_SDK
         minSdk = MIN_SDK
@@ -115,4 +118,23 @@ kotlin {
             }
         }
     }
+
+    // Only validates the jvm target; KGP's ABI validation filters for KotlinAndroidTarget, but the androidLibrary
+    // target here is a KotlinMultiplatformAndroidLibraryTargetImpl (AGP's KMP android plugin), so it's silently skipped.
+    // The android target's own ABI is covered separately below, via binary-compat-validation.
+    @OptIn(ExperimentalAbiValidation::class)
+    abiValidation {
+        filters {
+            exclude {
+                byNames.add("com.okta.directauth.BuildInfo")
+            }
+        }
+    }
+}
+
+binaryCompatValidationExtension {
+    taskNamePrefix.set("android")
+    kotlinCompileTaskName.set("compileAndroidMain")
+    javaCompileTaskName.set("")
+    ignoredClasses.add("com.okta.directauth.BuildInfo")
 }

--- a/okta-idx-kotlin/build.gradle.kts
+++ b/okta-idx-kotlin/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     id("com.google.devtools.ksp")
     id("kotlin-parcelize")
     id("spotless")
-    id("binary-compatibility-validator")
+    id("binary-compat-validation")
     id("com.vanniktech.maven.publish.base")
     kotlin("plugin.serialization") version libs.versions.kotlin.get()
 }
@@ -49,7 +49,7 @@ kotlin {
     }
 }
 
-apiValidation {
+binaryCompatValidationExtension {
     ignoredClasses.add("com.okta.idx.kotlin.BuildConfig")
 }
 

--- a/web-authentication-ui/api/web-authentication-ui.api
+++ b/web-authentication-ui/api/web-authentication-ui.api
@@ -1,3 +1,22 @@
+public final class com/okta/webauthenticationui/DefaultWebAuthenticationProvider : com/okta/webauthenticationui/WebAuthenticationProvider {
+	public static final field Companion Lcom/okta/webauthenticationui/DefaultWebAuthenticationProvider$Companion;
+	public static final field X_OKTA_USER_AGENT Ljava/lang/String;
+	public fun <init> ()V
+	public fun <init> (Lcom/okta/authfoundation/events/EventCoordinator;)V
+	public fun <init> (Lcom/okta/authfoundation/events/EventCoordinator;Ljava/util/List;)V
+	public fun <init> (Lcom/okta/authfoundation/events/EventCoordinator;Ljava/util/List;I)V
+	public fun <init> (Lcom/okta/authfoundation/events/EventCoordinator;Ljava/util/List;ILkotlin/jvm/functions/Function2;)V
+	public synthetic fun <init> (Lcom/okta/authfoundation/events/EventCoordinator;Ljava/util/List;ILkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getPreferredBrowsers ()Ljava/util/List;
+	public final fun getQueryIntentServicesFlags ()I
+	public fun launch (Landroid/content/Context;Lokhttp3/HttpUrl;)Ljava/lang/Exception;
+}
+
+public final class com/okta/webauthenticationui/DefaultWebAuthenticationProvider$Companion {
+	public final fun getDEFAULT_PREFERRED_BROWSERS ()Ljava/util/List;
+	public final fun getUSER_AGENT_HEADER ()Ljava/lang/String;
+}
+
 public abstract interface class com/okta/webauthenticationui/ForegroundActivityEvent : com/okta/webauthenticationui/events/UIEvent {
 }
 
@@ -45,12 +64,12 @@ public final class com/okta/webauthenticationui/ForegroundActivityEvent$OnResume
 
 public final class com/okta/webauthenticationui/WebAuthentication {
 	public static final field Companion Lcom/okta/webauthenticationui/WebAuthentication$Companion;
-	public fun <init> (Lcom/okta/authfoundation/client/kmp/OAuth2Client;Lcom/okta/webauthenticationui/WebAuthenticationProvider;)V
-	public synthetic fun <init> (Lcom/okta/authfoundation/client/kmp/OAuth2Client;Lcom/okta/webauthenticationui/WebAuthenticationProvider;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lcom/okta/authfoundation/client/OAuth2Client;Lcom/okta/webauthenticationui/WebAuthenticationProvider;)V
 	public synthetic fun <init> (Lcom/okta/authfoundation/client/OAuth2Client;Lcom/okta/webauthenticationui/WebAuthenticationProvider;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lcom/okta/authfoundation/client/OidcConfiguration;Lcom/okta/webauthenticationui/WebAuthenticationProvider;)V
 	public synthetic fun <init> (Lcom/okta/authfoundation/client/OidcConfiguration;Lcom/okta/webauthenticationui/WebAuthenticationProvider;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/okta/authfoundation/client/kmp/OAuth2Client;Lcom/okta/webauthenticationui/WebAuthenticationProvider;)V
+	public synthetic fun <init> (Lcom/okta/authfoundation/client/kmp/OAuth2Client;Lcom/okta/webauthenticationui/WebAuthenticationProvider;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lcom/okta/webauthenticationui/WebAuthenticationProvider;)V
 	public synthetic fun <init> (Lcom/okta/webauthenticationui/WebAuthenticationProvider;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun login (Landroid/content/Context;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -67,30 +86,8 @@ public final class com/okta/webauthenticationui/WebAuthentication$FlowAlreadyInP
 public final class com/okta/webauthenticationui/WebAuthentication$FlowCancelledException : java/lang/Exception {
 }
 
-public final class com/okta/webauthenticationui/DefaultWebAuthenticationProvider : com/okta/webauthenticationui/WebAuthenticationProvider {
-	public synthetic fun <init> (Lcom/okta/authfoundation/events/EventCoordinator;Ljava/util/List;ILkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> ()V
-	public fun <init> (Lcom/okta/authfoundation/events/EventCoordinator;)V
-	public fun <init> (Lcom/okta/authfoundation/events/EventCoordinator;Ljava/util/List;)V
-	public fun <init> (Lcom/okta/authfoundation/events/EventCoordinator;Ljava/util/List;I)V
-	public fun <init> (Lcom/okta/authfoundation/events/EventCoordinator;Ljava/util/List;ILkotlin/jvm/functions/Function2;)V
-	public static final field Companion Lcom/okta/webauthenticationui/DefaultWebAuthenticationProvider$Companion;
-	public final fun getPreferredBrowsers ()Ljava/util/List;
-	public final fun getQueryIntentServicesFlags ()I
-	public fun launch (Landroid/content/Context;Lokhttp3/HttpUrl;)Ljava/lang/Exception;
-}
-
-public final class com/okta/webauthenticationui/DefaultWebAuthenticationProvider$Companion {
-	public final fun getDEFAULT_PREFERRED_BROWSERS ()Ljava/util/List;
-	public final fun getUSER_AGENT_HEADER ()Ljava/lang/String;
-	public static final field X_OKTA_USER_AGENT Ljava/lang/String;
-}
-
 public abstract interface class com/okta/webauthenticationui/WebAuthenticationProvider {
 	public abstract fun launch (Landroid/content/Context;Lokhttp3/HttpUrl;)Ljava/lang/Exception;
-}
-
-public abstract interface class com/okta/webauthenticationui/events/UIEvent : com/okta/authfoundation/events/Event {
 }
 
 public final class com/okta/webauthenticationui/events/CustomizeBrowserEvent : com/okta/webauthenticationui/events/UIEvent {
@@ -103,5 +100,8 @@ public final class com/okta/webauthenticationui/events/CustomizeBrowserEvent : c
 public final class com/okta/webauthenticationui/events/CustomizeCustomTabsEvent : com/okta/webauthenticationui/events/UIEvent {
 	public final fun getContext ()Landroid/content/Context;
 	public final fun getIntentBuilder ()Landroidx/browser/customtabs/CustomTabsIntent$Builder;
+}
+
+public abstract interface class com/okta/webauthenticationui/events/UIEvent : com/okta/authfoundation/events/Event {
 }
 

--- a/web-authentication-ui/build.gradle.kts
+++ b/web-authentication-ui/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     id("com.android.library")
     alias(libs.plugins.dokka)
     id("kotlin-parcelize")
-    id("binary-compatibility-validator")
+    id("binary-compat-validation")
     kotlin("plugin.serialization") version libs.versions.kotlin.get()
     id("com.vanniktech.maven.publish.base")
     id("spotless")
@@ -60,7 +60,7 @@ androidComponents {
     }
 }
 
-apiValidation {
+binaryCompatValidationExtension {
     ignoredClasses.add("com.okta.webauthenticationui.BuildConfig")
 }
 


### PR DESCRIPTION
KGP's native abiValidation only covers the jvm target on auth-foundation/ oauth2 - their android target is AGP's KotlinMultiplatformAndroidLibraryTargetImpl, which KGP's validator filters out since it only recognizes KotlinAndroidTarget. Separately, the standalone binary-compatibility-validator plugin registers zero tasks on four Android-only modules (web-authentication-ui, okta-idx-kotlin, native-authentication, legacy-token-migration), since none apply kotlin("android")
- AGP's built-in Kotlin support isn't detected by BCV's plugin-detection logic either (OKTA-1233588). Both gaps share the same fix: a project-owned convention plugin (buildSrc's BinaryCompatValidationPlugin/Extension, applied as id("binary-compat-validation")) that registers BCV's own internal task types (KotlinApiBuildTask/KotlinApiCompareTask) directly against a named compile task's output classes, bypassing BCV's plugin-detection entirely.

Applied as:
- auth-foundation, oauth2: checkKotlinAbi/updateKotlinAbi (KGP native, jvm target) plus androidApiCheck/androidApiDump (binary-compat-validation, android target).
- web-authentication-ui, okta-idx-kotlin, native-authentication, legacy-token-migration: releaseApiCheck/releaseApiDump, replacing the standalone binary-compatibility-validator plugin and its apiValidation {} block entirely.
- okta-direct-auth: same checkKotlinAbi + androidApiCheck treatment as auth-foundation/oauth2. It previously had zero ABI tracking despite being published to Maven Central; generated its first baseline dumps. okta-direct-auth-shared is intentionally left out - it's unpublished sample UI code whose generated AppConfig.kt bakes in machine-local values from local.properties, which would make a dump non-reproducible across machines.

Root checkLegacyAbi now depends on checkKotlinAbi, androidApiCheck, and releaseApiCheck across all subprojects (each looked up via findByName, so a module missing a given task is silently skipped rather than failing). CI's api-check job now scopes to :checkLegacyAbi to avoid also matching KGP's own deprecated per-module checkLegacyAbi task on auth-foundation/oauth2. Removed the now-dead binary-compatibility-validator/kotlinBinaryCompatibility entries from the version catalog.

Regenerated dumps for auth-foundation, oauth2, native-authentication, and web-authentication-ui against real, stale drift (confirming both gaps were live, not hypothetical).

Incidental: replaced deprecated androidLibrary {} with android {} in auth-foundation, oauth2, and okta-direct-auth-shared (identical underlying target; AGP DSL rename only, no ABI impact). Bumped compose-rules ktlint 0.5.3 -> 0.6.3.

RESOLVES: (OKTA-1206544, OKTA-1233588)