### PR TITLE
Deprecate Android-only auth-foundation/oauth2 APIs in favor of KMP

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,6 +499,103 @@ val oauthFlow = WebAuthentication(client)
 
 `WebAuthenticationClient` has been renamed to `WebAuthentication`.
 
+## Migrating from Android-only APIs to KMP APIs
+
+The original Android-only APIs in `auth-foundation` and `oauth2` (`OAuth2Client`, `OidcConfiguration`, `Credential`, `CredentialDataSource`, and the `com.okta.oauth2.*` flow classes) are deprecated in favor of Kotlin Multiplatform (KMP) equivalents that work identically on Android and JVM. The deprecated classes remain functional — there's no forced migration — but new code should prefer the KMP variants below.
+
+#### Client initialization
+
+Android-only:
+```kotlin
+OidcConfiguration.default = OidcConfiguration(
+  clientId = "{clientId}",
+  defaultScope = "openid email profile offline_access",
+  issuer = "https://{yourOktaOrg}.okta.com/oauth2/default"
+)
+val client = OAuth2Client.default
+```
+
+KMP:
+```kotlin
+val client = OAuth2ClientBuilder.create(
+  issuerUrl = "https://{yourOktaOrg}.okta.com",
+  clientId = "{clientId}",
+  scope = listOf("openid", "email", "profile", "offline_access"),
+) {
+  authorizationServerId = "default"
+}.getOrThrow()
+```
+
+#### Credential storage
+
+Android-only `Credential` is a mutable, static-companion-driven class backed by `CredentialDataSource`. The KMP `Credential` is an **immutable snapshot** managed by an explicit `TokenCredentialManager` instance — methods that mutate state (`refreshToken()`, `setTagsAsync()`, etc.) return a *new* `Credential` snapshot rather than mutating in place.
+
+Android-only:
+```kotlin
+val credential = Credential.store(token = result.result)
+Credential.setDefaultAsync(credential)
+// ...
+val refreshed = credential.refreshToken() // mutates `credential` in place
+```
+
+KMP (Android app, with Keystore/biometric-backed storage via `AndroidTokenEncryptionHandler`):
+```kotlin
+val database = createTokenDatabase(context)
+val storage = RoomTokenStorage(
+  database,
+  AndroidTokenEncryptionHandler(requireBiometric = true, userAuthenticationTimeout = 0),
+  client.configuration
+)
+val credentialManager = TokenCredentialManager(client, storage, RoomDefaultCredentialIdStore(database))
+
+// A flow's Result<TokenInfo> is not necessarily a TokenData at runtime — convert explicitly, don't cast.
+val tokenInfo: TokenInfo = resourceOwnerFlow.start(username, password).getOrThrow()
+val tokenData = TokenData(
+  id = tokenInfo.id, tokenType = tokenInfo.tokenType, expiresIn = tokenInfo.expiresIn,
+  accessToken = tokenInfo.accessToken, scope = tokenInfo.scope, refreshToken = tokenInfo.refreshToken,
+  idToken = tokenInfo.idToken, deviceSecret = tokenInfo.deviceSecret, issuedTokenType = tokenInfo.issuedTokenType,
+  configuration = client.configuration, issuedAt = client.configuration.clock.currentTimeEpochSecond()
+)
+val credential = credentialManager.store(tokenData).getOrThrow()
+credentialManager.setDefault(credential)
+// ...
+val refreshed = credential.refreshToken().getOrThrow() // returns a *new* snapshot; `credential` is now stale
+```
+
+On non-Android JVM targets, use `createEncryptedTokenStorage(configuration, dbPath)` from `com.okta.authfoundation.credential.kmp.storage` (JVM-only Keystore/biometric gating is not applicable there) or the Java-friendly `com.okta.authfoundation.credential.jvm.TokenCredentialManager` wrapper.
+
+> Note: `AndroidTokenEncryptionHandler`-backed storage encrypts only the access-token column (like the JVM path) — it does not whole-database encrypt the underlying SQLite file the way the legacy SQLCipher-backed `RoomTokenStorage` did. Use a custom `TokenEncryptionHandler` if whole-database encryption is a requirement.
+
+#### OAuth flows
+
+Android-only:
+```kotlin
+val resourceOwnerFlow = ResourceOwnerFlow() // com.okta.oauth2.ResourceOwnerFlow
+val result = resourceOwnerFlow.start(username, password) // OAuth2ClientResult<Token>
+```
+
+KMP:
+```kotlin
+val resourceOwnerFlow = ResourceOwnerFlow(client) // com.okta.oauth2.kmp.ResourceOwnerFlow
+val result = resourceOwnerFlow.start(username, password) // Result<TokenInfo>
+```
+
+The same rename applies to `DeviceAuthorizationFlow`, `SessionTokenFlow`, `TokenExchangeFlow`, `AuthorizationCodeFlow`, and `RedirectEndSessionFlow` — swap the `com.okta.oauth2.*` import for `com.okta.oauth2.kmp.*`, and pass an explicit KMP `OAuth2Client` instead of relying on `OidcConfiguration.default`. `WebAuthentication` already uses the KMP client internally regardless of which constructor you use.
+
+#### Scope as a list
+
+Scope parameters that previously only accepted a space-delimited `String` now also accept a `List<String>`, for consistency with `OAuth2ClientBuilder.create(scope: List<String>)`:
+
+```kotlin
+// Deprecated
+resourceOwnerFlow.start(username, password, scope = "openid profile")
+
+// Preferred
+resourceOwnerFlow.start(username, password, scope = listOf("openid", "profile"))
+```
+
+This applies to `start(...)`/`login(...)` on all the flow classes above. Fields that mirror the OAuth2 wire format (`TokenInfo.scope`, `Token.scope`) remain `String?`, since the token endpoint always returns scope as a single space-delimited string per [RFC 6749 §3.3](https://datatracker.ietf.org/doc/html/rfc6749#section-3.3).
+
 ## Troubleshooting
 
 - java.lang.NoClassDefFoundError: Failed resolution of: Ljava/time/Instant;

--- a/app/src/main/java/sample/okta/android/LaunchFragment.kt
+++ b/app/src/main/java/sample/okta/android/LaunchFragment.kt
@@ -19,7 +19,6 @@ import android.os.Bundle
 import android.view.View
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
-import com.okta.authfoundation.credential.Credential
 import kotlinx.coroutines.launch
 import sample.okta.android.databinding.FragmentLaunchBinding
 import sample.okta.android.util.BaseFragment
@@ -35,7 +34,11 @@ internal class LaunchFragment :
         super.onViewCreated(view, savedInstanceState)
 
         lifecycleScope.launch {
-            if (Credential.allIdsAsync().isNotEmpty()) {
+            if (SampleApplication.credentialManager
+                    .allIds()
+                    .getOrThrow()
+                    .isNotEmpty()
+            ) {
                 binding.loggedInTextView.visibility = View.VISIBLE
                 binding.dashboardButton.visibility = View.VISIBLE
                 binding.dashboardButton.setOnClickListener {

--- a/app/src/main/java/sample/okta/android/SampleApplication.kt
+++ b/app/src/main/java/sample/okta/android/SampleApplication.kt
@@ -21,10 +21,13 @@ import android.content.Context
 import androidx.biometric.BiometricPrompt
 import com.okta.authfoundation.AuthFoundation
 import com.okta.authfoundation.client.OAuth2ClientBuilder
-import com.okta.authfoundation.client.OidcConfiguration
 import com.okta.authfoundation.client.kmp.OAuth2Client
-import com.okta.authfoundation.credential.Credential
 import com.okta.authfoundation.credential.TokenDbRecoveryUtil
+import com.okta.authfoundation.credential.kmp.AndroidTokenEncryptionHandler
+import com.okta.authfoundation.credential.kmp.TokenCredentialManager
+import com.okta.authfoundation.credential.kmp.storage.RoomDefaultCredentialIdStore
+import com.okta.authfoundation.credential.kmp.storage.RoomTokenStorage
+import com.okta.authfoundation.credential.kmp.storage.createTokenDatabase
 import timber.log.Timber
 
 class SampleApplication : Application() {
@@ -40,6 +43,28 @@ class SampleApplication : Application() {
                     scope = SampleHelper.DEFAULT_SCOPE.split(" ")
                 ).getOrThrow()
         }
+
+        /** Backs biometric-gated decryption for [credentialManager]. */
+        val tokenEncryptionHandler: AndroidTokenEncryptionHandler by lazy {
+            AndroidTokenEncryptionHandler(
+                requireBiometric = true,
+                userAuthenticationTimeout = 0,
+                promptInfo =
+                    BiometricPrompt.PromptInfo
+                        .Builder()
+                        .setTitle("Authenticate")
+                        .setSubtitle("Verify your identity to access your account")
+                        .setNegativeButtonText("Cancel")
+                        .build()
+            )
+        }
+
+        val credentialManager: TokenCredentialManager by lazy {
+            val database = createTokenDatabase(context)
+            val storage = RoomTokenStorage(database, tokenEncryptionHandler, oAuth2Client.configuration)
+            val defaultIdStore = RoomDefaultCredentialIdStore(database)
+            TokenCredentialManager(oAuth2Client, storage, defaultIdStore)
+        }
     }
 
     override fun onCreate() {
@@ -50,20 +75,6 @@ class SampleApplication : Application() {
         Timber.plant(Timber.DebugTree())
 
         AuthFoundation.initializeAndroidContext(this)
-        OidcConfiguration.default =
-            OidcConfiguration(
-                clientId = BuildConfig.CLIENT_ID,
-                defaultScope = SampleHelper.DEFAULT_SCOPE,
-                issuer = BuildConfig.ISSUER
-            )
-        Credential.Security.standard = Credential.Security.BiometricStrong(userAuthenticationTimeout = 0)
-        Credential.Security.promptInfo =
-            BiometricPrompt.PromptInfo
-                .Builder()
-                .setTitle("Authenticate")
-                .setSubtitle("Verify your identity to access your account")
-                .setNegativeButtonText("Cancel")
-                .build()
         // Use this in case token database is corrupted due to automatic backup/restore
         TokenDbRecoveryUtil.setupDatabaseRecovery()
     }

--- a/app/src/main/java/sample/okta/android/SampleHelper.kt
+++ b/app/src/main/java/sample/okta/android/SampleHelper.kt
@@ -15,7 +15,35 @@
  */
 package sample.okta.android
 
+import com.okta.authfoundation.client.OAuth2ClientConfiguration
+import com.okta.authfoundation.client.TokenInfo
+import com.okta.authfoundation.credential.kmp.TokenData
+
 internal object SampleHelper {
     const val CREDENTIAL_NAME_TAG_KEY: String = "sample.okta.android.credential.name"
     const val DEFAULT_SCOPE: String = "openid email profile offline_access"
 }
+
+/**
+ * The KMP flows (and [WebAuthentication][com.okta.webauthenticationui.WebAuthentication], via the legacy
+ * Android [com.okta.authfoundation.credential.Token], which also implements [TokenInfo]) return a
+ * [TokenInfo] whose concrete runtime type is not [TokenData]. This app stores credentials via the KMP
+ * [com.okta.authfoundation.credential.kmp.TokenCredentialManager], which requires a [TokenData] snapshot,
+ * so every freshly-minted token must be converted explicitly rather than cast.
+ *
+ * [issuedAt] defaults to "now" since this is always called immediately after a token is minted.
+ */
+internal fun TokenInfo.toTokenData(configuration: OAuth2ClientConfiguration): TokenData =
+    TokenData(
+        id = id,
+        tokenType = tokenType,
+        expiresIn = expiresIn,
+        accessToken = accessToken,
+        scope = scope,
+        refreshToken = refreshToken,
+        idToken = idToken,
+        deviceSecret = deviceSecret,
+        issuedTokenType = issuedTokenType,
+        configuration = configuration,
+        issuedAt = configuration.clock.currentTimeEpochSecond()
+    )

--- a/app/src/main/java/sample/okta/android/browser/BrowserViewModel.kt
+++ b/app/src/main/java/sample/okta/android/browser/BrowserViewModel.kt
@@ -21,12 +21,13 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.okta.authfoundation.client.OAuth2ClientResult
-import com.okta.authfoundation.credential.Credential
+import com.okta.authfoundation.credential.kmp.TokenData
 import com.okta.webauthenticationui.WebAuthentication
 import kotlinx.coroutines.launch
 import sample.okta.android.BuildConfig
 import sample.okta.android.SampleApplication
 import sample.okta.android.SampleHelper
+import sample.okta.android.toTokenData
 import timber.log.Timber
 
 class BrowserViewModel : ViewModel() {
@@ -63,8 +64,10 @@ class BrowserViewModel : ViewModel() {
                 }
 
                 is OAuth2ClientResult.Success -> {
-                    val credential = Credential.store(result.result)
-                    Credential.setDefaultAsync(credential)
+                    val credentialManager = SampleApplication.credentialManager
+                    val tokenData = result.result.toTokenData(SampleApplication.oAuth2Client.configuration)
+                    val credential = credentialManager.store(tokenData).getOrThrow()
+                    credentialManager.setDefault(credential)
                     _state.value = BrowserState.Token
                 }
             }

--- a/app/src/main/java/sample/okta/android/dashboard/DashboardFragment.kt
+++ b/app/src/main/java/sample/okta/android/dashboard/DashboardFragment.kt
@@ -24,11 +24,11 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
-import com.okta.authfoundation.credential.Credential
 import com.okta.authfoundation.credential.RevokeTokenType
 import com.okta.authfoundation.credential.TokenType
 import kotlinx.coroutines.launch
 import sample.okta.android.R
+import sample.okta.android.SampleApplication
 import sample.okta.android.databinding.FragmentDashboardBinding
 import sample.okta.android.databinding.RowDashboardClaimBinding
 import sample.okta.android.util.BaseFragment
@@ -53,7 +53,10 @@ internal class DashboardFragment :
         object : OnBackPressedCallback(true) {
             override fun handleOnBackPressed() {
                 lifecycleScope.launch {
-                    Credential.getDefaultAsync()?.let { viewModel.setCredential(it) }
+                    SampleApplication.credentialManager
+                        .getDefault()
+                        .getOrThrow()
+                        ?.let { viewModel.setCredential(it) }
                 }
             }
         }
@@ -72,7 +75,7 @@ internal class DashboardFragment :
                 is DashboardViewModel.CredentialState.Loaded -> {
                     val credential = credentialState.credential
                     lifecycleScope.launch {
-                        val defaultCredential = Credential.getDefaultAsync()
+                        val defaultCredential = SampleApplication.credentialManager.getDefault().getOrThrow()
                         onBackPressedCallback.isEnabled = defaultCredential != credential
 
                         binding.credentialName.text = if (defaultCredential == credential) "Default" else "TokenExchange"

--- a/app/src/main/java/sample/okta/android/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/sample/okta/android/dashboard/DashboardViewModel.kt
@@ -21,10 +21,11 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.okta.authfoundation.client.OAuth2ClientResult
-import com.okta.authfoundation.client.dto.OidcIntrospectInfo
-import com.okta.authfoundation.credential.Credential
+import com.okta.authfoundation.client.dto.IntrospectInfo
 import com.okta.authfoundation.credential.RevokeTokenType
+import com.okta.authfoundation.credential.TokenMetadata
 import com.okta.authfoundation.credential.TokenType
+import com.okta.authfoundation.credential.kmp.Credential
 import com.okta.webauthenticationui.WebAuthentication
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -54,14 +55,15 @@ internal class DashboardViewModel(
 
     init {
         viewModelScope.launch {
+            val credentialManager = SampleApplication.credentialManager
             val cred =
                 if (credentialTagNameValue == null) {
-                    Credential.getDefaultAsync()
+                    credentialManager.getDefault().getOrThrow()
                 } else {
-                    Credential
-                        .findAsync {
-                            it.tags[SampleHelper.CREDENTIAL_NAME_TAG_KEY] == credentialTagNameValue
-                        }.firstOrNull() ?: Credential.getDefaultAsync()
+                    credentialManager
+                        .find { metadata: TokenMetadata -> metadata.tags[SampleHelper.CREDENTIAL_NAME_TAG_KEY] == credentialTagNameValue }
+                        .getOrThrow()
+                        .firstOrNull() ?: credentialManager.getDefault().getOrThrow()
                 }
             cred?.let { setCredential(it) } ?: run {
                 _credentialLiveData.value = CredentialState.LoggedOut
@@ -82,30 +84,23 @@ internal class DashboardViewModel(
         tokenType: RevokeTokenType,
     ) {
         performRequest(buttonId) { credential ->
-            when (credential.revokeToken(tokenType)) {
-                is OAuth2ClientResult.Error -> {
-                    RequestState.Result("Failed to revoke token.")
-                }
-
-                is OAuth2ClientResult.Success -> {
-                    RequestState.Result("Token Revoked.")
-                }
-            }
+            credential.revokeToken(tokenType).fold(
+                onFailure = { RequestState.Result("Failed to revoke token.") },
+                onSuccess = { RequestState.Result("Token Revoked.") }
+            )
         }
     }
 
     fun refresh(buttonId: Int) {
         performRequest(buttonId) { credential ->
-            when (credential.refreshToken()) {
-                is OAuth2ClientResult.Error -> {
-                    RequestState.Result("Failed to refresh token.")
-                }
-
-                is OAuth2ClientResult.Success -> {
-                    _credentialLiveData.value = CredentialState.Loaded(credential) // Update the UI.
+            credential.refreshToken().fold(
+                onFailure = { RequestState.Result("Failed to refresh token.") },
+                onSuccess = { refreshed ->
+                    this.credential = refreshed
+                    _credentialLiveData.value = CredentialState.Loaded(refreshed) // Update the UI.
                     RequestState.Result("Token Refreshed.")
                 }
-            }
+            )
         }
     }
 
@@ -114,20 +109,16 @@ internal class DashboardViewModel(
         tokenType: TokenType,
     ) {
         performRequest(buttonId) { credential ->
-            when (val result = credential.introspectToken(tokenType)) {
-                is OAuth2ClientResult.Error -> {
-                    RequestState.Result("Failed to introspect token.")
-                }
-
-                is OAuth2ClientResult.Success -> {
-                    val successResult = result.result
-                    if (successResult is OidcIntrospectInfo.Active) {
-                        RequestState.Result(successResult.deserializeClaims(JsonObject.serializer()).asMap().displayableKeyValues())
+            credential.introspectToken(tokenType).fold(
+                onFailure = { RequestState.Result("Failed to introspect token.") },
+                onSuccess = { info ->
+                    if (info is IntrospectInfo.Active) {
+                        RequestState.Result(info.deserializeClaims(JsonObject.serializer()).asMap().displayableKeyValues())
                     } else {
                         RequestState.Result(mapOf("active" to "false").displayableKeyValues())
                     }
                 }
-            }
+            )
         }
     }
 
@@ -148,7 +139,7 @@ internal class DashboardViewModel(
                 }
 
                 is OAuth2ClientResult.Success -> {
-                    credential.delete()
+                    credential.deleteAsync()
                     _requestStateLiveData.value = RequestState.Result("Logout successful!")
                 }
             }
@@ -184,16 +175,15 @@ internal class DashboardViewModel(
     }
 
     private suspend fun getUserInfo() {
-        when (val userInfoResult = credential.getUserInfo()) {
-            is OAuth2ClientResult.Error -> {
-                Timber.e(userInfoResult.exception, "Failed to fetch user info.")
+        credential.getUserInfo().fold(
+            onFailure = { exception ->
+                Timber.e(exception, "Failed to fetch user info.")
                 _userInfoLiveData.postValue(emptyMap())
+            },
+            onSuccess = { userInfo ->
+                _userInfoLiveData.postValue(userInfo.deserializeClaims(JsonObject.serializer()).asMap())
             }
-
-            is OAuth2ClientResult.Success -> {
-                _userInfoLiveData.postValue(userInfoResult.result.deserializeClaims(JsonObject.serializer()).asMap())
-            }
-        }
+        )
     }
 
     sealed class RequestState {
@@ -214,7 +204,7 @@ internal class DashboardViewModel(
 
     fun deleteCredential() {
         viewModelScope.launch {
-            credential.delete()
+            credential.deleteAsync()
         }
     }
 }

--- a/app/src/main/java/sample/okta/android/deviceauthorization/DeviceAuthorizationViewModel.kt
+++ b/app/src/main/java/sample/okta/android/deviceauthorization/DeviceAuthorizationViewModel.kt
@@ -19,10 +19,11 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.okta.authfoundation.client.OAuth2ClientResult
-import com.okta.authfoundation.credential.Credential
-import com.okta.oauth2.DeviceAuthorizationFlow
+import com.okta.oauth2.kmp.DeviceAuthorizationFlow
+import com.okta.oauth2.kmp.DeviceAuthorizationFlowContext
 import kotlinx.coroutines.launch
+import sample.okta.android.SampleApplication
+import sample.okta.android.toTokenData
 import timber.log.Timber
 
 internal class DeviceAuthorizationViewModel : ViewModel() {
@@ -37,37 +38,36 @@ internal class DeviceAuthorizationViewModel : ViewModel() {
         _state.value = DeviceAuthorizationState.Loading
 
         viewModelScope.launch {
-            val deviceAuthorizationFlow = DeviceAuthorizationFlow()
-            when (val result = deviceAuthorizationFlow.start()) {
-                is OAuth2ClientResult.Error -> {
-                    Timber.e(result.exception, "Failed to start device authorization flow.")
+            val deviceAuthorizationFlow = DeviceAuthorizationFlow(SampleApplication.oAuth2Client)
+            deviceAuthorizationFlow.start().fold(
+                onFailure = { exception ->
+                    Timber.e(exception, "Failed to start device authorization flow.")
                     _state.value = DeviceAuthorizationState.Error("An error occurred.")
+                },
+                onSuccess = { flowContext ->
+                    _state.value = DeviceAuthorizationState.Polling(flowContext.userCode, flowContext.verificationUri)
+                    resume(deviceAuthorizationFlow, flowContext)
                 }
-
-                is OAuth2ClientResult.Success -> {
-                    _state.value = DeviceAuthorizationState.Polling(result.result.userCode, result.result.verificationUri)
-                    resume(deviceAuthorizationFlow, result.result)
-                }
-            }
+            )
         }
     }
 
     private suspend fun resume(
         deviceAuthorizationFlow: DeviceAuthorizationFlow,
-        flowContext: DeviceAuthorizationFlow.Context,
+        flowContext: DeviceAuthorizationFlowContext,
     ) {
-        when (val result = deviceAuthorizationFlow.resume(flowContext)) {
-            is OAuth2ClientResult.Error -> {
-                Timber.e(result.exception, "Failed to resume device authorization flow.")
+        deviceAuthorizationFlow.resume(flowContext).fold(
+            onFailure = { exception ->
+                Timber.e(exception, "Failed to resume device authorization flow.")
                 _state.value = DeviceAuthorizationState.Error("An error occurred.")
-            }
-
-            is OAuth2ClientResult.Success -> {
-                val credential = Credential.store(token = result.result)
-                Credential.setDefaultAsync(credential)
+            },
+            onSuccess = { tokenInfo ->
+                val tokenData = tokenInfo.toTokenData(SampleApplication.oAuth2Client.configuration)
+                val credential = SampleApplication.credentialManager.store(tokenData).getOrThrow()
+                SampleApplication.credentialManager.setDefault(credential)
                 _state.value = DeviceAuthorizationState.Token
             }
-        }
+        )
     }
 }
 

--- a/app/src/main/java/sample/okta/android/resourceowner/ResourceOwnerViewModel.kt
+++ b/app/src/main/java/sample/okta/android/resourceowner/ResourceOwnerViewModel.kt
@@ -19,10 +19,10 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.okta.authfoundation.client.OAuth2ClientResult
-import com.okta.authfoundation.credential.Credential
-import com.okta.oauth2.ResourceOwnerFlow
+import com.okta.oauth2.kmp.ResourceOwnerFlow
 import kotlinx.coroutines.launch
+import sample.okta.android.SampleApplication
+import sample.okta.android.toTokenData
 import timber.log.Timber
 
 internal class ResourceOwnerViewModel : ViewModel() {
@@ -36,19 +36,19 @@ internal class ResourceOwnerViewModel : ViewModel() {
         _state.value = ResourceOwnerState.Loading
 
         viewModelScope.launch {
-            val resourceOwnerFlow = ResourceOwnerFlow()
-            when (val result = resourceOwnerFlow.start(username, password)) {
-                is OAuth2ClientResult.Error -> {
-                    Timber.e(result.exception, "Failed to start resource owner flow.")
+            val resourceOwnerFlow = ResourceOwnerFlow(SampleApplication.oAuth2Client)
+            resourceOwnerFlow.start(username, password).fold(
+                onFailure = { exception ->
+                    Timber.e(exception, "Failed to start resource owner flow.")
                     _state.value = ResourceOwnerState.Error("An error occurred.")
-                }
-
-                is OAuth2ClientResult.Success -> {
-                    val credential = Credential.store(token = result.result)
-                    Credential.setDefaultAsync(credential)
+                },
+                onSuccess = { tokenInfo ->
+                    val tokenData = tokenInfo.toTokenData(SampleApplication.oAuth2Client.configuration)
+                    val credential = SampleApplication.credentialManager.store(tokenData).getOrThrow()
+                    SampleApplication.credentialManager.setDefault(credential)
                     _state.value = ResourceOwnerState.Token
                 }
-            }
+            )
         }
     }
 }

--- a/app/src/main/java/sample/okta/android/tokenexchange/TokenExchangeViewModel.kt
+++ b/app/src/main/java/sample/okta/android/tokenexchange/TokenExchangeViewModel.kt
@@ -19,11 +19,12 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.okta.authfoundation.client.OAuth2ClientResult
-import com.okta.authfoundation.credential.Credential
-import com.okta.oauth2.TokenExchangeFlow
+import com.okta.authfoundation.credential.TokenMetadata
+import com.okta.oauth2.kmp.TokenExchangeFlow
 import kotlinx.coroutines.launch
+import sample.okta.android.SampleApplication
 import sample.okta.android.SampleHelper
+import sample.okta.android.toTokenData
 import timber.log.Timber
 
 class TokenExchangeViewModel : ViewModel() {
@@ -42,12 +43,14 @@ class TokenExchangeViewModel : ViewModel() {
         _state.value = TokenExchangeState.Loading
 
         viewModelScope.launch {
-            val credential = Credential.getDefaultAsync()
+            val credentialManager = SampleApplication.credentialManager
+            val credential = credentialManager.getDefault().getOrThrow()
             val tokenExchangeCredential =
-                Credential
-                    .findAsync { it.tags[SampleHelper.CREDENTIAL_NAME_TAG_KEY] == NAME_TAG_VALUE }
+                credentialManager
+                    .find { metadata: TokenMetadata -> metadata.tags[SampleHelper.CREDENTIAL_NAME_TAG_KEY] == NAME_TAG_VALUE }
+                    .getOrThrow()
                     .firstOrNull()
-            val tokenExchangeFlow = TokenExchangeFlow()
+            val tokenExchangeFlow = TokenExchangeFlow(SampleApplication.oAuth2Client)
             val idToken = credential?.token?.idToken
             if (idToken == null) {
                 _state.value = TokenExchangeState.Error("Missing Id Token")
@@ -58,21 +61,21 @@ class TokenExchangeViewModel : ViewModel() {
                 _state.value = TokenExchangeState.Error("Missing Device Secret")
                 return@launch
             }
-            when (val result = tokenExchangeFlow.start(idToken, deviceSecret)) {
-                is OAuth2ClientResult.Error -> {
-                    Timber.e(result.exception, "Failed to start token exchange flow.")
+            tokenExchangeFlow.start(idToken, deviceSecret).fold(
+                onFailure = { exception ->
+                    Timber.e(exception, "Failed to start token exchange flow.")
                     _state.value = TokenExchangeState.Error("An error occurred.")
-                }
-
-                is OAuth2ClientResult.Success -> {
-                    tokenExchangeCredential?.delete()
-                    Credential.store(
-                        result.result,
+                },
+                onSuccess = { tokenInfo ->
+                    tokenExchangeCredential?.deleteAsync()
+                    val tokenData = tokenInfo.toTokenData(SampleApplication.oAuth2Client.configuration)
+                    credentialManager.store(
+                        tokenData,
                         tags = mapOf(Pair(SampleHelper.CREDENTIAL_NAME_TAG_KEY, NAME_TAG_VALUE))
                     )
                     _state.value = TokenExchangeState.Token(NAME_TAG_VALUE)
                 }
-            }
+            )
         }
     }
 }

--- a/auth-foundation/api/auth-foundation.api
+++ b/auth-foundation/api/auth-foundation.api
@@ -880,6 +880,7 @@ public final class com/okta/authfoundation/credential/Credential : com/okta/auth
 	public final fun revokeAllTokens (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun revokeToken (Lcom/okta/authfoundation/credential/RevokeTokenType;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun scope ()Ljava/lang/String;
+	public final fun scopes ()Ljava/util/List;
 	public final fun setTags (Ljava/util/Map;)V
 	public final fun setTagsAsync (Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
@@ -1214,6 +1215,19 @@ public final class com/okta/authfoundation/credential/events/TokenStorageAccessE
 	public final fun withShouldClearStorageAndTryAgain (Z)Lcom/okta/authfoundation/credential/events/TokenStorageAccessErrorEvent;
 }
 
+public final class com/okta/authfoundation/credential/kmp/AndroidTokenEncryptionHandler : com/okta/authfoundation/credential/kmp/TokenEncryptionHandler {
+	public static final field Companion Lcom/okta/authfoundation/credential/kmp/AndroidTokenEncryptionHandler$Companion;
+	public static final field DEFAULT_KEY_ALIAS Ljava/lang/String;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;ZILandroidx/biometric/BiometricPrompt$PromptInfo;Ljava/security/KeyStore;Ljava/security/KeyPairGenerator;)V
+	public synthetic fun <init> (Ljava/lang/String;ZILandroidx/biometric/BiometricPrompt$PromptInfo;Ljava/security/KeyStore;Ljava/security/KeyPairGenerator;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun decrypt ([BLjava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun encrypt ([BLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/okta/authfoundation/credential/kmp/AndroidTokenEncryptionHandler$Companion {
+}
+
 public final class com/okta/authfoundation/credential/kmp/BearerTokenPluginConfig {
 	public fun <init> ()V
 	public final fun getAccessTokenProvider ()Lkotlin/jvm/functions/Function1;
@@ -1250,11 +1264,13 @@ public abstract interface class com/okta/authfoundation/credential/kmp/Credentia
 	public abstract fun revokeAllTokens-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun revokeToken-gIAlu-s (Lcom/okta/authfoundation/credential/RevokeTokenType;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun scope ()Ljava/lang/String;
+	public fun scopes ()Ljava/util/List;
 	public abstract fun setTagsAsync-gIAlu-s (Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class com/okta/authfoundation/credential/kmp/Credential$DefaultImpls {
 	public static fun refreshToken-gIAlu-s (Lcom/okta/authfoundation/credential/kmp/Credential;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun scopes (Lcom/okta/authfoundation/credential/kmp/Credential;)Ljava/util/List;
 }
 
 public final class com/okta/authfoundation/credential/kmp/CredentialImpl : com/okta/authfoundation/credential/kmp/Credential {
@@ -1276,6 +1292,7 @@ public final class com/okta/authfoundation/credential/kmp/CredentialImpl : com/o
 	public fun revokeAllTokens-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun revokeToken-gIAlu-s (Lcom/okta/authfoundation/credential/RevokeTokenType;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun scope ()Ljava/lang/String;
+	public fun scopes ()Ljava/util/List;
 	public fun setTagsAsync-gIAlu-s (Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -1346,6 +1363,11 @@ public abstract interface class com/okta/authfoundation/credential/kmp/TokenEncr
 	public abstract fun encrypt ([BLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public final class com/okta/authfoundation/credential/kmp/TokenEncryptionKeyInvalidatedException : java/lang/Exception {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun getKeyAlias ()Ljava/lang/String;
+}
+
 public abstract interface class com/okta/authfoundation/credential/kmp/TokenStorage {
 	public abstract fun add-0E7RQCE (Lcom/okta/authfoundation/client/TokenInfo;Lcom/okta/authfoundation/credential/TokenMetadata;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun allIds-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -1354,6 +1376,13 @@ public abstract interface class com/okta/authfoundation/credential/kmp/TokenStor
 	public abstract fun remove-gIAlu-s (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun replace-gIAlu-s (Lcom/okta/authfoundation/client/TokenInfo;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun setMetadata-gIAlu-s (Lcom/okta/authfoundation/credential/TokenMetadata;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/okta/authfoundation/credential/kmp/storage/AndroidTokenDatabaseFactoryKt {
+	public static final fun createEncryptedTokenStorage (Landroid/content/Context;Lcom/okta/authfoundation/client/OAuth2ClientConfiguration;Ljava/lang/String;ZILandroidx/biometric/BiometricPrompt$PromptInfo;Ljava/lang/String;)Lcom/okta/authfoundation/credential/kmp/storage/RoomTokenStorage;
+	public static synthetic fun createEncryptedTokenStorage$default (Landroid/content/Context;Lcom/okta/authfoundation/client/OAuth2ClientConfiguration;Ljava/lang/String;ZILandroidx/biometric/BiometricPrompt$PromptInfo;Ljava/lang/String;ILjava/lang/Object;)Lcom/okta/authfoundation/credential/kmp/storage/RoomTokenStorage;
+	public static final fun createTokenDatabase (Landroid/content/Context;Ljava/lang/String;)Lcom/okta/authfoundation/credential/kmp/storage/TokenDatabase;
+	public static synthetic fun createTokenDatabase$default (Landroid/content/Context;Ljava/lang/String;ILjava/lang/Object;)Lcom/okta/authfoundation/credential/kmp/storage/TokenDatabase;
 }
 
 public final class com/okta/authfoundation/credential/kmp/storage/RoomDefaultCredentialIdStore : com/okta/authfoundation/credential/kmp/DefaultCredentialIdStore {

--- a/auth-foundation/api/jvm/auth-foundation.api
+++ b/auth-foundation/api/jvm/auth-foundation.api
@@ -778,11 +778,13 @@ public abstract interface class com/okta/authfoundation/credential/kmp/Credentia
 	public abstract fun revokeAllTokens-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun revokeToken-gIAlu-s (Lcom/okta/authfoundation/credential/RevokeTokenType;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun scope ()Ljava/lang/String;
+	public fun scopes ()Ljava/util/List;
 	public abstract fun setTagsAsync-gIAlu-s (Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class com/okta/authfoundation/credential/kmp/Credential$DefaultImpls {
 	public static fun refreshToken-gIAlu-s (Lcom/okta/authfoundation/credential/kmp/Credential;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun scopes (Lcom/okta/authfoundation/credential/kmp/Credential;)Ljava/util/List;
 }
 
 public final class com/okta/authfoundation/credential/kmp/CredentialImpl : com/okta/authfoundation/credential/kmp/Credential {
@@ -804,6 +806,7 @@ public final class com/okta/authfoundation/credential/kmp/CredentialImpl : com/o
 	public fun revokeAllTokens-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun revokeToken-gIAlu-s (Lcom/okta/authfoundation/credential/RevokeTokenType;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun scope ()Ljava/lang/String;
+	public fun scopes ()Ljava/util/List;
 	public fun setTagsAsync-gIAlu-s (Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -890,6 +893,11 @@ public final class com/okta/authfoundation/credential/kmp/TokenData : com/okta/a
 public abstract interface class com/okta/authfoundation/credential/kmp/TokenEncryptionHandler {
 	public abstract fun decrypt ([BLjava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun encrypt ([BLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/okta/authfoundation/credential/kmp/TokenEncryptionKeyInvalidatedException : java/lang/Exception {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun getKeyAlias ()Ljava/lang/String;
 }
 
 public abstract interface class com/okta/authfoundation/credential/kmp/TokenStorage {

--- a/auth-foundation/src/androidDeviceTest/kotlin/com/okta/authfoundation/credential/kmp/AndroidTokenEncryptionHandlerTest.kt
+++ b/auth-foundation/src/androidDeviceTest/kotlin/com/okta/authfoundation/credential/kmp/AndroidTokenEncryptionHandlerTest.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.credential.kmp
+
+import androidx.biometric.BiometricPrompt
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.security.GeneralSecurityException
+import kotlin.test.assertFailsWith
+
+@RunWith(AndroidJUnit4::class)
+internal class AndroidTokenEncryptionHandlerTest {
+    private val keyAlias = "AndroidTokenEncryptionHandlerTest.keyAlias"
+    private val bioKeyAlias = "$keyAlias.bio"
+    private val plaintext = "top-secret-access-token".encodeToByteArray()
+
+    private lateinit var plainHandler: AndroidTokenEncryptionHandler
+    private lateinit var bioHandler: AndroidTokenEncryptionHandler
+
+    // Shares bioKeyAlias with `bioHandler` — the RSA key material lives in the shared Android Keystore,
+    // not on the handler instance, so a second instance configured with promptInfo can decrypt what the
+    // first instance (deliberately constructed without promptInfo) encrypted.
+    private lateinit var bioHandlerWithPrompt: AndroidTokenEncryptionHandler
+
+    @Before
+    fun setup() {
+        plainHandler = AndroidTokenEncryptionHandler(keyAlias = keyAlias)
+        bioHandler = AndroidTokenEncryptionHandler(keyAlias = bioKeyAlias, requireBiometric = true, userAuthenticationTimeout = 0)
+        bioHandlerWithPrompt =
+            AndroidTokenEncryptionHandler(
+                keyAlias = bioKeyAlias,
+                requireBiometric = true,
+                userAuthenticationTimeout = 0,
+                promptInfo =
+                    BiometricPrompt.PromptInfo
+                        .Builder()
+                        .setTitle("title")
+                        .setNegativeButtonText("cancel")
+                        .build()
+            )
+        plainHandler.keyStore.deleteEntry(keyAlias)
+        bioHandler.keyStore.deleteEntry(bioKeyAlias)
+    }
+
+    @Test
+    fun encryptThenDecryptSucceeds() =
+        runTest {
+            val result = plainHandler.encrypt(plaintext)
+            val decrypted = plainHandler.decrypt(result.ciphertext, result.encryptionExtras)
+            assertThat(decrypted).isEqualTo(plaintext)
+        }
+
+    @Test
+    fun encryptRegeneratesKey_whenKeyDeletedAfterGeneration() =
+        runTest {
+            // Unlike the legacy DefaultTokenEncryptionHandler (which requires an explicit generateKey()
+            // call before use), this handler lazily provisions its Keystore key on first use, since the
+            // KMP TokenEncryptionHandler interface has no separate key-generation step. Deleting the alias
+            // therefore causes the next encrypt() to self-heal by regenerating the key, rather than fail.
+            plainHandler.encrypt(plaintext) // provisions the key
+            plainHandler.keyStore.deleteEntry(keyAlias)
+
+            val result = plainHandler.encrypt(plaintext)
+            val decrypted = plainHandler.decrypt(result.ciphertext, result.encryptionExtras)
+            assertThat(decrypted).isEqualTo(plaintext)
+        }
+
+    @Test
+    fun decryptingBiometricTokenWithNoPromptInfoFails() =
+        runTest {
+            val result = bioHandler.encrypt(plaintext)
+            val exception =
+                assertFailsWith<IllegalArgumentException> {
+                    bioHandler.decrypt(result.ciphertext, result.encryptionExtras)
+                }
+            assertThat(exception.message).contains("promptInfo")
+        }
+
+    @Test
+    fun biometricDecryptRoutesThroughAuthenticator_andPreservesThrowingContractOnFailure() =
+        runTest {
+            // AndroidBiometricAuthenticator resolves a Cipher/key for the alias from the Keystore. Deleting
+            // the key after encryption forces cipher resolution to fail before any BiometricPrompt UI is
+            // shown, surfacing as a GeneralSecurityException rather than being swallowed.
+            val result = bioHandler.encrypt(plaintext)
+            bioHandler.keyStore.deleteEntry(bioKeyAlias)
+
+            assertFailsWith<GeneralSecurityException> {
+                bioHandlerWithPrompt.decrypt(result.ciphertext, result.encryptionExtras)
+            }
+        }
+}

--- a/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/client/OAuth2Client.kt
+++ b/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/client/OAuth2Client.kt
@@ -49,7 +49,19 @@ typealias OidcClient = OAuth2Client
  * This is for low level access, and it's typically preferred to use a [Credential], which streamlines usage.
  *
  * [Okta Developer Docs](https://developer.okta.com/docs/reference/api/oidc)
+ *
+ * @deprecated This Android-only OAuth2Client is deprecated in favor of the KMP variant, which works on
+ * Android and JVM. Build one via [com.okta.authfoundation.client.OAuth2ClientBuilder.create] and use
+ * [com.okta.authfoundation.client.kmp.OAuth2Client] instead.
  */
+@Deprecated(
+    message =
+        "The Android-only OAuth2Client is deprecated in favor of the KMP variant, which works on Android " +
+            "and JVM. Build one via OAuth2ClientBuilder.create(issuerUrl, clientId, scope) and use " +
+            "com.okta.authfoundation.client.kmp.OAuth2Client instead. This class will be removed in a " +
+            "future major release.",
+    level = DeprecationLevel.WARNING
+)
 class OAuth2Client private constructor(
     @property:InternalAuthFoundationApi val configuration: OidcConfiguration,
     internal val endpoints: CoalescingOrchestrator<OAuth2ClientResult<OidcEndpoints>>,

--- a/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/client/OidcConfiguration.kt
+++ b/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/client/OidcConfiguration.kt
@@ -33,7 +33,18 @@ import kotlin.coroutines.CoroutineContext
  * Configuration options for an OAuth2Client.
  *
  * This class is used to define the configuration, as defined in your Okta application settings, that will be used to interact with the OIDC Authorization Server.
+ *
+ * @deprecated OidcConfiguration is deprecated in favor of the KMP [com.okta.authfoundation.client.OAuth2ClientBuilder],
+ * which works on Android and JVM.
  */
+@Deprecated(
+    message =
+        "OidcConfiguration is deprecated in favor of the KMP OAuth2ClientBuilder, which works on Android " +
+            "and JVM. Use OAuth2ClientBuilder.create(issuerUrl, clientId, scope) to build a " +
+            "com.okta.authfoundation.client.kmp.OAuth2Client instead. This class will be removed in a " +
+            "future major release.",
+    level = DeprecationLevel.WARNING
+)
 @Serializable
 class OidcConfiguration private constructor(
     /** The application's client ID. */

--- a/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/credential/AndroidBiometricAuthenticator.kt
+++ b/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/credential/AndroidBiometricAuthenticator.kt
@@ -18,6 +18,7 @@ package com.okta.authfoundation.credential
 import androidx.biometric.BiometricPrompt.PromptInfo
 import com.okta.authfoundation.BiometricDecryptionActivity
 import com.okta.authfoundation.InternalAuthFoundationApi
+import com.okta.authfoundation.credential.kmp.KeystoreEnvelopeCrypto
 import com.okta.authfoundation.util.runCatchingCancellable
 import java.security.InvalidKeyException
 import java.security.KeyStore
@@ -66,7 +67,7 @@ class AndroidBiometricAuthenticator(
         val privateKey =
             keyStore.getKey(keyAlias, null)
                 ?: throw InvalidKeyException("No key found for alias: $keyAlias")
-        return DefaultTokenEncryptionHandler.getRsaCipher().apply { init(Cipher.DECRYPT_MODE, privateKey) }
+        return KeystoreEnvelopeCrypto.getRsaCipher().apply { init(Cipher.DECRYPT_MODE, privateKey) }
     }
 
     private fun aesCipher(
@@ -76,8 +77,8 @@ class AndroidBiometricAuthenticator(
         val secretKey =
             keyStore.getKey(keyAlias, null)
                 ?: throw InvalidKeyException("No key found for alias: $keyAlias")
-        return DefaultTokenEncryptionHandler.getAesCipher().apply {
-            init(Cipher.DECRYPT_MODE, secretKey, GCMParameterSpec(DefaultTokenEncryptionHandler.GCM_TAG_LENGTH_BITS, iv))
+        return KeystoreEnvelopeCrypto.getAesCipher().apply {
+            init(Cipher.DECRYPT_MODE, secretKey, GCMParameterSpec(KeystoreEnvelopeCrypto.GCM_TAG_LENGTH_BITS, iv))
         }
     }
 }

--- a/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/credential/Credential.kt
+++ b/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/credential/Credential.kt
@@ -56,7 +56,19 @@ import java.util.Objects
  * Note: [Credential] itself never invokes biometric authentication directly; all biometric-gated token
  * decryption is delegated entirely to [TokenEncryptionHandler] (which, in turn, uses
  * [BiometricAuthenticator]/[AndroidBiometricAuthenticator]).
+ *
+ * @deprecated Credential is deprecated in favor of the KMP variant, which works on Android and JVM. Use
+ * [com.okta.authfoundation.credential.kmp.TokenCredentialManager] to manage credentials, and
+ * [com.okta.authfoundation.credential.kmp.Credential] for the resulting immutable snapshots.
  */
+@Deprecated(
+    message =
+        "Credential is deprecated in favor of the KMP variant, which works on Android and JVM. Use " +
+            "com.okta.authfoundation.credential.kmp.TokenCredentialManager to manage credentials, and " +
+            "com.okta.authfoundation.credential.kmp.Credential for the resulting immutable snapshots. " +
+            "This class will be removed in a future major release.",
+    level = DeprecationLevel.WARNING
+)
 class Credential internal constructor(
     token: Token,
     internal val client: OAuth2Client = OAuth2Client.createFromConfiguration(token.oidcConfiguration),
@@ -533,6 +545,11 @@ class Credential internal constructor(
      * Returns the scopes associated with the associated [Token] if present, otherwise the default scopes associated with the [OAuth2Client].
      */
     fun scope(): String = token.scope ?: client.configuration.defaultScope
+
+    /**
+     * Returns the scopes associated with the associated [Token] if present, otherwise the default scopes associated with the [OAuth2Client], as a list.
+     */
+    fun scopes(): List<String> = scope().split(" ").filter { it.isNotBlank() }
 
     /**
      * Retrieve the [Jwt] associated with the [Token.idToken] field.

--- a/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/credential/CredentialDataSource.kt
+++ b/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/credential/CredentialDataSource.kt
@@ -26,6 +26,13 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import java.util.Collections
 
+@Deprecated(
+    message =
+        "CredentialDataSource is deprecated in favor of com.okta.authfoundation.credential.kmp.CredentialDataSource, " +
+            "used internally by com.okta.authfoundation.credential.kmp.TokenCredentialManager. This class will be " +
+            "removed in a future major release.",
+    level = DeprecationLevel.WARNING
+)
 @InternalAuthFoundationApi
 class CredentialDataSource(
     private val storage: TokenStorage,

--- a/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/credential/RoomTokenStorage.kt
+++ b/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/credential/RoomTokenStorage.kt
@@ -33,6 +33,13 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import net.zetetic.database.sqlcipher.SupportOpenHelperFactory
 
+@Deprecated(
+    message =
+        "RoomTokenStorage is deprecated in favor of com.okta.authfoundation.credential.kmp.storage.RoomTokenStorage, " +
+            "used by the KMP TokenCredentialManager. On Android, back it with AndroidTokenEncryptionHandler for " +
+            "Keystore/biometric-backed encryption. This class will be removed in a future major release.",
+    level = DeprecationLevel.WARNING
+)
 @InternalAuthFoundationApi
 class RoomTokenStorage(
     tokenDatabase: TokenDatabase,

--- a/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/credential/Token.kt
+++ b/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/credential/Token.kt
@@ -30,7 +30,17 @@ import java.util.Objects
 
 /**
  * Token information representing a user's access to a resource server, including access token, refresh token, and other related information.
+ *
+ * @deprecated Token is deprecated in favor of [com.okta.authfoundation.client.TokenInfo] (KMP) /
+ * [com.okta.authfoundation.credential.kmp.TokenData], used by the KMP OAuth2Client and TokenCredentialManager.
  */
+@Deprecated(
+    message =
+        "Token is deprecated in favor of com.okta.authfoundation.client.TokenInfo (KMP) / " +
+            "com.okta.authfoundation.credential.kmp.TokenData, used by the KMP OAuth2Client and " +
+            "TokenCredentialManager. This class will be removed in a future major release.",
+    level = DeprecationLevel.WARNING
+)
 @Serializable
 class Token @OptIn(ExperimentalSerializationApi::class) private constructor(
     override val id: String,

--- a/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/credential/TokenEncryptionHandler.kt
+++ b/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/credential/TokenEncryptionHandler.kt
@@ -19,12 +19,12 @@ import android.os.Build
 import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyPermanentlyInvalidatedException
 import android.security.keystore.KeyProperties
-import android.util.Base64
 import androidx.biometric.BiometricPrompt
 import com.okta.authfoundation.AuthFoundationDefaults
 import com.okta.authfoundation.InternalAuthFoundationApi
 import com.okta.authfoundation.client.OidcConfiguration
 import com.okta.authfoundation.credential.TokenEncryptionHandler.Companion.isSyncDecryptionContext
+import com.okta.authfoundation.credential.kmp.KeystoreEnvelopeCrypto
 import com.okta.authfoundation.util.AndroidKeystoreUtil
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -34,10 +34,6 @@ import java.security.KeyPairGenerator
 import java.security.KeyStore
 import java.security.spec.X509EncodedKeySpec
 import javax.crypto.Cipher
-import javax.crypto.KeyGenerator
-import javax.crypto.SecretKey
-import javax.crypto.spec.GCMParameterSpec
-import javax.crypto.spec.SecretKeySpec
 
 /**
  * Interface for defining how [Token]s are encrypted before storing in [RoomTokenStorage], the default implementation of [TokenStorage].
@@ -131,12 +127,6 @@ class DefaultTokenEncryptionHandler(
     internal val keyStore: KeyStore = AndroidKeystoreUtil.keyStore,
     private val keyPairGenerator: KeyPairGenerator = AndroidKeystoreUtil.getRsaKeyPairGenerator(),
 ) : TokenEncryptionHandler {
-    private val aesKeyGenerator =
-        KeyGenerator.getInstance("AES").apply {
-            // Generate 256-bit AES keys for encryption
-            init(256)
-        }
-
     override fun generateKey(security: Credential.Security) {
         if (keyStore.containsAlias(security.keyAlias)) return
 
@@ -211,27 +201,11 @@ class DefaultTokenEncryptionHandler(
             .getInstance(publicRsaKey.algorithm)
             .generatePublic(X509EncodedKeySpec(publicRsaKey.encoded))
 
-        val aesKey = aesKeyGenerator.generateKey()
-        val encryptionExtras = mutableMapOf<String, String>()
-
         val serializedToken =
             OidcConfiguration.defaultJson().encodeToString(Token.serializer(), token)
-        val aesCipher = getAesCipher().apply { init(Cipher.ENCRYPT_MODE, aesKey) }
-        val encryptedToken = aesCipher.doFinal(serializedToken.toByteArray())
+        val envelope = KeystoreEnvelopeCrypto.encrypt(serializedToken.toByteArray(), publicRsaKey)
 
-        val rsaCipher = getRsaCipher().apply { init(Cipher.ENCRYPT_MODE, publicRsaKey) }
-        val aesKeyMaterial =
-            (
-                Base64.encodeToString(
-                    aesKey.encoded,
-                    Base64.NO_WRAP
-                ) + BASE64_SEPARATOR + Base64.encodeToString(aesCipher.iv, Base64.NO_WRAP)
-            ).toByteArray()
-        val encryptedAesKeyMaterial = rsaCipher.doFinal(aesKeyMaterial)
-        encryptionExtras[ENCRYPTED_AES_KEY_MATERIAL] =
-            Base64.encodeToString(encryptedAesKeyMaterial, Base64.NO_WRAP)
-
-        return TokenEncryptionHandler.EncryptionResult(encryptedToken, encryptionExtras.toMap())
+        return TokenEncryptionHandler.EncryptionResult(envelope.ciphertext, envelope.extras)
     }
 
     override suspend fun decrypt(
@@ -240,109 +214,62 @@ class DefaultTokenEncryptionHandler(
         security: Credential.Security,
         promptInfo: BiometricPrompt.PromptInfo?,
     ): Token {
-        return when (security) {
-            is Credential.BiometricSecurity -> {
-                if (promptInfo == null) {
-                    throw IllegalArgumentException(BIO_TOKEN_NO_PROMPT_INFO_ERROR)
-                }
-
-                try {
-                    /*
-                    Try decrypting without biometrics for the following:
-                    1. User might have already authenticated within a non-zero userAuthenticationTimeout during another call.
-                    2. We might catch KeyPermanentlyInvalidatedException
-                     */
-                    return rsaDecrypt(encryptedToken, encryptionExtras, security)
-                } catch (ex: KeyPermanentlyInvalidatedException) {
-                    // This key is no longer valid and the caller should delete all Token entries using this key
-                    keyStore.deleteEntry(security.keyAlias)
-                    throw ex
-                } catch (ex: GeneralSecurityException) {
-                    // Do nothing. We will try using Biometrics after this
-                }
-
-                if (isSyncDecryptionContext) {
-                    throw BiometricInvocationException("Attempted fetching Biometric Token from sync context.")
-                }
-                val authenticator = AndroidBiometricAuthenticator(promptInfo, keyStore)
-                if (security.userAuthenticationTimeout == 0) { // auth-per-use key
-                    internalDecrypt(encryptedToken, encryptionExtras) { encryptedAesKey ->
-                        authenticator.decrypt(encryptedAesKey, security.keyAlias).getOrThrow()
+        val decryptedBytes =
+            when (security) {
+                is Credential.BiometricSecurity -> {
+                    if (promptInfo == null) {
+                        throw IllegalArgumentException(BIO_TOKEN_NO_PROMPT_INFO_ERROR)
                     }
-                } else {
-                    authenticator.unlock().getOrThrow()
+
+                    try {
+                        /*
+                        Try decrypting without biometrics for the following:
+                        1. User might have already authenticated within a non-zero userAuthenticationTimeout during another call.
+                        2. We might catch KeyPermanentlyInvalidatedException
+                         */
+                        rsaDecrypt(encryptedToken, encryptionExtras, security)
+                    } catch (ex: KeyPermanentlyInvalidatedException) {
+                        // This key is no longer valid and the caller should delete all Token entries using this key
+                        keyStore.deleteEntry(security.keyAlias)
+                        throw ex
+                    } catch (ex: GeneralSecurityException) {
+                        if (isSyncDecryptionContext) {
+                            throw BiometricInvocationException("Attempted fetching Biometric Token from sync context.")
+                        }
+                        val authenticator = AndroidBiometricAuthenticator(promptInfo, keyStore)
+                        if (security.userAuthenticationTimeout == 0) { // auth-per-use key
+                            KeystoreEnvelopeCrypto.decrypt(encryptedToken, encryptionExtras) { encryptedAesKey ->
+                                authenticator.decrypt(encryptedAesKey, security.keyAlias).getOrThrow()
+                            }
+                        } else {
+                            authenticator.unlock().getOrThrow()
+                            rsaDecrypt(encryptedToken, encryptionExtras, security)
+                        }
+                    }
+                }
+
+                else -> {
                     rsaDecrypt(encryptedToken, encryptionExtras, security)
                 }
             }
-
-            else -> {
-                rsaDecrypt(encryptedToken, encryptionExtras, security)
-            }
-        }
+        return OidcConfiguration
+            .defaultJson()
+            .decodeFromString(Token.serializer(), decryptedBytes.decodeToString())
     }
 
     private suspend fun rsaDecrypt(
         encryptedToken: ByteArray,
         encryptionExtras: Map<String, String>,
         security: Credential.Security,
-    ): Token {
+    ): ByteArray {
         val privateRsaKey = keyStore.getKey(security.keyAlias, null)
-        val rsaCipher = getRsaCipher().apply { init(Cipher.DECRYPT_MODE, privateRsaKey) }
-        return internalDecrypt(encryptedToken, encryptionExtras) { encryptedAesKey ->
-            rsaCipher.doFinal(encryptedAesKey)
+        return KeystoreEnvelopeCrypto.decrypt(encryptedToken, encryptionExtras) { encryptedAesKey ->
+            KeystoreEnvelopeCrypto.getRsaCipher().apply { init(Cipher.DECRYPT_MODE, privateRsaKey) }.doFinal(encryptedAesKey)
         }
     }
 
-    private suspend fun internalDecrypt(
-        encryptedToken: ByteArray,
-        encryptionExtras: Map<String, String>,
-        rsaDecryptFunc: suspend (encryptedAesKey: ByteArray) -> ByteArray,
-    ): Token {
-        val encryptedAesKeyMaterial =
-            Base64.decode(encryptionExtras[ENCRYPTED_AES_KEY_MATERIAL], Base64.NO_WRAP)
-        val aesKeyMaterial =
-            rsaDecryptFunc(encryptedAesKeyMaterial).decodeToString().split(
-                BASE64_SEPARATOR,
-                limit = 2
-            )
-        val encodedAesKey = Base64.decode(aesKeyMaterial[0], Base64.NO_WRAP)
-        val aesIv = Base64.decode(aesKeyMaterial[1], Base64.NO_WRAP)
-        val aesKey = SecretKeySpec(encodedAesKey, "AES") as SecretKey
-
-        val aesCipher =
-            getAesCipher().apply {
-                init(
-                    Cipher.DECRYPT_MODE,
-                    aesKey,
-                    GCMParameterSpec(GCM_TAG_LENGTH_BITS, aesIv)
-                )
-            }
-        val decryptedToken = aesCipher.doFinal(encryptedToken)
-        val serializedToken = decryptedToken.decodeToString()
-        return OidcConfiguration
-            .defaultJson()
-            .decodeFromString(Token.serializer(), serializedToken)
-    }
-
     internal companion object {
-        internal const val ENCRYPTED_AES_KEY_MATERIAL = "ENCRYPTED_AES_KEY_MATERIAL"
-        internal const val BASE64_SEPARATOR = ","
         internal const val BIO_TOKEN_NO_PROMPT_INFO_ERROR =
             "promptInfo is required for decrypting biometric tokens"
-        internal const val GCM_TAG_LENGTH_BITS = 128
-
-        internal fun getAesCipher(): Cipher =
-            Cipher.getInstance(
-                KeyProperties.KEY_ALGORITHM_AES + "/" +
-                    KeyProperties.BLOCK_MODE_GCM + "/" +
-                    KeyProperties.ENCRYPTION_PADDING_NONE
-            )
-
-        internal fun getRsaCipher(): Cipher =
-            Cipher.getInstance(
-                KeyProperties.KEY_ALGORITHM_RSA + "/" +
-                    KeyProperties.BLOCK_MODE_ECB + "/" +
-                    KeyProperties.ENCRYPTION_PADDING_RSA_OAEP
-            )
     }
 }

--- a/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/credential/TokenStorage.kt
+++ b/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/credential/TokenStorage.kt
@@ -24,7 +24,17 @@ import com.okta.authfoundation.AuthFoundationDefaults
  * A default implementation is provided, but for advanced use-cases, you may implement this protocol yourself and pass an instance to [AuthFoundationDefaults.tokenStorageFactory].
  *
  * Warning: When implementing a custom [TokenStorage] class, it's vitally important that you do not directly invoke any of these methods yourself. These methods are intended to be called on-demand by the other AuthFoundation classes, and the behavior is undefined if these methods are called directly by the developer.
+ *
+ * @deprecated TokenStorage is deprecated in favor of [com.okta.authfoundation.credential.kmp.TokenStorage],
+ * used by the KMP TokenCredentialManager/RoomTokenStorage.
  */
+@Deprecated(
+    message =
+        "TokenStorage is deprecated in favor of com.okta.authfoundation.credential.kmp.TokenStorage, used by " +
+            "the KMP TokenCredentialManager/RoomTokenStorage. This interface will be removed in a future " +
+            "major release.",
+    level = DeprecationLevel.WARNING
+)
 interface TokenStorage {
     /**
      * @return All token IDs.

--- a/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/credential/kmp/AndroidTokenEncryptionHandler.kt
+++ b/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/credential/kmp/AndroidTokenEncryptionHandler.kt
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.credential.kmp
+
+import android.os.Build
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyPermanentlyInvalidatedException
+import android.security.keystore.KeyProperties
+import androidx.biometric.BiometricPrompt
+import com.okta.authfoundation.InternalAuthFoundationApi
+import com.okta.authfoundation.credential.AndroidBiometricAuthenticator
+import com.okta.authfoundation.util.AndroidKeystoreUtil
+import java.security.GeneralSecurityException
+import java.security.KeyFactory
+import java.security.KeyPairGenerator
+import java.security.KeyStore
+import java.security.spec.X509EncodedKeySpec
+import javax.crypto.Cipher
+
+/**
+ * Android [TokenEncryptionHandler] backed by the Android Keystore, with optional biometric gating.
+ *
+ * A single instance encrypts with one fixed policy chosen at construction — either a plain
+ * Keystore-resident RSA/AES envelope ([requireBiometric] = false), or the same envelope protected by a
+ * biometric-gated key ([requireBiometric] = true). This mirrors the JVM `JceTokenEncryptionHandler`'s
+ * "one strategy per instance" model. For per-credential mixed security tiers (some biometric, some not),
+ * construct multiple [RoomTokenStorage][com.okta.authfoundation.credential.kmp.storage.RoomTokenStorage]
+ * instances with different [keyAlias] values.
+ *
+ * [promptInfo] must be non-null before a [decrypt] call is attempted when [requireBiometric] is true, or
+ * that call fails with [IllegalArgumentException]. If different operations need different prompt text,
+ * construct separate [RoomTokenStorage][com.okta.authfoundation.credential.kmp.storage.RoomTokenStorage]
+ * instances (see [keyAlias] above) rather than mutating this instance — neither [TokenStorage.getToken] nor
+ * [TokenEncryptionHandler.decrypt] take a per-call prompt, so a single instance can only ever show one
+ * prompt anyway.
+ *
+ * @param keyAlias the Android Keystore alias used for this handler's RSA key pair.
+ * @param requireBiometric when true, a biometric (or device credential, depending on Keystore capability)
+ *   challenge is required to decrypt.
+ * @param userAuthenticationTimeout seconds after a successful biometric challenge during which decryption
+ *   may proceed without re-prompting; `0` means "auth-per-use" (every decrypt shows the prompt). Ignored
+ *   when [requireBiometric] is false.
+ * @param promptInfo the [BiometricPrompt.PromptInfo] to display for biometric challenges. Required
+ *   (non-null) when [requireBiometric] is true.
+ * @param keyStore the [KeyStore] used to store/retrieve the RSA key pair.
+ * @param keyPairGenerator the generator used to create the RSA key pair on first use.
+ */
+@OptIn(InternalAuthFoundationApi::class)
+class AndroidTokenEncryptionHandler(
+    private val keyAlias: String = DEFAULT_KEY_ALIAS,
+    private val requireBiometric: Boolean = false,
+    private val userAuthenticationTimeout: Int = 5,
+    private val promptInfo: BiometricPrompt.PromptInfo? = null,
+    internal val keyStore: KeyStore = AndroidKeystoreUtil.keyStore,
+    private val keyPairGenerator: KeyPairGenerator = AndroidKeystoreUtil.getRsaKeyPairGenerator(),
+) : TokenEncryptionHandler {
+    private fun ensureKeyExists() {
+        if (keyStore.containsAlias(keyAlias)) return
+
+        val specBuilder =
+            KeyGenParameterSpec
+                .Builder(keyAlias, KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT)
+                .setBlockModes(KeyProperties.BLOCK_MODE_ECB)
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_RSA_OAEP)
+                .setKeySize(2048)
+                .setDigests(
+                    KeyProperties.DIGEST_SHA1,
+                    KeyProperties.DIGEST_SHA256,
+                    KeyProperties.DIGEST_SHA512
+                )
+
+        val spec =
+            if (!requireBiometric) {
+                specBuilder.setUserAuthenticationRequired(false).build()
+            } else {
+                specBuilder
+                    .apply {
+                        setUserAuthenticationRequired(true)
+                        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.R) {
+                            setUserAuthenticationParameters(
+                                userAuthenticationTimeout,
+                                KeyProperties.AUTH_BIOMETRIC_STRONG
+                            )
+                        } else {
+                            // Setting -1 timeout sets strong biometric encryption in Android 10 and below;
+                            // it cannot be set to a custom userAuthenticationTimeout on those versions.
+                            setUserAuthenticationValidityDurationSeconds(-1)
+                        }
+                    }.build()
+            }
+
+        keyPairGenerator.initialize(spec)
+        keyPairGenerator.generateKeyPair()
+    }
+
+    override suspend fun encrypt(plaintext: ByteArray): EncryptionResult {
+        ensureKeyExists()
+        val publicRsaKey =
+            keyStore.getCertificate(keyAlias)?.publicKey
+                ?: throw KeyPermanentlyInvalidatedException("No public key found for alias $keyAlias")
+
+        // workaround for using public key from
+        // https://developer.android.com/reference/android/security/keystore/KeyGenParameterSpec.html#known-issues
+        KeyFactory
+            .getInstance(publicRsaKey.algorithm)
+            .generatePublic(X509EncodedKeySpec(publicRsaKey.encoded))
+
+        val envelope = KeystoreEnvelopeCrypto.encrypt(plaintext, publicRsaKey)
+        return EncryptionResult(envelope.ciphertext, envelope.extras)
+    }
+
+    override suspend fun decrypt(
+        ciphertext: ByteArray,
+        encryptionExtras: Map<String, String>,
+    ): ByteArray =
+        try {
+            if (!requireBiometric) {
+                plainDecrypt(ciphertext, encryptionExtras)
+            } else {
+                try {
+                    // The key may still be usable without a fresh challenge (non-zero userAuthenticationTimeout
+                    // window still open from a prior call).
+                    plainDecrypt(ciphertext, encryptionExtras)
+                } catch (ex: KeyPermanentlyInvalidatedException) {
+                    throw ex
+                } catch (ex: GeneralSecurityException) {
+                    biometricDecrypt(ciphertext, encryptionExtras)
+                }
+            }
+        } catch (ex: KeyPermanentlyInvalidatedException) {
+            keyStore.deleteEntry(keyAlias)
+            throw TokenEncryptionKeyInvalidatedException(keyAlias)
+        }
+
+    private suspend fun plainDecrypt(
+        ciphertext: ByteArray,
+        encryptionExtras: Map<String, String>,
+    ): ByteArray {
+        val privateRsaKey = keyStore.getKey(keyAlias, null)
+        return KeystoreEnvelopeCrypto.decrypt(ciphertext, encryptionExtras) { encryptedAesKeyMaterial ->
+            KeystoreEnvelopeCrypto.getRsaCipher().apply { init(Cipher.DECRYPT_MODE, privateRsaKey) }.doFinal(encryptedAesKeyMaterial)
+        }
+    }
+
+    private suspend fun biometricDecrypt(
+        ciphertext: ByteArray,
+        encryptionExtras: Map<String, String>,
+    ): ByteArray {
+        val prompt =
+            promptInfo
+                ?: throw IllegalArgumentException("promptInfo must be set before decrypting a biometric-protected token.")
+        val authenticator = AndroidBiometricAuthenticator(prompt, keyStore)
+
+        return if (userAuthenticationTimeout == 0) { // auth-per-use key
+            KeystoreEnvelopeCrypto.decrypt(ciphertext, encryptionExtras) { encryptedAesKeyMaterial ->
+                authenticator.decrypt(encryptedAesKeyMaterial, keyAlias).getOrThrow()
+            }
+        } else {
+            authenticator.unlock().getOrThrow()
+            plainDecrypt(ciphertext, encryptionExtras)
+        }
+    }
+
+    companion object {
+        const val DEFAULT_KEY_ALIAS = "com.okta.authfoundation.credential.kmp.AndroidTokenEncryptionHandler"
+    }
+}

--- a/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/credential/kmp/KeystoreEnvelopeCrypto.kt
+++ b/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/credential/kmp/KeystoreEnvelopeCrypto.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.credential.kmp
+
+import android.security.keystore.KeyProperties
+import android.util.Base64
+import java.security.PublicKey
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * Shared RSA-envelope/AES-GCM primitives used by both the legacy Android `DefaultTokenEncryptionHandler`
+ * and [AndroidTokenEncryptionHandler]. A fresh AES-256 key encrypts the plaintext; that AES key (plus its
+ * GCM IV) is itself wrapped with an Android Keystore RSA key, so decryption always requires access to the
+ * Keystore-resident private key (and, for biometric-gated keys, a successful biometric challenge).
+ */
+internal object KeystoreEnvelopeCrypto {
+    internal const val ENCRYPTED_AES_KEY_MATERIAL = "ENCRYPTED_AES_KEY_MATERIAL"
+    internal const val BASE64_SEPARATOR = ","
+    internal const val GCM_TAG_LENGTH_BITS = 128
+
+    internal fun getAesCipher(): Cipher =
+        Cipher.getInstance(
+            KeyProperties.KEY_ALGORITHM_AES + "/" +
+                KeyProperties.BLOCK_MODE_GCM + "/" +
+                KeyProperties.ENCRYPTION_PADDING_NONE
+        )
+
+    internal fun getRsaCipher(): Cipher =
+        Cipher.getInstance(
+            KeyProperties.KEY_ALGORITHM_RSA + "/" +
+                KeyProperties.BLOCK_MODE_ECB + "/" +
+                KeyProperties.ENCRYPTION_PADDING_RSA_OAEP
+        )
+
+    /** Result of [encrypt]: the AES-GCM ciphertext, plus the RSA-wrapped AES key material as extras. */
+    internal class Envelope(
+        val ciphertext: ByteArray,
+        val extras: Map<String, String>,
+    )
+
+    /**
+     * Encrypts [plaintext] with a fresh AES-256-GCM key, then wraps that key (and its IV) with
+     * [publicRsaKey] using RSA-OAEP so only the matching Keystore private key can unwrap it.
+     */
+    internal fun encrypt(
+        plaintext: ByteArray,
+        publicRsaKey: PublicKey,
+    ): Envelope {
+        val aesKey = KeyGenerator.getInstance("AES").apply { init(256) }.generateKey()
+        val aesCipher = getAesCipher().apply { init(Cipher.ENCRYPT_MODE, aesKey) }
+        val ciphertext = aesCipher.doFinal(plaintext)
+
+        val aesKeyMaterial =
+            (
+                Base64.encodeToString(aesKey.encoded, Base64.NO_WRAP) +
+                    BASE64_SEPARATOR +
+                    Base64.encodeToString(aesCipher.iv, Base64.NO_WRAP)
+            ).toByteArray()
+        val rsaCipher = getRsaCipher().apply { init(Cipher.ENCRYPT_MODE, publicRsaKey) }
+        val encryptedAesKeyMaterial = rsaCipher.doFinal(aesKeyMaterial)
+
+        return Envelope(
+            ciphertext,
+            mapOf(ENCRYPTED_AES_KEY_MATERIAL to Base64.encodeToString(encryptedAesKeyMaterial, Base64.NO_WRAP))
+        )
+    }
+
+    /**
+     * Decrypts [ciphertext] previously produced by [encrypt]. [unwrapAesKeyMaterial] is handed the
+     * RSA-encrypted AES key material extracted from [encryptionExtras] and must return it decrypted —
+     * callers choose how the RSA unwrap happens (plain Keystore private key, or biometric-gated).
+     */
+    internal suspend fun decrypt(
+        ciphertext: ByteArray,
+        encryptionExtras: Map<String, String>,
+        unwrapAesKeyMaterial: suspend (encryptedAesKeyMaterial: ByteArray) -> ByteArray,
+    ): ByteArray {
+        val encryptedAesKeyMaterial = Base64.decode(encryptionExtras[ENCRYPTED_AES_KEY_MATERIAL], Base64.NO_WRAP)
+        val aesKeyMaterial = unwrapAesKeyMaterial(encryptedAesKeyMaterial)
+        val parts = aesKeyMaterial.decodeToString().split(BASE64_SEPARATOR, limit = 2)
+        val aesKey = SecretKeySpec(Base64.decode(parts[0], Base64.NO_WRAP), "AES")
+        val iv = Base64.decode(parts[1], Base64.NO_WRAP)
+
+        val aesCipher =
+            getAesCipher().apply {
+                init(Cipher.DECRYPT_MODE, aesKey, GCMParameterSpec(GCM_TAG_LENGTH_BITS, iv))
+            }
+        return aesCipher.doFinal(ciphertext)
+    }
+}

--- a/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/credential/kmp/storage/AndroidTokenDatabaseFactory.kt
+++ b/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/credential/kmp/storage/AndroidTokenDatabaseFactory.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.credential.kmp.storage
+
+import android.content.Context
+import androidx.biometric.BiometricPrompt
+import androidx.room.Room
+import androidx.sqlite.driver.bundled.BundledSQLiteDriver
+import com.okta.authfoundation.client.OAuth2ClientConfiguration
+import com.okta.authfoundation.credential.kmp.AndroidTokenEncryptionHandler
+import kotlinx.coroutines.Dispatchers
+
+/**
+ * Creates a [TokenDatabase] for Android applications, backed by Room's bundled SQLite driver.
+ *
+ * Unlike the legacy SQLCipher-backed `RoomTokenStorage`, this database file itself is not whole-database
+ * encrypted — only the access-token column is encrypted, via whichever [com.okta.authfoundation.credential.kmp.TokenEncryptionHandler]
+ * is passed to [RoomTokenStorage] (see [createEncryptedTokenStorage]).
+ *
+ * @param context the Android application context.
+ * @param dbName the Room database file name. Defaults to [TokenDatabase.DB_NAME].
+ * @return a configured [TokenDatabase] instance.
+ */
+fun createTokenDatabase(
+    context: Context,
+    dbName: String = TokenDatabase.DB_NAME,
+): TokenDatabase =
+    Room
+        .databaseBuilder<TokenDatabase>(context = context.applicationContext, name = dbName)
+        .setDriver(BundledSQLiteDriver())
+        .setQueryCoroutineContext(Dispatchers.IO)
+        .build()
+
+/**
+ * Creates a [RoomTokenStorage] for Android applications, encrypting the access token via
+ * [AndroidTokenEncryptionHandler] (Android Keystore, with optional biometric gating).
+ *
+ * @param context the Android application context.
+ * @param configuration the [OAuth2ClientConfiguration] used to reconstruct tokens.
+ * @param keyAlias the Android Keystore alias for the encryption key. Defaults to [AndroidTokenEncryptionHandler.DEFAULT_KEY_ALIAS].
+ * @param requireBiometric when true, decrypting a stored token requires a biometric (or device credential)
+ *   challenge. See [AndroidTokenEncryptionHandler].
+ * @param userAuthenticationTimeout seconds after a successful biometric challenge during which decryption
+ *   may proceed without re-prompting; `0` means "auth-per-use". Ignored when [requireBiometric] is false.
+ * @param promptInfo the [BiometricPrompt.PromptInfo] to display for biometric challenges. Required
+ *   (non-null) when [requireBiometric] is true — see [AndroidTokenEncryptionHandler].
+ * @param dbName the Room database file name. Defaults to [TokenDatabase.DB_NAME].
+ * @return a configured [RoomTokenStorage] instance with encryption enabled.
+ */
+fun createEncryptedTokenStorage(
+    context: Context,
+    configuration: OAuth2ClientConfiguration,
+    keyAlias: String = AndroidTokenEncryptionHandler.DEFAULT_KEY_ALIAS,
+    requireBiometric: Boolean = false,
+    userAuthenticationTimeout: Int = 5,
+    promptInfo: BiometricPrompt.PromptInfo? = null,
+    dbName: String = TokenDatabase.DB_NAME,
+): RoomTokenStorage {
+    val database = createTokenDatabase(context, dbName)
+    val encryptionHandler =
+        AndroidTokenEncryptionHandler(
+            keyAlias = keyAlias,
+            requireBiometric = requireBiometric,
+            userAuthenticationTimeout = userAuthenticationTimeout,
+            promptInfo = promptInfo
+        )
+    return RoomTokenStorage(database, encryptionHandler, configuration)
+}

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/credential/kmp/BiometricKeyInvalidatedException.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/credential/kmp/BiometricKeyInvalidatedException.kt
@@ -23,13 +23,19 @@ package com.okta.authfoundation.credential.kmp
  * [TokenStorage.getToken] instead of the platform-specific
  * `KeyPermanentlyInvalidatedException`.
  *
- * On Android, the invalidated token is **auto-deleted by default** for backward compatibility
- * (matching the legacy `BiometricTokenInvalidatedEvent.deleteInvalidatedToken = true` default).
- * Callers can inspect [tokenId] and [keyAlias] for logging or custom logic; deletion is no
- * longer required unless the app has suppressed the legacy event's default behavior.
+ * On the legacy Android-only `com.okta.authfoundation.credential.RoomTokenStorage` path, the
+ * invalidated token is **auto-deleted by default** for backward compatibility (matching the
+ * legacy `BiometricTokenInvalidatedEvent.deleteInvalidatedToken = true` default); deletion is no
+ * longer required there unless the app has suppressed the legacy event's default behavior.
+ *
+ * On the KMP `TokenCredentialManager`/[TokenStorage] path — including
+ * [AndroidTokenEncryptionHandler][com.okta.authfoundation.credential.kmp.AndroidTokenEncryptionHandler]-backed
+ * storage — there is no auto-delete: the caller must inspect [tokenId] and explicitly remove the
+ * token from storage (e.g. via `TokenCredentialManager.get(tokenId)`'s associated credential) if
+ * that behavior is desired.
  *
  * @param tokenId the ID of the token whose biometric key was invalidated.
- * @param keyAlias the Android keystore alias of the invalidated key.
+ * @param keyAlias the platform-specific alias of the invalidated key.
  */
 class BiometricKeyInvalidatedException(
     val tokenId: String,

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/credential/kmp/Credential.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/credential/kmp/Credential.kt
@@ -209,4 +209,7 @@ interface Credential : CredentialIdentifier {
 
     /** Returns the scopes associated with the token, or the client's default scopes. Pure read. */
     fun scope(): String
+
+    /** Returns the scopes associated with the token, or the client's default scopes, as a list. Pure read. */
+    fun scopes(): List<String> = scope().split(" ").filter { it.isNotBlank() }
 }

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/credential/kmp/TokenEncryptionKeyInvalidatedException.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/credential/kmp/TokenEncryptionKeyInvalidatedException.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.authfoundation.credential.kmp
+
+/**
+ * Platform-agnostic signal thrown by a [TokenEncryptionHandler.decrypt] implementation when the key
+ * protecting the ciphertext has been permanently invalidated (for example, an Android Keystore key
+ * invalidated by new biometric enrollment).
+ *
+ * [RoomTokenStorage][com.okta.authfoundation.credential.kmp.storage.RoomTokenStorage] catches this in
+ * [TokenStorage.getToken] and rethrows it as [BiometricKeyInvalidatedException] with the token ID, so
+ * platform-specific invalidation exceptions never leak through the KMP [TokenEncryptionHandler] contract.
+ *
+ * @param keyAlias the platform-specific alias of the invalidated key.
+ */
+class TokenEncryptionKeyInvalidatedException(
+    val keyAlias: String,
+) : Exception("Encryption key invalidated (alias: $keyAlias)")

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/credential/kmp/storage/RoomTokenStorage.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/credential/kmp/storage/RoomTokenStorage.kt
@@ -18,8 +18,10 @@ package com.okta.authfoundation.credential.kmp.storage
 import com.okta.authfoundation.client.OAuth2ClientConfiguration
 import com.okta.authfoundation.client.TokenInfo
 import com.okta.authfoundation.credential.TokenMetadata
+import com.okta.authfoundation.credential.kmp.BiometricKeyInvalidatedException
 import com.okta.authfoundation.credential.kmp.TokenData
 import com.okta.authfoundation.credential.kmp.TokenEncryptionHandler
+import com.okta.authfoundation.credential.kmp.TokenEncryptionKeyInvalidatedException
 import com.okta.authfoundation.credential.kmp.TokenStorage
 
 /**
@@ -136,11 +138,15 @@ class RoomTokenStorage(
                     ?: throw NoSuchElementException("No token with id $id exists.")
 
             val decryptedAccessToken =
-                encryptionHandler
-                    .decrypt(
-                        entity.accessToken,
-                        entity.encryptionExtras
-                    ).decodeToString()
+                try {
+                    encryptionHandler
+                        .decrypt(
+                            entity.accessToken,
+                            entity.encryptionExtras
+                        ).decodeToString()
+                } catch (ex: TokenEncryptionKeyInvalidatedException) {
+                    throw BiometricKeyInvalidatedException(id, ex.keyAlias)
+                }
 
             TokenData(
                 id = entity.id,

--- a/auth-foundation/src/jvmTest/kotlin/com/okta/authfoundation/credential/kmp/storage/RoomTokenStorageTest.kt
+++ b/auth-foundation/src/jvmTest/kotlin/com/okta/authfoundation/credential/kmp/storage/RoomTokenStorageTest.kt
@@ -19,14 +19,17 @@ import androidx.room.Room
 import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import com.okta.authfoundation.credential.TestOAuth2ClientConfiguration
 import com.okta.authfoundation.credential.TokenMetadata
+import com.okta.authfoundation.credential.kmp.BiometricKeyInvalidatedException
 import com.okta.authfoundation.credential.kmp.EncryptionResult
 import com.okta.authfoundation.credential.kmp.TokenData
 import com.okta.authfoundation.credential.kmp.TokenEncryptionHandler
+import com.okta.authfoundation.credential.kmp.TokenEncryptionKeyInvalidatedException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -206,6 +209,18 @@ class RoomTokenStorageTest {
             assertTrue(storage.allIds().getOrThrow().isEmpty())
         }
 
+    @Test
+    fun getToken_ThrowsBiometricKeyInvalidatedException_WhenHandlerSignalsKeyInvalidated() =
+        runTest {
+            val invalidatingStorage = RoomTokenStorage(database, KeyInvalidatingEncryptionHandler("test-alias"), configuration)
+            invalidatingStorage.add(createTestToken(), createTestMetadata()).getOrThrow()
+
+            val result = invalidatingStorage.getToken("test-id")
+            val exception = assertFailsWith<BiometricKeyInvalidatedException> { result.getOrThrow() }
+            assertEquals("test-id", exception.tokenId)
+            assertEquals("test-alias", exception.keyAlias)
+        }
+
     private class PassthroughEncryptionHandler : TokenEncryptionHandler {
         override suspend fun encrypt(plaintext: ByteArray): EncryptionResult = EncryptionResult(ciphertext = plaintext)
 
@@ -224,5 +239,17 @@ class RoomTokenStorageTest {
             ciphertext: ByteArray,
             encryptionExtras: Map<String, String>,
         ): ByteArray = ciphertext.map { (it.toInt() xor key.toInt()).toByte() }.toByteArray()
+    }
+
+    /** Simulates a platform [TokenEncryptionHandler] whose key was permanently invalidated. */
+    private class KeyInvalidatingEncryptionHandler(
+        private val keyAlias: String,
+    ) : TokenEncryptionHandler {
+        override suspend fun encrypt(plaintext: ByteArray): EncryptionResult = EncryptionResult(ciphertext = plaintext)
+
+        override suspend fun decrypt(
+            ciphertext: ByteArray,
+            encryptionExtras: Map<String, String>,
+        ): ByteArray = throw TokenEncryptionKeyInvalidatedException(keyAlias)
     }
 }

--- a/oauth2/api/jvm/oauth2.api
+++ b/oauth2/api/jvm/oauth2.api
@@ -2,7 +2,9 @@ public abstract interface class com/okta/oauth2/kmp/AuthorizationCodeFlow {
 	public static final field Companion Lcom/okta/oauth2/kmp/AuthorizationCodeFlow$Companion;
 	public abstract fun resume-0E7RQCE (Ljava/lang/String;Lcom/okta/oauth2/kmp/AuthorizationCodeFlowContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun start-BWLJW6A (Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun start-BWLJW6A (Ljava/lang/String;Ljava/util/Map;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun start-BWLJW6A$default (Lcom/okta/oauth2/kmp/AuthorizationCodeFlow;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun start-BWLJW6A$default (Lcom/okta/oauth2/kmp/AuthorizationCodeFlow;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class com/okta/oauth2/kmp/AuthorizationCodeFlow$Companion {
@@ -10,7 +12,9 @@ public final class com/okta/oauth2/kmp/AuthorizationCodeFlow$Companion {
 }
 
 public final class com/okta/oauth2/kmp/AuthorizationCodeFlow$DefaultImpls {
+	public static fun start-BWLJW6A (Lcom/okta/oauth2/kmp/AuthorizationCodeFlow;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun start-BWLJW6A$default (Lcom/okta/oauth2/kmp/AuthorizationCodeFlow;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun start-BWLJW6A$default (Lcom/okta/oauth2/kmp/AuthorizationCodeFlow;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class com/okta/oauth2/kmp/AuthorizationCodeFlow$MissingResultCodeException : java/lang/Exception {
@@ -47,6 +51,7 @@ public abstract interface class com/okta/oauth2/kmp/DeviceAuthorizationFlow {
 	public static final field Companion Lcom/okta/oauth2/kmp/DeviceAuthorizationFlow$Companion;
 	public abstract fun resume-gIAlu-s (Lcom/okta/oauth2/kmp/DeviceAuthorizationFlowContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun start-gIAlu-s (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun start-gIAlu-s (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun start-gIAlu-s$default (Lcom/okta/oauth2/kmp/DeviceAuthorizationFlow;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
@@ -55,6 +60,7 @@ public final class com/okta/oauth2/kmp/DeviceAuthorizationFlow$Companion {
 }
 
 public final class com/okta/oauth2/kmp/DeviceAuthorizationFlow$DefaultImpls {
+	public static fun start-gIAlu-s (Lcom/okta/oauth2/kmp/DeviceAuthorizationFlow;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun start-gIAlu-s$default (Lcom/okta/oauth2/kmp/DeviceAuthorizationFlow;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
@@ -131,6 +137,7 @@ public final class com/okta/oauth2/kmp/RedirectEndSessionFlowContext {
 public abstract interface class com/okta/oauth2/kmp/ResourceOwnerFlow {
 	public static final field Companion Lcom/okta/oauth2/kmp/ResourceOwnerFlow$Companion;
 	public abstract fun start-BWLJW6A (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun start-BWLJW6A (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun start-BWLJW6A$default (Lcom/okta/oauth2/kmp/ResourceOwnerFlow;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
@@ -139,13 +146,16 @@ public final class com/okta/oauth2/kmp/ResourceOwnerFlow$Companion {
 }
 
 public final class com/okta/oauth2/kmp/ResourceOwnerFlow$DefaultImpls {
+	public static fun start-BWLJW6A (Lcom/okta/oauth2/kmp/ResourceOwnerFlow;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun start-BWLJW6A$default (Lcom/okta/oauth2/kmp/ResourceOwnerFlow;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public abstract interface class com/okta/oauth2/kmp/SessionTokenFlow {
 	public static final field Companion Lcom/okta/oauth2/kmp/SessionTokenFlow$Companion;
 	public abstract fun start-yxL6bBk (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun start-yxL6bBk (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun start-yxL6bBk$default (Lcom/okta/oauth2/kmp/SessionTokenFlow;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun start-yxL6bBk$default (Lcom/okta/oauth2/kmp/SessionTokenFlow;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class com/okta/oauth2/kmp/SessionTokenFlow$Companion {
@@ -153,13 +163,17 @@ public final class com/okta/oauth2/kmp/SessionTokenFlow$Companion {
 }
 
 public final class com/okta/oauth2/kmp/SessionTokenFlow$DefaultImpls {
+	public static fun start-yxL6bBk (Lcom/okta/oauth2/kmp/SessionTokenFlow;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun start-yxL6bBk$default (Lcom/okta/oauth2/kmp/SessionTokenFlow;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun start-yxL6bBk$default (Lcom/okta/oauth2/kmp/SessionTokenFlow;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public abstract interface class com/okta/oauth2/kmp/TokenExchangeFlow {
 	public static final field Companion Lcom/okta/oauth2/kmp/TokenExchangeFlow$Companion;
 	public abstract fun start-yxL6bBk (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun start-yxL6bBk (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun start-yxL6bBk$default (Lcom/okta/oauth2/kmp/TokenExchangeFlow;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun start-yxL6bBk$default (Lcom/okta/oauth2/kmp/TokenExchangeFlow;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class com/okta/oauth2/kmp/TokenExchangeFlow$Companion {
@@ -167,7 +181,9 @@ public final class com/okta/oauth2/kmp/TokenExchangeFlow$Companion {
 }
 
 public final class com/okta/oauth2/kmp/TokenExchangeFlow$DefaultImpls {
+	public static fun start-yxL6bBk (Lcom/okta/oauth2/kmp/TokenExchangeFlow;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun start-yxL6bBk$default (Lcom/okta/oauth2/kmp/TokenExchangeFlow;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun start-yxL6bBk$default (Lcom/okta/oauth2/kmp/TokenExchangeFlow;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class com/okta/oauth2/kmp/jvm/AuthorizationCodeFlow : java/io/Closeable {
@@ -177,7 +193,9 @@ public final class com/okta/oauth2/kmp/jvm/AuthorizationCodeFlow : java/io/Close
 	public final fun start (Ljava/lang/String;Lcom/okta/oauth2/kmp/BrowserRedirectHandler;)Ljava/util/concurrent/CompletableFuture;
 	public final fun start (Ljava/lang/String;Lcom/okta/oauth2/kmp/BrowserRedirectHandler;Ljava/util/Map;)Ljava/util/concurrent/CompletableFuture;
 	public final fun start (Ljava/lang/String;Lcom/okta/oauth2/kmp/BrowserRedirectHandler;Ljava/util/Map;Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
+	public final fun start (Ljava/lang/String;Lcom/okta/oauth2/kmp/BrowserRedirectHandler;Ljava/util/Map;Ljava/util/List;)Ljava/util/concurrent/CompletableFuture;
 	public static synthetic fun start$default (Lcom/okta/oauth2/kmp/jvm/AuthorizationCodeFlow;Ljava/lang/String;Lcom/okta/oauth2/kmp/BrowserRedirectHandler;Ljava/util/Map;Ljava/lang/String;ILjava/lang/Object;)Ljava/util/concurrent/CompletableFuture;
+	public static synthetic fun start$default (Lcom/okta/oauth2/kmp/jvm/AuthorizationCodeFlow;Ljava/lang/String;Lcom/okta/oauth2/kmp/BrowserRedirectHandler;Ljava/util/Map;Ljava/util/List;ILjava/lang/Object;)Ljava/util/concurrent/CompletableFuture;
 }
 
 public final class com/okta/oauth2/kmp/jvm/DeviceAuthorizationFlow : java/io/Closeable {
@@ -186,6 +204,7 @@ public final class com/okta/oauth2/kmp/jvm/DeviceAuthorizationFlow : java/io/Clo
 	public fun close ()V
 	public final fun resume (Lcom/okta/oauth2/kmp/DeviceAuthorizationFlowContext;)Ljava/util/concurrent/CompletableFuture;
 	public final fun start (Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
+	public final fun start (Ljava/util/List;)Ljava/util/concurrent/CompletableFuture;
 	public static synthetic fun start$default (Lcom/okta/oauth2/kmp/jvm/DeviceAuthorizationFlow;Ljava/lang/String;ILjava/lang/Object;)Ljava/util/concurrent/CompletableFuture;
 }
 
@@ -204,6 +223,7 @@ public final class com/okta/oauth2/kmp/jvm/ResourceOwnerFlow : java/io/Closeable
 	public fun close ()V
 	public final fun start (Ljava/lang/String;Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
 	public final fun start (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
+	public final fun start (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Ljava/util/concurrent/CompletableFuture;
 	public static synthetic fun start$default (Lcom/okta/oauth2/kmp/jvm/ResourceOwnerFlow;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ljava/util/concurrent/CompletableFuture;
 }
 
@@ -214,7 +234,9 @@ public final class com/okta/oauth2/kmp/jvm/SessionTokenFlow : java/io/Closeable 
 	public final fun start (Ljava/lang/String;Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
 	public final fun start (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Ljava/util/concurrent/CompletableFuture;
 	public final fun start (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
+	public final fun start (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;)Ljava/util/concurrent/CompletableFuture;
 	public static synthetic fun start$default (Lcom/okta/oauth2/kmp/jvm/SessionTokenFlow;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;ILjava/lang/Object;)Ljava/util/concurrent/CompletableFuture;
+	public static synthetic fun start$default (Lcom/okta/oauth2/kmp/jvm/SessionTokenFlow;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;ILjava/lang/Object;)Ljava/util/concurrent/CompletableFuture;
 }
 
 public final class com/okta/oauth2/kmp/jvm/TokenExchangeFlow : java/io/Closeable {
@@ -224,6 +246,8 @@ public final class com/okta/oauth2/kmp/jvm/TokenExchangeFlow : java/io/Closeable
 	public final fun start (Ljava/lang/String;Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
 	public final fun start (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
 	public final fun start (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
+	public final fun start (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Ljava/util/concurrent/CompletableFuture;
 	public static synthetic fun start$default (Lcom/okta/oauth2/kmp/jvm/TokenExchangeFlow;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ljava/util/concurrent/CompletableFuture;
+	public static synthetic fun start$default (Lcom/okta/oauth2/kmp/jvm/TokenExchangeFlow;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Ljava/util/concurrent/CompletableFuture;
 }
 

--- a/oauth2/api/oauth2.api
+++ b/oauth2/api/oauth2.api
@@ -5,7 +5,9 @@ public final class com/okta/oauth2/AuthorizationCodeFlow {
 	public fun <init> (Lcom/okta/authfoundation/client/OidcConfiguration;)V
 	public final fun resume (Landroid/net/Uri;Lcom/okta/oauth2/AuthorizationCodeFlow$Context;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun start (Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun start (Ljava/lang/String;Ljava/util/Map;Ljava/util/List;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun start$default (Lcom/okta/oauth2/AuthorizationCodeFlow;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun start$default (Lcom/okta/oauth2/AuthorizationCodeFlow;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class com/okta/oauth2/AuthorizationCodeFlow$Companion {
@@ -32,7 +34,9 @@ public final class com/okta/oauth2/DeviceAuthorizationFlow {
 	public fun <init> (Lcom/okta/authfoundation/client/OidcConfiguration;)V
 	public final fun resume (Lcom/okta/oauth2/DeviceAuthorizationFlow$Context;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun start (Ljava/util/Map;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun start (Ljava/util/Map;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun start$default (Lcom/okta/oauth2/DeviceAuthorizationFlow;Ljava/util/Map;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun start$default (Lcom/okta/oauth2/DeviceAuthorizationFlow;Ljava/util/Map;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class com/okta/oauth2/DeviceAuthorizationFlow$Companion {
@@ -77,6 +81,7 @@ public final class com/okta/oauth2/ResourceOwnerFlow {
 	public fun <init> (Lcom/okta/authfoundation/client/OAuth2Client;)V
 	public fun <init> (Lcom/okta/authfoundation/client/OidcConfiguration;)V
 	public final fun start (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun start (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun start$default (Lcom/okta/oauth2/ResourceOwnerFlow;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
@@ -88,7 +93,9 @@ public final class com/okta/oauth2/SessionTokenFlow {
 	public fun <init> (Lcom/okta/authfoundation/client/OAuth2Client;)V
 	public fun <init> (Lcom/okta/authfoundation/client/OidcConfiguration;)V
 	public final fun start (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun start (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun start$default (Lcom/okta/oauth2/SessionTokenFlow;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun start$default (Lcom/okta/oauth2/SessionTokenFlow;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class com/okta/oauth2/TokenExchangeFlow {
@@ -97,7 +104,9 @@ public final class com/okta/oauth2/TokenExchangeFlow {
 	public fun <init> (Lcom/okta/authfoundation/client/OAuth2Client;)V
 	public fun <init> (Lcom/okta/authfoundation/client/OidcConfiguration;)V
 	public final fun start (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun start (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun start$default (Lcom/okta/oauth2/TokenExchangeFlow;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun start$default (Lcom/okta/oauth2/TokenExchangeFlow;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class com/okta/oauth2/TokenExchangeFlow$Companion {
@@ -118,7 +127,9 @@ public abstract interface class com/okta/oauth2/kmp/AuthorizationCodeFlow {
 	public static final field Companion Lcom/okta/oauth2/kmp/AuthorizationCodeFlow$Companion;
 	public abstract fun resume-0E7RQCE (Ljava/lang/String;Lcom/okta/oauth2/kmp/AuthorizationCodeFlowContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun start-BWLJW6A (Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun start-BWLJW6A (Ljava/lang/String;Ljava/util/Map;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun start-BWLJW6A$default (Lcom/okta/oauth2/kmp/AuthorizationCodeFlow;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun start-BWLJW6A$default (Lcom/okta/oauth2/kmp/AuthorizationCodeFlow;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class com/okta/oauth2/kmp/AuthorizationCodeFlow$Companion {
@@ -126,7 +137,9 @@ public final class com/okta/oauth2/kmp/AuthorizationCodeFlow$Companion {
 }
 
 public final class com/okta/oauth2/kmp/AuthorizationCodeFlow$DefaultImpls {
+	public static fun start-BWLJW6A (Lcom/okta/oauth2/kmp/AuthorizationCodeFlow;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun start-BWLJW6A$default (Lcom/okta/oauth2/kmp/AuthorizationCodeFlow;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun start-BWLJW6A$default (Lcom/okta/oauth2/kmp/AuthorizationCodeFlow;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class com/okta/oauth2/kmp/AuthorizationCodeFlow$MissingResultCodeException : java/lang/Exception {
@@ -163,6 +176,7 @@ public abstract interface class com/okta/oauth2/kmp/DeviceAuthorizationFlow {
 	public static final field Companion Lcom/okta/oauth2/kmp/DeviceAuthorizationFlow$Companion;
 	public abstract fun resume-gIAlu-s (Lcom/okta/oauth2/kmp/DeviceAuthorizationFlowContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun start-gIAlu-s (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun start-gIAlu-s (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun start-gIAlu-s$default (Lcom/okta/oauth2/kmp/DeviceAuthorizationFlow;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
@@ -171,6 +185,7 @@ public final class com/okta/oauth2/kmp/DeviceAuthorizationFlow$Companion {
 }
 
 public final class com/okta/oauth2/kmp/DeviceAuthorizationFlow$DefaultImpls {
+	public static fun start-gIAlu-s (Lcom/okta/oauth2/kmp/DeviceAuthorizationFlow;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun start-gIAlu-s$default (Lcom/okta/oauth2/kmp/DeviceAuthorizationFlow;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
@@ -229,6 +244,7 @@ public final class com/okta/oauth2/kmp/RedirectEndSessionFlowContext {
 public abstract interface class com/okta/oauth2/kmp/ResourceOwnerFlow {
 	public static final field Companion Lcom/okta/oauth2/kmp/ResourceOwnerFlow$Companion;
 	public abstract fun start-BWLJW6A (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun start-BWLJW6A (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun start-BWLJW6A$default (Lcom/okta/oauth2/kmp/ResourceOwnerFlow;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
@@ -237,13 +253,16 @@ public final class com/okta/oauth2/kmp/ResourceOwnerFlow$Companion {
 }
 
 public final class com/okta/oauth2/kmp/ResourceOwnerFlow$DefaultImpls {
+	public static fun start-BWLJW6A (Lcom/okta/oauth2/kmp/ResourceOwnerFlow;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun start-BWLJW6A$default (Lcom/okta/oauth2/kmp/ResourceOwnerFlow;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public abstract interface class com/okta/oauth2/kmp/SessionTokenFlow {
 	public static final field Companion Lcom/okta/oauth2/kmp/SessionTokenFlow$Companion;
 	public abstract fun start-yxL6bBk (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun start-yxL6bBk (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun start-yxL6bBk$default (Lcom/okta/oauth2/kmp/SessionTokenFlow;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun start-yxL6bBk$default (Lcom/okta/oauth2/kmp/SessionTokenFlow;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class com/okta/oauth2/kmp/SessionTokenFlow$Companion {
@@ -251,13 +270,17 @@ public final class com/okta/oauth2/kmp/SessionTokenFlow$Companion {
 }
 
 public final class com/okta/oauth2/kmp/SessionTokenFlow$DefaultImpls {
+	public static fun start-yxL6bBk (Lcom/okta/oauth2/kmp/SessionTokenFlow;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun start-yxL6bBk$default (Lcom/okta/oauth2/kmp/SessionTokenFlow;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun start-yxL6bBk$default (Lcom/okta/oauth2/kmp/SessionTokenFlow;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public abstract interface class com/okta/oauth2/kmp/TokenExchangeFlow {
 	public static final field Companion Lcom/okta/oauth2/kmp/TokenExchangeFlow$Companion;
 	public abstract fun start-yxL6bBk (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun start-yxL6bBk (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun start-yxL6bBk$default (Lcom/okta/oauth2/kmp/TokenExchangeFlow;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun start-yxL6bBk$default (Lcom/okta/oauth2/kmp/TokenExchangeFlow;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class com/okta/oauth2/kmp/TokenExchangeFlow$Companion {
@@ -265,6 +288,8 @@ public final class com/okta/oauth2/kmp/TokenExchangeFlow$Companion {
 }
 
 public final class com/okta/oauth2/kmp/TokenExchangeFlow$DefaultImpls {
+	public static fun start-yxL6bBk (Lcom/okta/oauth2/kmp/TokenExchangeFlow;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun start-yxL6bBk$default (Lcom/okta/oauth2/kmp/TokenExchangeFlow;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun start-yxL6bBk$default (Lcom/okta/oauth2/kmp/TokenExchangeFlow;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 

--- a/oauth2/src/androidMain/kotlin/com/okta/oauth2/AuthorizationCodeFlow.kt
+++ b/oauth2/src/androidMain/kotlin/com/okta/oauth2/AuthorizationCodeFlow.kt
@@ -31,7 +31,19 @@ import java.util.UUID
  * [AuthorizationCodeFlow] encapsulates the behavior required to authentication using an OIDC Browser redirect flow.
  *
  * See [Authorization Code Flow documentation](https://developer.okta.com/docs/guides/implement-grant-type/authcodepkce/main/#about-the-authorization-code-grant-with-pkce)
+ *
+ * @deprecated This Android-only AuthorizationCodeFlow is deprecated in favor of the KMP variant, which works
+ * on Android and JVM. Use [com.okta.oauth2.kmp.AuthorizationCodeFlow] instead, or the higher-level
+ * [com.okta.webauthenticationui.WebAuthentication] which is already KMP-backed.
  */
+@Deprecated(
+    message =
+        "The Android-only AuthorizationCodeFlow is deprecated in favor of the KMP variant, which works on " +
+            "Android and JVM. Use com.okta.oauth2.kmp.AuthorizationCodeFlow instead, or the higher-level " +
+            "com.okta.webauthenticationui.WebAuthentication which is already KMP-backed. This class will be " +
+            "removed in a future major release.",
+    level = DeprecationLevel.WARNING
+)
 class AuthorizationCodeFlow(
     private val client: OAuth2Client,
 ) {
@@ -104,8 +116,30 @@ class AuthorizationCodeFlow(
      * @param redirectUrl the redirect URL.
      * @param extraRequestParameters the extra key value pairs to send to the authorize endpoint.
      *  See [Authorize Documentation](https://developer.okta.com/docs/reference/api/oidc/#authorize) for parameter options.
+     * @param scope the scopes to request during sign in.
+     */
+    @Suppress("DEPRECATION")
+    suspend fun start(
+        redirectUrl: String,
+        extraRequestParameters: Map<String, String> = emptyMap(),
+        scope: List<String>,
+        state: String = UUID.randomUUID().toString(),
+    ): OAuth2ClientResult<Context> = start(redirectUrl, extraRequestParameters, scope.joinToString(" "), state)
+
+    /**
+     * Initiates the OIDC Authorization Code redirect flow.
+     *
+     * See [AuthorizationCodeFlow.resume] for completing the flow.
+     *
+     * @param redirectUrl the redirect URL.
+     * @param extraRequestParameters the extra key value pairs to send to the authorize endpoint.
+     *  See [Authorize Documentation](https://developer.okta.com/docs/reference/api/oidc/#authorize) for parameter options.
      * @param scope the scopes to request during sign in. Defaults to the configured [OAuth2Client] [OidcConfiguration.defaultScope].
      */
+    @Deprecated(
+        message = "Use the overload accepting scope as a List<String> instead.",
+        replaceWith = ReplaceWith("start(redirectUrl, extraRequestParameters, scope.split(\" \"), state)")
+    )
     suspend fun start(
         redirectUrl: String,
         extraRequestParameters: Map<String, String> = emptyMap(),

--- a/oauth2/src/androidMain/kotlin/com/okta/oauth2/DeviceAuthorizationFlow.kt
+++ b/oauth2/src/androidMain/kotlin/com/okta/oauth2/DeviceAuthorizationFlow.kt
@@ -36,7 +36,17 @@ import okhttp3.Request
  * 2. A simple user code they can easily enter on that secondary device.
  *
  * Upon visiting that URL and entering in the code, the user is prompted to sign in using their standard credentials. Upon completing authentication, the device automatically signs the user in, without any direct interaction on the user's part.
+ *
+ * @deprecated This Android-only DeviceAuthorizationFlow is deprecated in favor of the KMP variant, which
+ * works on Android and JVM. Use [com.okta.oauth2.kmp.DeviceAuthorizationFlow] instead.
  */
+@Deprecated(
+    message =
+        "The Android-only DeviceAuthorizationFlow is deprecated in favor of the KMP variant, which works on " +
+            "Android and JVM. Use com.okta.oauth2.kmp.DeviceAuthorizationFlow instead. This class will be " +
+            "removed in a future major release.",
+    level = DeprecationLevel.WARNING
+)
 class DeviceAuthorizationFlow(
     private val client: OAuth2Client,
 ) {
@@ -118,8 +128,28 @@ class DeviceAuthorizationFlow(
      * @param extraRequestParameters the extra key value pairs to send to the device authorize endpoint.
      *  See [Device Authorize Documentation](https://developer.okta.com/docs/reference/api/oidc/#device-authorize) for parameter
      *  options.
+     * @param scope the scopes to request during sign in.
+     */
+    @Suppress("DEPRECATION")
+    suspend fun start(
+        extraRequestParameters: Map<String, String> = emptyMap(),
+        scope: List<String>,
+    ): OAuth2ClientResult<Context> = start(extraRequestParameters, scope.joinToString(" "))
+
+    /**
+     * Initiates a device authorization flow.
+     *
+     * See [DeviceAuthorizationFlow.resume] for completing the flow.
+     *
+     * @param extraRequestParameters the extra key value pairs to send to the device authorize endpoint.
+     *  See [Device Authorize Documentation](https://developer.okta.com/docs/reference/api/oidc/#device-authorize) for parameter
+     *  options.
      * @param scope the scopes to request during sign in. Defaults to the configured [OAuth2Client] [OidcConfiguration.defaultScope].
      */
+    @Deprecated(
+        message = "Use the overload accepting scope as a List<String> instead.",
+        replaceWith = ReplaceWith("start(extraRequestParameters, scope.split(\" \"))")
+    )
     suspend fun start(
         extraRequestParameters: Map<String, String> = emptyMap(),
         scope: String = client.configuration.defaultScope,

--- a/oauth2/src/androidMain/kotlin/com/okta/oauth2/RedirectEndSessionFlow.kt
+++ b/oauth2/src/androidMain/kotlin/com/okta/oauth2/RedirectEndSessionFlow.kt
@@ -28,7 +28,19 @@ import java.util.UUID
  * [RedirectEndSessionFlow] encapsulates the behavior required to logout using an OIDC Browser redirect flow.
  *
  * > Note: OIDC Logout terminology is nuanced, see [Logout Documentation](https://github.com/okta/okta-mobile-kotlin#logout) for additional details.
+ *
+ * @deprecated This Android-only RedirectEndSessionFlow is deprecated in favor of the KMP variant, which
+ * works on Android and JVM. Use [com.okta.oauth2.kmp.RedirectEndSessionFlow] instead, or the higher-level
+ * [com.okta.webauthenticationui.WebAuthentication.logoutOfBrowser] which is already KMP-backed.
  */
+@Deprecated(
+    message =
+        "The Android-only RedirectEndSessionFlow is deprecated in favor of the KMP variant, which works on " +
+            "Android and JVM. Use com.okta.oauth2.kmp.RedirectEndSessionFlow instead, or the higher-level " +
+            "com.okta.webauthenticationui.WebAuthentication.logoutOfBrowser which is already KMP-backed. " +
+            "This class will be removed in a future major release.",
+    level = DeprecationLevel.WARNING
+)
 class RedirectEndSessionFlow(
     private val client: OAuth2Client,
 ) {

--- a/oauth2/src/androidMain/kotlin/com/okta/oauth2/ResourceOwnerFlow.kt
+++ b/oauth2/src/androidMain/kotlin/com/okta/oauth2/ResourceOwnerFlow.kt
@@ -30,7 +30,17 @@ import okhttp3.Request
  * This simple authentication flow permits a user to authenticate using a simple username and password. As such, the configuration is straightforward.
  *
  * > Important: Resource Owner authentication does not support MFA or other more secure authentication models, and is not recommended for production applications.
+ *
+ * @deprecated This Android-only ResourceOwnerFlow is deprecated in favor of the KMP variant, which works on
+ * Android and JVM. Use [com.okta.oauth2.kmp.ResourceOwnerFlow] instead.
  */
+@Deprecated(
+    message =
+        "The Android-only ResourceOwnerFlow is deprecated in favor of the KMP variant, which works on " +
+            "Android and JVM. Use com.okta.oauth2.kmp.ResourceOwnerFlow instead. This class will be removed " +
+            "in a future major release.",
+    level = DeprecationLevel.WARNING
+)
 class ResourceOwnerFlow(
     private val client: OAuth2Client,
 ) {
@@ -57,8 +67,26 @@ class ResourceOwnerFlow(
      *
      * @param username the username
      * @param password the password
+     * @param scope the scopes to request during sign in.
+     */
+    @Suppress("DEPRECATION")
+    suspend fun start(
+        username: String,
+        password: String,
+        scope: List<String>,
+    ): OAuth2ClientResult<Token> = start(username, password, scope.joinToString(" "))
+
+    /**
+     * Initiates the Resource Owner flow.
+     *
+     * @param username the username
+     * @param password the password
      * @param scope the scopes to request during sign in. Defaults to the configured [client] [OidcConfiguration.defaultScope].
      */
+    @Deprecated(
+        message = "Use the overload accepting scope as a List<String> instead.",
+        replaceWith = ReplaceWith("start(username, password, scope.split(\" \"))")
+    )
     suspend fun start(
         username: String,
         password: String,

--- a/oauth2/src/androidMain/kotlin/com/okta/oauth2/SessionTokenFlow.kt
+++ b/oauth2/src/androidMain/kotlin/com/okta/oauth2/SessionTokenFlow.kt
@@ -26,7 +26,17 @@ import okhttp3.Request
 /**
  * [SessionTokenFlow] encapsulates the behavior required to authentication using a session token obtained from the Okta Legacy Authn
  * APIs.
+ *
+ * @deprecated This Android-only SessionTokenFlow is deprecated in favor of the KMP variant, which works on
+ * Android and JVM. Use [com.okta.oauth2.kmp.SessionTokenFlow] instead.
  */
+@Deprecated(
+    message =
+        "The Android-only SessionTokenFlow is deprecated in favor of the KMP variant, which works on " +
+            "Android and JVM. Use com.okta.oauth2.kmp.SessionTokenFlow instead. This class will be removed " +
+            "in a future major release.",
+    level = DeprecationLevel.WARNING
+)
 class SessionTokenFlow(
     private val client: OAuth2Client,
 ) {
@@ -49,8 +59,29 @@ class SessionTokenFlow(
      * @param redirectUrl the redirect URL.
      * @param extraRequestParameters the extra key value pairs to send to the authorize endpoint.
      *  See [Authorize Documentation](https://developer.okta.com/docs/reference/api/oidc/#authorize) for parameter options.
+     * @param scope the scopes to request during sign in.
+     */
+    @Suppress("DEPRECATION")
+    suspend fun start(
+        sessionToken: String,
+        redirectUrl: String,
+        extraRequestParameters: Map<String, String> = emptyMap(),
+        scope: List<String>,
+    ): OAuth2ClientResult<Token> = start(sessionToken, redirectUrl, extraRequestParameters, scope.joinToString(" "))
+
+    /**
+     * Initiates the Session Token Flow.
+     *
+     * @param sessionToken the session token obtained from Okta legacy Authn APIs.
+     * @param redirectUrl the redirect URL.
+     * @param extraRequestParameters the extra key value pairs to send to the authorize endpoint.
+     *  See [Authorize Documentation](https://developer.okta.com/docs/reference/api/oidc/#authorize) for parameter options.
      * @param scope the scopes to request during sign in. Defaults to the configured [client] [OidcConfiguration.defaultScope].
      */
+    @Deprecated(
+        message = "Use the overload accepting scope as a List<String> instead.",
+        replaceWith = ReplaceWith("start(sessionToken, redirectUrl, extraRequestParameters, scope.split(\" \"))")
+    )
     suspend fun start(
         sessionToken: String,
         redirectUrl: String,

--- a/oauth2/src/androidMain/kotlin/com/okta/oauth2/TokenExchangeFlow.kt
+++ b/oauth2/src/androidMain/kotlin/com/okta/oauth2/TokenExchangeFlow.kt
@@ -30,7 +30,17 @@ import okhttp3.Request
  * As an example, consider [SSO for Native Apps](https://developer.okta.com/docs/guides/configure-native-sso/main/#native-sso-flow) where a client exchanges the ID and the Device Secret tokens to get access to the resource.
  *
  * See the [specification](https://openid.net/specs/openid-connect-native-sso-1_0.html)
+ *
+ * @deprecated This Android-only TokenExchangeFlow is deprecated in favor of the KMP variant, which works on
+ * Android and JVM. Use [com.okta.oauth2.kmp.TokenExchangeFlow] instead.
  */
+@Deprecated(
+    message =
+        "The Android-only TokenExchangeFlow is deprecated in favor of the KMP variant, which works on " +
+            "Android and JVM. Use com.okta.oauth2.kmp.TokenExchangeFlow instead. This class will be removed " +
+            "in a future major release.",
+    level = DeprecationLevel.WARNING
+)
 class TokenExchangeFlow(
     private val client: OAuth2Client,
 ) {
@@ -58,8 +68,28 @@ class TokenExchangeFlow(
      * @param idToken the id token for the user to create a new token for.
      * @param deviceSecret the [Token.deviceSecret] obtained via another authentication flow.
      * @param audience the audience of the authorization server. Defaults to `api://default`.
+     * @param scope the scopes to request during sign in.
+     */
+    @Suppress("DEPRECATION")
+    suspend fun start(
+        idToken: String,
+        deviceSecret: String,
+        audience: String = "api://default",
+        scope: List<String>,
+    ): OAuth2ClientResult<Token> = start(idToken, deviceSecret, audience, scope.joinToString(" "))
+
+    /**
+     * Initiates the Token Exchange flow.
+     *
+     * @param idToken the id token for the user to create a new token for.
+     * @param deviceSecret the [Token.deviceSecret] obtained via another authentication flow.
+     * @param audience the audience of the authorization server. Defaults to `api://default`.
      * @param scope the scopes to request during sign in. Defaults to the configured [client] [OidcConfiguration.defaultScope].
      */
+    @Deprecated(
+        message = "Use the overload accepting scope as a List<String> instead.",
+        replaceWith = ReplaceWith("start(idToken, deviceSecret, audience, scope.split(\" \"))")
+    )
     suspend fun start(
         idToken: String,
         deviceSecret: String,

--- a/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/AuthorizationCodeFlow.kt
+++ b/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/AuthorizationCodeFlow.kt
@@ -59,6 +59,20 @@ interface AuthorizationCodeFlow {
     ): Result<AuthorizationCodeFlowContext>
 
     /**
+     * Initiates the Authorization Code redirect flow.
+     *
+     * @param redirectUrl the registered redirect URI for this client.
+     * @param extraRequestParameters additional query parameters for the authorization endpoint.
+     * @param scope the scopes to request.
+     * @return a [Result] containing an [AuthorizationCodeFlowContext] with the authorization URL and state.
+     */
+    suspend fun start(
+        redirectUrl: String,
+        extraRequestParameters: Map<String, String> = emptyMap(),
+        scope: List<String>,
+    ): Result<AuthorizationCodeFlowContext> = start(redirectUrl, extraRequestParameters, scope.joinToString(" "))
+
+    /**
      * Completes the Authorization Code redirect flow by exchanging the authorization code for tokens.
      *
      * @param uri the redirect URI received from the browser after authorization.

--- a/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/DeviceAuthorizationFlow.kt
+++ b/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/DeviceAuthorizationFlow.kt
@@ -44,6 +44,16 @@ interface DeviceAuthorizationFlow {
     suspend fun start(scope: String? = null): Result<DeviceAuthorizationFlowContext>
 
     /**
+     * Initiates the device authorization flow.
+     *
+     * @param scope the OAuth2 scopes to request.
+     * @return [Result.success] with a [DeviceAuthorizationFlowContext], or [Result.failure] with:
+     * - [com.okta.authfoundation.client.OAuth2ClientResult.Error.OidcEndpointsNotAvailableException] if the device authorization endpoint is unavailable.
+     * - Other exceptions for network or parse failures.
+     */
+    suspend fun start(scope: List<String>): Result<DeviceAuthorizationFlowContext> = start(scope.joinToString(" "))
+
+    /**
      * Polls the token endpoint until the user authorizes or the session expires.
      *
      * Should be called repeatedly after [start]. Retries automatically on

--- a/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/ResourceOwnerFlow.kt
+++ b/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/ResourceOwnerFlow.kt
@@ -53,6 +53,21 @@ interface ResourceOwnerFlow {
         scope: String? = null,
     ): Result<TokenInfo>
 
+    /**
+     * Initiates the Resource Owner flow by exchanging credentials for tokens.
+     *
+     * @param username the user's username or email.
+     * @param password the user's password.
+     * @param scope the scopes to request.
+     * @return [Result.success] with [TokenInfo] on successful authentication,
+     *   or [Result.failure] with the error.
+     */
+    suspend fun start(
+        username: String,
+        password: String,
+        scope: List<String>,
+    ): Result<TokenInfo> = start(username, password, scope.joinToString(" "))
+
     companion object {
         /**
          * Creates a [ResourceOwnerFlow] backed by the given [client].

--- a/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/SessionTokenFlow.kt
+++ b/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/SessionTokenFlow.kt
@@ -43,6 +43,22 @@ interface SessionTokenFlow {
         scope: String? = null,
     ): Result<TokenInfo>
 
+    /**
+     * Initiates the session token flow and returns a [TokenInfo] on success.
+     *
+     * @param sessionToken the session token obtained from Okta legacy Authn APIs.
+     * @param redirectUrl the redirect URL registered with the authorization server.
+     * @param extraRequestParameters additional key-value pairs appended to the authorization URL.
+     * @param scope the scopes to request.
+     * @return [Result.success] with [TokenInfo] on success, or [Result.failure] on error.
+     */
+    suspend fun start(
+        sessionToken: String,
+        redirectUrl: String,
+        extraRequestParameters: Map<String, String> = emptyMap(),
+        scope: List<String>,
+    ): Result<TokenInfo> = start(sessionToken, redirectUrl, extraRequestParameters, scope.joinToString(" "))
+
     companion object {
         /**
          * Creates a [SessionTokenFlow] backed by the given [OAuth2Client].

--- a/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/TokenExchangeFlow.kt
+++ b/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/TokenExchangeFlow.kt
@@ -49,6 +49,25 @@ interface TokenExchangeFlow {
         scope: String? = null,
     ): Result<TokenInfo>
 
+    /**
+     * Initiates the token exchange flow.
+     *
+     * @param idToken the ID token for the user.
+     * @param deviceSecret the device secret obtained from a previous authentication flow.
+     * @param audience the audience of the authorization server. Defaults to `api://default`.
+     * @param scope the OAuth2 scopes to request.
+     * @return [Result.success] with [TokenInfo] on success, or [Result.failure] with:
+     * - [com.okta.authfoundation.client.OAuth2ClientResult.Error.OidcEndpointsNotAvailableException] if endpoints are unavailable.
+     * - [com.okta.authfoundation.client.OAuth2ClientResult.Error.HttpResponseException] on server errors.
+     * - Other exceptions for network or parsing failures.
+     */
+    suspend fun start(
+        idToken: String,
+        deviceSecret: String,
+        audience: String? = null,
+        scope: List<String>,
+    ): Result<TokenInfo> = start(idToken, deviceSecret, audience, scope.joinToString(" "))
+
     companion object {
         /**
          * Creates a [TokenExchangeFlow] backed by the given [OAuth2Client].

--- a/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/jvm/AuthorizationCodeFlow.kt
+++ b/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/jvm/AuthorizationCodeFlow.kt
@@ -68,10 +68,45 @@ class AuthorizationCodeFlow(
      * @param redirectUrl the registered redirect URI for this client.
      * @param browserRedirectHandler handles opening the browser and capturing the redirect.
      * @param extraRequestParameters additional authorization endpoint parameters.
+     * @param scope the scopes to request.
+     * @return a [CompletableFuture] that completes with [TokenInfo] on success,
+     *   or completes exceptionally on failure.
+     */
+    fun start(
+        redirectUrl: String,
+        browserRedirectHandler: BrowserRedirectHandler,
+        extraRequestParameters: Map<String, String> = emptyMap(),
+        scope: List<String>,
+    ): CompletableFuture<TokenInfo> =
+        coroutineScope.future {
+            val flowContext =
+                delegate
+                    .start(
+                        redirectUrl = redirectUrl,
+                        extraRequestParameters = extraRequestParameters,
+                        scope = scope
+                    ).getOrThrow()
+            val redirectUri = browserRedirectHandler.handleRedirect(flowContext.url)
+            delegate.resume(redirectUri, flowContext).getOrThrow()
+        }
+
+    /**
+     * Performs the full Authorization Code flow asynchronously.
+     *
+     * Opens [redirectUrl] in a browser via [browserRedirectHandler], waits for the
+     * redirect callback, and exchanges the authorization code for tokens.
+     *
+     * @param redirectUrl the registered redirect URI for this client.
+     * @param browserRedirectHandler handles opening the browser and capturing the redirect.
+     * @param extraRequestParameters additional authorization endpoint parameters.
      * @param scope the scopes to request. Defaults to the client's configured default scope when null.
      * @return a [CompletableFuture] that completes with [TokenInfo] on success,
      *   or completes exceptionally on failure.
      */
+    @Deprecated(
+        message = "Use the overload accepting scope as a List<String> instead.",
+        replaceWith = ReplaceWith("start(redirectUrl, browserRedirectHandler, extraRequestParameters, scope.split(\" \"))")
+    )
     @JvmOverloads
     fun start(
         redirectUrl: String,

--- a/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/jvm/DeviceAuthorizationFlow.kt
+++ b/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/jvm/DeviceAuthorizationFlow.kt
@@ -60,10 +60,26 @@ class DeviceAuthorizationFlow(
     /**
      * Initiates the device authorization flow asynchronously.
      *
+     * @param scope the scopes to request.
+     * @return a [CompletableFuture] that completes with [DeviceAuthorizationFlowContext] on success,
+     *   or completes exceptionally on failure.
+     */
+    fun start(scope: List<String>): CompletableFuture<DeviceAuthorizationFlowContext> =
+        coroutineScope.future {
+            delegate.start(scope).getOrThrow()
+        }
+
+    /**
+     * Initiates the device authorization flow asynchronously.
+     *
      * @param scope the scopes to request. Defaults to the client's configured default scope when null.
      * @return a [CompletableFuture] that completes with [DeviceAuthorizationFlowContext] on success,
      *   or completes exceptionally on failure.
      */
+    @Deprecated(
+        message = "Use the overload accepting scope as a List<String> instead.",
+        replaceWith = ReplaceWith("start(scope.split(\" \"))")
+    )
     fun start(scope: String? = null): CompletableFuture<DeviceAuthorizationFlowContext> =
         coroutineScope.future {
             delegate.start(scope).getOrThrow()

--- a/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/jvm/ResourceOwnerFlow.kt
+++ b/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/jvm/ResourceOwnerFlow.kt
@@ -60,10 +60,32 @@ class ResourceOwnerFlow(
      *
      * @param username the user's username or email.
      * @param password the user's password.
+     * @param scope the scopes to request.
+     * @return a [CompletableFuture] that completes with [TokenInfo] on success,
+     *   or completes exceptionally on failure.
+     */
+    fun start(
+        username: String,
+        password: String,
+        scope: List<String>,
+    ): CompletableFuture<TokenInfo> =
+        coroutineScope.future {
+            delegate.start(username, password, scope).getOrThrow()
+        }
+
+    /**
+     * Initiates the Resource Owner flow asynchronously.
+     *
+     * @param username the user's username or email.
+     * @param password the user's password.
      * @param scope the scopes to request. Defaults to the client's configured default scope when null.
      * @return a [CompletableFuture] that completes with [TokenInfo] on success,
      *   or completes exceptionally on failure.
      */
+    @Deprecated(
+        message = "Use the overload accepting scope as a List<String> instead.",
+        replaceWith = ReplaceWith("start(username, password, scope.split(\" \"))")
+    )
     @JvmOverloads
     fun start(
         username: String,

--- a/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/jvm/SessionTokenFlow.kt
+++ b/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/jvm/SessionTokenFlow.kt
@@ -61,10 +61,34 @@ class SessionTokenFlow(
      * @param sessionToken the session token obtained from the Okta legacy Authn API.
      * @param redirectUrl the redirect URL registered with the authorization server.
      * @param extraRequestParameters additional key-value pairs appended to the authorization URL.
+     * @param scope the scopes to request.
+     * @return a [CompletableFuture] that completes with [TokenInfo] on success,
+     *   or completes exceptionally on failure.
+     */
+    fun start(
+        sessionToken: String,
+        redirectUrl: String,
+        extraRequestParameters: Map<String, String> = emptyMap(),
+        scope: List<String>,
+    ): CompletableFuture<TokenInfo> =
+        coroutineScope.future {
+            delegate.start(sessionToken, redirectUrl, extraRequestParameters, scope).getOrThrow()
+        }
+
+    /**
+     * Initiates the Session Token flow asynchronously.
+     *
+     * @param sessionToken the session token obtained from the Okta legacy Authn API.
+     * @param redirectUrl the redirect URL registered with the authorization server.
+     * @param extraRequestParameters additional key-value pairs appended to the authorization URL.
      * @param scope the space-delimited scopes to request. Defaults to the client's configured default scope when null.
      * @return a [CompletableFuture] that completes with [TokenInfo] on success,
      *   or completes exceptionally on failure.
      */
+    @Deprecated(
+        message = "Use the overload accepting scope as a List<String> instead.",
+        replaceWith = ReplaceWith("start(sessionToken, redirectUrl, extraRequestParameters, scope.split(\" \"))")
+    )
     @JvmOverloads
     fun start(
         sessionToken: String,

--- a/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/jvm/TokenExchangeFlow.kt
+++ b/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/jvm/TokenExchangeFlow.kt
@@ -61,10 +61,34 @@ class TokenExchangeFlow(
      * @param idToken the ID token for the user.
      * @param deviceSecret the device secret from a previous authentication flow.
      * @param audience optional audience; pass null to omit from the request.
+     * @param scope the scopes to request.
+     * @return a [CompletableFuture] that completes with [TokenInfo] on success,
+     *   or completes exceptionally on failure.
+     */
+    fun start(
+        idToken: String,
+        deviceSecret: String,
+        audience: String? = null,
+        scope: List<String>,
+    ): CompletableFuture<TokenInfo> =
+        coroutineScope.future {
+            delegate.start(idToken, deviceSecret, audience, scope).getOrThrow()
+        }
+
+    /**
+     * Initiates the token exchange flow asynchronously.
+     *
+     * @param idToken the ID token for the user.
+     * @param deviceSecret the device secret from a previous authentication flow.
+     * @param audience optional audience; pass null to omit from the request.
      * @param scope the scopes to request. Defaults to the client's configured default scope when null.
      * @return a [CompletableFuture] that completes with [TokenInfo] on success,
      *   or completes exceptionally on failure.
      */
+    @Deprecated(
+        message = "Use the overload accepting scope as a List<String> instead.",
+        replaceWith = ReplaceWith("start(idToken, deviceSecret, audience, scope.split(\" \"))")
+    )
     @JvmOverloads
     fun start(
         idToken: String,

--- a/web-authentication-ui/api/web-authentication-ui.api
+++ b/web-authentication-ui/api/web-authentication-ui.api
@@ -73,7 +73,9 @@ public final class com/okta/webauthenticationui/WebAuthentication {
 	public fun <init> (Lcom/okta/webauthenticationui/WebAuthenticationProvider;)V
 	public synthetic fun <init> (Lcom/okta/webauthenticationui/WebAuthenticationProvider;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun login (Landroid/content/Context;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun login (Landroid/content/Context;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun login$default (Lcom/okta/webauthenticationui/WebAuthentication;Landroid/content/Context;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun login$default (Lcom/okta/webauthenticationui/WebAuthentication;Landroid/content/Context;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun logoutOfBrowser (Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 

--- a/web-authentication-ui/src/main/java/com/okta/webauthenticationui/WebAuthentication.kt
+++ b/web-authentication-ui/src/main/java/com/okta/webauthenticationui/WebAuthentication.kt
@@ -201,8 +201,30 @@ class WebAuthentication private constructor(
      * @param redirectUrl the redirect URL.
      * @param extraRequestParameters the extra key value pairs to send to the authorize endpoint.
      *  See [Authorize Documentation](https://developer.okta.com/docs/reference/api/oidc/#authorize) for parameter options.
+     * @param scope the scopes to request during sign in.
+     */
+    @Suppress("DEPRECATION")
+    suspend fun login(
+        context: Context,
+        redirectUrl: String,
+        extraRequestParameters: Map<String, String> = emptyMap(),
+        scope: List<String>,
+    ): OAuth2ClientResult<Token> = login(context, redirectUrl, extraRequestParameters, scope.joinToString(" "))
+
+    /**
+     * Initiates the OIDC Authorization Code redirect flow.
+     *
+     * @param context the Android [Activity] [Context] which is used to display the login flow via the configured
+     * [WebAuthenticationProvider].
+     * @param redirectUrl the redirect URL.
+     * @param extraRequestParameters the extra key value pairs to send to the authorize endpoint.
+     *  See [Authorize Documentation](https://developer.okta.com/docs/reference/api/oidc/#authorize) for parameter options.
      * @param scope the scopes to request during sign in. Defaults to the configured client's default scope.
      */
+    @Deprecated(
+        message = "Use the overload accepting scope as a List<String> instead.",
+        replaceWith = ReplaceWith("login(context, redirectUrl, extraRequestParameters, scope.split(\" \"))")
+    )
     suspend fun login(
         context: Context,
         redirectUrl: String,


### PR DESCRIPTION
Adds an Android Keystore/biometric-capable KMP TokenEncryptionHandler (the KMP credential storage stack previously only worked on JVM), adds List<String> scope overloads alongside the existing String ones for consistency, deprecates the Android-only OAuth2Client/OidcConfiguration/ Credential/CredentialDataSource/TokenStorage/RoomTokenStorage/Token and the six com.okta.oauth2.* flow classes in favor of their KMP equivalents, migrates the app sample to the KMP variant end-to-end, and documents the migration path in README.md.

RESOLVES: OKTA-1209077