### PR TITLE
Support aud claim as JSON array in ID token validation

### DIFF
--- a/auth-foundation/api/auth-foundation.api
+++ b/auth-foundation/api/auth-foundation.api
@@ -317,7 +317,7 @@ public abstract interface class com/okta/authfoundation/claims/ClaimsProvider {
 
 public final class com/okta/authfoundation/claims/ClaimsProviderKt {
 	public static final fun getActive (Lcom/okta/authfoundation/claims/ClaimsProvider;)Ljava/lang/Boolean;
-	public static final fun getAudience (Lcom/okta/authfoundation/claims/ClaimsProvider;)Ljava/lang/String;
+	public static final fun getAudience (Lcom/okta/authfoundation/claims/ClaimsProvider;)Ljava/util/List;
 	public static final fun getAuthContextClassReference (Lcom/okta/authfoundation/claims/ClaimsProvider;)Ljava/lang/String;
 	public static final fun getAuthMethodsReference (Lcom/okta/authfoundation/claims/ClaimsProvider;)Ljava/util/List;
 	public static final fun getClientId (Lcom/okta/authfoundation/claims/ClaimsProvider;)Ljava/lang/String;

--- a/auth-foundation/api/jvm/auth-foundation.api
+++ b/auth-foundation/api/jvm/auth-foundation.api
@@ -241,7 +241,7 @@ public abstract interface class com/okta/authfoundation/claims/ClaimsProvider {
 
 public final class com/okta/authfoundation/claims/ClaimsProviderKt {
 	public static final fun getActive (Lcom/okta/authfoundation/claims/ClaimsProvider;)Ljava/lang/Boolean;
-	public static final fun getAudience (Lcom/okta/authfoundation/claims/ClaimsProvider;)Ljava/lang/String;
+	public static final fun getAudience (Lcom/okta/authfoundation/claims/ClaimsProvider;)Ljava/util/List;
 	public static final fun getAuthContextClassReference (Lcom/okta/authfoundation/claims/ClaimsProvider;)Ljava/lang/String;
 	public static final fun getAuthMethodsReference (Lcom/okta/authfoundation/claims/ClaimsProvider;)Ljava/util/List;
 	public static final fun getClientId (Lcom/okta/authfoundation/claims/ClaimsProvider;)Ljava/lang/String;

--- a/auth-foundation/src/androidHostTest/kotlin/com/okta/authfoundation/claims/DefaultClaimsProviderTest.kt
+++ b/auth-foundation/src/androidHostTest/kotlin/com/okta/authfoundation/claims/DefaultClaimsProviderTest.kt
@@ -166,7 +166,14 @@ class DefaultClaimsProviderTest {
         val claims: JsonObject = json.decodeFromString("""{"aud":"bar"}""")
         val subject = DefaultClaimsProvider(claims, json)
         val result = subject.audience
-        assertThat(result).isEqualTo("bar")
+        assertThat(result).isEqualTo(listOf("bar"))
+    }
+
+    @Test fun `test audience as array`() {
+        val claims: JsonObject = json.decodeFromString("""{"aud":["bar","baz"]}""")
+        val subject = DefaultClaimsProvider(claims, json)
+        val result = subject.audience
+        assertThat(result).isEqualTo(listOf("bar", "baz"))
     }
 
     @Test fun `test clientId`() {

--- a/auth-foundation/src/androidHostTest/kotlin/com/okta/authfoundation/client/DefaultIdTokenValidatorTest.kt
+++ b/auth-foundation/src/androidHostTest/kotlin/com/okta/authfoundation/client/DefaultIdTokenValidatorTest.kt
@@ -17,6 +17,7 @@ package com.okta.authfoundation.client
 
 import com.google.common.truth.Truth.assertThat
 import com.okta.authfoundation.jwt.IdTokenClaims
+import com.okta.authfoundation.jwt.IdTokenClaimsWithAudienceList
 import com.okta.authfoundation.jwt.JwtBuilder.Companion.createJwtBuilder
 import com.okta.testhelpers.OktaRule
 import kotlinx.coroutines.runBlocking
@@ -77,6 +78,32 @@ class DefaultIdTokenValidatorTest {
     @Test fun testInvalidAudience() {
         val idTokenClaims = IdTokenClaims(audience = "mismatch")
         assertFailsWithMessage("Invalid audience.", IdTokenValidator.Error.INVALID_AUDIENCE, idTokenClaims)
+    }
+
+    @Test fun testAudienceArrayContainingClientIdPasses(): Unit =
+        runBlocking {
+            val client = oktaRule.createOAuth2Client(oktaRule.createEndpoints("https://example-test.okta.com".toHttpUrl().newBuilder()))
+            val idTokenClaims = IdTokenClaimsWithAudienceList(audience = listOf("unit_test_client_id", "other_aud"))
+            val idToken = client.createJwtBuilder().createJwt(claims = idTokenClaims)
+            idTokenValidator.validate(client, idToken, IdTokenValidator.Parameters(null, null))
+        }
+
+    @Test fun testAudienceArrayNotContainingClientIdThrows() {
+        val idTokenClaims = IdTokenClaimsWithAudienceList(audience = listOf("other_client_1", "other_client_2"))
+        try {
+            val client = oktaRule.createOAuth2Client(oktaRule.createEndpoints("https://example-test.okta.com".toHttpUrl().newBuilder()))
+            runBlocking {
+                idTokenValidator.validate(
+                    client,
+                    client.createJwtBuilder().createJwt(claims = idTokenClaims),
+                    IdTokenValidator.Parameters(null, null)
+                )
+            }
+            fail()
+        } catch (e: IdTokenValidator.Error) {
+            assertThat(e).hasMessageThat().isEqualTo("Invalid audience.")
+            assertThat(e.identifier).isEqualTo(IdTokenValidator.Error.INVALID_AUDIENCE)
+        }
     }
 
     @Test fun testInvalidHttps() {

--- a/auth-foundation/src/androidHostTest/kotlin/com/okta/authfoundation/jwt/JwtBuilder.kt
+++ b/auth-foundation/src/androidHostTest/kotlin/com/okta/authfoundation/jwt/JwtBuilder.kt
@@ -102,3 +102,25 @@ class IdTokenClaims(
     @SerialName("ds_hash") val deviceSecretHash: String? = "DAeLOFRqifysbgsrbOgbog",
     @SerialName("nonce") val nonce: String? = null,
 )
+
+/** Same shape as [IdTokenClaims], but with `aud` as a JSON array — RFC 7519 §4.1.3 permits both forms. */
+@Serializable
+class IdTokenClaimsWithAudienceList(
+    @SerialName("sub") val subject: String? = "00ub41z7mgzNqryMv696",
+    @SerialName("name") val name: String? = "Okta User",
+    @SerialName("email") val email: String? = "okta.user@example.com",
+    @SerialName("ver") val version: Int? = 1,
+    @SerialName("iss") val issuer: String? = "https://example-test.okta.com/oauth2/default",
+    @SerialName("aud") val audience: List<String> = listOf("unit_test_client_id"),
+    @SerialName("iat") val issuedAt: Long? = 1644347069,
+    @SerialName("exp") val expiresAt: Long? = 1644350669,
+    @SerialName("jti") val jwtId: String? = "ID.55cxBtdYl8l6arKISPBwd0yOT-9UCTaXaQTXt2laRLs",
+    @SerialName("amr") val authenticationMethods: List<String>? = listOf("pwd"),
+    @SerialName("idp") val identityProvider: String? = "00o8fou7sRaGGwdn4696",
+    @SerialName("sid") val sessionId: String? = "idxWxklp_4kSxuC_nU1pXD-nA",
+    @SerialName("preferred_username") val preferredUsername: String? = "jaynewstrom@example.com",
+    @SerialName("auth_time") val authTime: Long? = 1644347068,
+    @SerialName("at_hash") val accessTokenHash: String? = "gMcGTbhGT1G_ldsHoJsPzQ",
+    @SerialName("ds_hash") val deviceSecretHash: String? = "DAeLOFRqifysbgsrbOgbog",
+    @SerialName("nonce") val nonce: String? = null,
+)

--- a/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/client/IdTokenValidator.kt
+++ b/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/client/IdTokenValidator.kt
@@ -16,6 +16,7 @@
 package com.okta.authfoundation.client
 
 import com.okta.authfoundation.client.events.ValidateIdTokenEvent
+import com.okta.authfoundation.client.kmp.AudienceSerializer
 import com.okta.authfoundation.credential.Token
 import com.okta.authfoundation.jwt.Jwt
 import kotlinx.serialization.SerialName
@@ -118,7 +119,7 @@ internal class DefaultIdTokenValidator : IdTokenValidator {
         if (idTokenPayload.iss.toHttpUrl() != client.endpointsOrNull()?.issuer) {
             throw IdTokenValidator.Error("Invalid issuer.", IdTokenValidator.Error.INVALID_ISSUER)
         }
-        if (idTokenPayload.aud != client.configuration.clientId) {
+        if (client.configuration.clientId !in idTokenPayload.aud) {
             throw IdTokenValidator.Error("Invalid audience.", IdTokenValidator.Error.INVALID_AUDIENCE)
         }
         if (!idTokenPayload.iss.startsWith("https://")) {
@@ -162,7 +163,7 @@ internal class DefaultIdTokenValidator : IdTokenValidator {
 @Serializable
 internal class IdTokenValidationPayload(
     @SerialName("iss") val iss: String,
-    @SerialName("aud") val aud: String,
+    @SerialName("aud") @Serializable(with = AudienceSerializer::class) val aud: List<String>,
     @SerialName("exp") val exp: Int,
     @SerialName("iat") val iat: Int,
     @SerialName("nonce") val nonce: String? = null,

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/claims/ClaimsProvider.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/claims/ClaimsProvider.kt
@@ -15,6 +15,7 @@
  */
 package com.okta.authfoundation.claims
 
+import com.okta.authfoundation.client.kmp.AudienceSerializer
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.builtins.ListSerializer
@@ -119,10 +120,15 @@ val ClaimsProvider.active: Boolean?
         return deserializeClaim("active", Boolean.serializer())
     }
 
-/** The audience of the token. */
-val ClaimsProvider.audience: String?
+/**
+ * The audience(s) of the token.
+ *
+ * Per RFC 7519 §4.1.3 and OIDC Core 1.0 §3.1.3.7, the `aud` claim may be either a single string or a
+ * JSON array of strings; both forms are normalized into a [List].
+ */
+val ClaimsProvider.audience: List<String>?
     get() {
-        return deserializeClaim("aud", String.serializer())
+        return deserializeClaim("aud", AudienceSerializer)
     }
 
 /** The ID of the client associated with the token. */

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/kmp/DefaultIdTokenValidator.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/kmp/DefaultIdTokenValidator.kt
@@ -17,8 +17,18 @@ package com.okta.authfoundation.client.kmp
 
 import com.okta.authfoundation.client.OidcClock
 import com.okta.authfoundation.jwt.Jwt
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonEncoder
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonPrimitive
 import kotlin.math.abs
 
 /**
@@ -48,7 +58,7 @@ class DefaultIdTokenValidator(
         if (normalizedTokenIssuer != normalizedIssuer) {
             throw IdTokenValidator.Error("Invalid issuer.", IdTokenValidator.Error.INVALID_ISSUER)
         }
-        if (payload.aud != clientId) {
+        if (clientId !in payload.aud) {
             throw IdTokenValidator.Error("Invalid audience.", IdTokenValidator.Error.INVALID_AUDIENCE)
         }
         if (!payload.iss.startsWith("https://")) {
@@ -92,10 +102,40 @@ class DefaultIdTokenValidator(
 @Serializable
 internal class IdTokenValidationPayload(
     @SerialName("iss") val iss: String,
-    @SerialName("aud") val aud: String,
+    @SerialName("aud") @Serializable(with = AudienceSerializer::class) val aud: List<String>,
     @SerialName("exp") val exp: Int,
     @SerialName("iat") val iat: Int,
     @SerialName("nonce") val nonce: String? = null,
     @SerialName("auth_time") val authTime: Int? = null,
     @SerialName("sub") val sub: String? = null,
 )
+
+/**
+ * The `aud` claim is permitted by RFC 7519 §4.1.3 and OIDC Core 1.0 §3.1.3.7 to be either a single
+ * string or a JSON array of strings. This serializer normalizes either form into a [List] of strings.
+ */
+internal object AudienceSerializer : KSerializer<List<String>> {
+    override val descriptor: SerialDescriptor = buildClassSerialDescriptor("Audience")
+
+    override fun serialize(
+        encoder: Encoder,
+        value: List<String>,
+    ) {
+        val jsonEncoder = encoder as? JsonEncoder ?: error("AudienceSerializer only supports JSON.")
+        val element =
+            if (value.size == 1) {
+                JsonPrimitive(value.first())
+            } else {
+                JsonArray(value.map { JsonPrimitive(it) })
+            }
+        jsonEncoder.encodeJsonElement(element)
+    }
+
+    override fun deserialize(decoder: Decoder): List<String> {
+        val jsonDecoder = decoder as? JsonDecoder ?: error("AudienceSerializer only supports JSON.")
+        return when (val element = jsonDecoder.decodeJsonElement()) {
+            is JsonArray -> element.map { it.jsonPrimitive.content }
+            else -> listOf(element.jsonPrimitive.content)
+        }
+    }
+}

--- a/auth-foundation/src/commonTest/kotlin/com/okta/authfoundation/client/kmp/DefaultIdTokenValidatorTest.kt
+++ b/auth-foundation/src/commonTest/kotlin/com/okta/authfoundation/client/kmp/DefaultIdTokenValidatorTest.kt
@@ -30,6 +30,16 @@ class DefaultIdTokenValidatorTest {
     private val validJwt =
         "eyJraWQiOiJGSkEwSEdOdHN1dWRhX1BsNDVKNDJrdlFxY3N1XzBDNEZnN3BiSkxYVEhZIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiIwMHViNDF6N21nek5xcnlNdjY5NiIsIm5hbWUiOiJKYXkgTmV3c3Ryb20iLCJlbWFpbCI6ImpheW5ld3N0cm9tQGV4YW1wbGUuY29tIiwidmVyIjoxLCJpc3MiOiJodHRwczovL2V4YW1wbGUtdGVzdC5va3RhLmNvbS9vYXV0aDIvZGVmYXVsdCIsImF1ZCI6InVuaXRfdGVzdF9jbGllbnRfaWQiLCJpYXQiOjE2NDQzNDcwNjksImV4cCI6MTY0NDM1MDY2OSwianRpIjoiSUQuNTVjeEJ0ZFlsOGw2YXJLSVNQQndkMHlPVC05VUNUYVhhUVRYdDJsYVJMcyIsImFtciI6WyJwd2QiXSwiaWRwIjoiMDBvOGZvdTdzUmFHR3dkbjQ2OTYiLCJzaWQiOiJpZHhXeGtscF80a1N4dUNfblUxcFhELW5BIiwicHJlZmVycmVkX3VzZXJuYW1lIjoiamF5bmV3c3Ryb21AZXhhbXBsZS5jb20iLCJhdXRoX3RpbWUiOjE2NDQzNDcwNjgsImF0X2hhc2giOiJnTWNHVGJoR1QxR19sZHNIb0pzUHpRIiwiZHNfaGFzaCI6IkRBZUxPRlJxaWZ5c2Jnc3JiT2dib2cifQ.tT8aKK4r8yFcW9KgVtZxvjXRJVzz-_rve14CVtpUlyvCTE1yj20wmPS0z3-JirI9xXgt5KeNPYqo3Wbv8c9XY_HY3hsPQdILYpPsUkf-sctmzSoKC_dTbs5xe8uKSgmpMrggfUAWrNPiJt9Ek2p7GgP64Wx79Pq5vSHk0yWlonFfXut5ahpSfqWilmYlvLr8gFbqoLnAJfl4ZbTY8pPw_aQgCdcQ-ImHRu-8bCSCtbFRzZB-SMJFLfRF2kmx0H-QF855wUODTuUSydkff-BKb-8wnbqWg0R9NvRdoXhEybv8TXXZY3cQqgolWLAyiPMrz07n0q_UEjAilUiCjn1f4Q"
 
+    // Same claims as validJwt, but with `aud` as a JSON array containing "unit_test_client_id".
+    @Suppress("ktlint:standard:max-line-length")
+    private val validJwtWithAudienceArrayContainingClientId =
+        "eyJraWQiOiJGSkEwSEdOdHN1dWRhX1BsNDVKNDJrdlFxY3N1XzBDNEZnN3BiSkxYVEhZIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiIwMHViNDF6N21nek5xcnlNdjY5NiIsIm5hbWUiOiJKYXkgTmV3c3Ryb20iLCJlbWFpbCI6ImpheW5ld3N0cm9tQGV4YW1wbGUuY29tIiwidmVyIjoxLCJpc3MiOiJodHRwczovL2V4YW1wbGUtdGVzdC5va3RhLmNvbS9vYXV0aDIvZGVmYXVsdCIsImlhdCI6MTY0NDM0NzA2OSwiZXhwIjoxNjQ0MzUwNjY5LCJqdGkiOiJJRC41NWN4QnRkWWw4bDZhcktJU1BCd2QweU9ULTlVQ1RhWGFRVFh0MmxhUkxzIiwiYW1yIjpbInB3ZCJdLCJpZHAiOiIwMG84Zm91N3NSYUdHd2RuNDY5NiIsInNpZCI6ImlkeFd4a2xwXzRrU3h1Q19uVTFwWEQtbkEiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJqYXluZXdzdHJvbUBleGFtcGxlLmNvbSIsImF1dGhfdGltZSI6MTY0NDM0NzA2OCwiYXRfaGFzaCI6ImdNY0dUYmhHVDFHX2xkc0hvSnNQelEiLCJkc19oYXNoIjoiREFlTE9GUnFpZnlzYmdzcmJPZ2JvZyIsImF1ZCI6WyJ1bml0X3Rlc3RfY2xpZW50X2lkIiwib3RoZXJfYXVkIl19.tT8aKK4r8yFcW9KgVtZxvjXRJVzz-_rve14CVtpUlyvCTE1yj20wmPS0z3-JirI9xXgt5KeNPYqo3Wbv8c9XY_HY3hsPQdILYpPsUkf-sctmzSoKC_dTbs5xe8uKSgmpMrggfUAWrNPiJt9Ek2p7GgP64Wx79Pq5vSHk0yWlonFfXut5ahpSfqWilmYlvLr8gFbqoLnAJfl4ZbTY8pPw_aQgCdcQ-ImHRu-8bCSCtbFRzZB-SMJFLfRF2kmx0H-QF855wUODTuUSydkff-BKb-8wnbqWg0R9NvRdoXhEybv8TXXZY3cQqgolWLAyiPMrz07n0q_UEjAilUiCjn1f4Q"
+
+    // Same claims as validJwt, but with `aud` as a JSON array that does not contain "unit_test_client_id".
+    @Suppress("ktlint:standard:max-line-length")
+    private val validJwtWithAudienceArrayNotContainingClientId =
+        "eyJraWQiOiJGSkEwSEdOdHN1dWRhX1BsNDVKNDJrdlFxY3N1XzBDNEZnN3BiSkxYVEhZIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiIwMHViNDF6N21nek5xcnlNdjY5NiIsIm5hbWUiOiJKYXkgTmV3c3Ryb20iLCJlbWFpbCI6ImpheW5ld3N0cm9tQGV4YW1wbGUuY29tIiwidmVyIjoxLCJpc3MiOiJodHRwczovL2V4YW1wbGUtdGVzdC5va3RhLmNvbS9vYXV0aDIvZGVmYXVsdCIsImlhdCI6MTY0NDM0NzA2OSwiZXhwIjoxNjQ0MzUwNjY5LCJqdGkiOiJJRC41NWN4QnRkWWw4bDZhcktJU1BCd2QweU9ULTlVQ1RhWGFRVFh0MmxhUkxzIiwiYW1yIjpbInB3ZCJdLCJpZHAiOiIwMG84Zm91N3NSYUdHd2RuNDY5NiIsInNpZCI6ImlkeFd4a2xwXzRrU3h1Q19uVTFwWEQtbkEiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJqYXluZXdzdHJvbUBleGFtcGxlLmNvbSIsImF1dGhfdGltZSI6MTY0NDM0NzA2OCwiYXRfaGFzaCI6ImdNY0dUYmhHVDFHX2xkc0hvSnNQelEiLCJkc19oYXNoIjoiREFlTE9GUnFpZnlzYmdzcmJPZ2JvZyIsImF1ZCI6WyJvdGhlcl9jbGllbnRfMSIsIm90aGVyX2NsaWVudF8yIl19.tT8aKK4r8yFcW9KgVtZxvjXRJVzz-_rve14CVtpUlyvCTE1yj20wmPS0z3-JirI9xXgt5KeNPYqo3Wbv8c9XY_HY3hsPQdILYpPsUkf-sctmzSoKC_dTbs5xe8uKSgmpMrggfUAWrNPiJt9Ek2p7GgP64Wx79Pq5vSHk0yWlonFfXut5ahpSfqWilmYlvLr8gFbqoLnAJfl4ZbTY8pPw_aQgCdcQ-ImHRu-8bCSCtbFRzZB-SMJFLfRF2kmx0H-QF855wUODTuUSydkff-BKb-8wnbqWg0R9NvRdoXhEybv8TXXZY3cQqgolWLAyiPMrz07n0q_UEjAilUiCjn1f4Q"
+
     private val parser = JwtParser(kotlinx.serialization.json.Json { ignoreUnknownKeys = true }, Dispatchers.Default)
     private val validator = DefaultIdTokenValidator()
 
@@ -73,6 +83,34 @@ class DefaultIdTokenValidatorTest {
                     validator.validate(
                         issuerUrl = "https://example-test.okta.com/oauth2/default",
                         clientId = "wrong_client_id",
+                        idToken = jwt,
+                        clock = clockAtTokenTime
+                    )
+                }
+            assertEquals(IdTokenValidator.Error.INVALID_AUDIENCE, error.identifier)
+        }
+
+    @Test
+    fun validate_AudienceArrayContainingClientId_Passes() =
+        runTest {
+            val jwt = parser.parse(validJwtWithAudienceArrayContainingClientId)
+            validator.validate(
+                issuerUrl = "https://example-test.okta.com/oauth2/default",
+                clientId = "unit_test_client_id",
+                idToken = jwt,
+                clock = clockAtTokenTime
+            )
+        }
+
+    @Test
+    fun validate_AudienceArrayNotContainingClientId_Throws() =
+        runTest {
+            val jwt = parser.parse(validJwtWithAudienceArrayNotContainingClientId)
+            val error =
+                assertFailsWith<IdTokenValidator.Error> {
+                    validator.validate(
+                        issuerUrl = "https://example-test.okta.com/oauth2/default",
+                        clientId = "unit_test_client_id",
                         idToken = jwt,
                         clock = clockAtTokenTime
                     )


### PR DESCRIPTION
Per RFC 7519 §4.1.3 / OIDC Core 1.0 §3.1.3.7, the `aud` claim may be either a single string or a JSON array of strings. Add an AudienceSerializer to normalize both forms to a List<String>, and update audience validation in the Android and common DefaultIdTokenValidator implementations to check that the client ID is contained in the audience list rather than requiring an exact string match.