### PR TITLE
Bump forced Netty version off EoL 4.1.x branch

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,6 +51,7 @@ allprojects {
             force(libs.netty.codec.http)
             force(libs.netty.codec.http2)
             force(libs.netty.handler)
+            force(libs.netty.handler.proxy)
             force(libs.protobuf.java)
             force(libs.woodstox.core)
             force(libs.commons.lang3)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,7 +48,7 @@ mockitoCore = "5.23.0"
 mockitoKotlin = "6.3.0"
 mockk = "1.14.11"
 navigation = "2.9.8"
-netty = "4.1.135.Final"
+netty = "4.2.16.Final"
 okhttp = "5.4.0"
 okio = "3.18.0"
 oktaAuthn = "3.0.0"
@@ -170,6 +170,7 @@ netty-codec-http = { module = "io.netty:netty-codec-http", version.ref = "netty"
 netty-codec-http2 = { module = "io.netty:netty-codec-http2", version.ref = "netty" }
 netty-common = { module = "io.netty:netty-common", version.ref = "netty" }
 netty-handler = { module = "io.netty:netty-handler", version.ref = "netty" }
+netty-handler-proxy = { module = "io.netty:netty-handler-proxy", version.ref = "netty" }
 okhttp-core = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 okhttp-mock-web-server = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp" }
 okhttp-tls = { module = "com.squareup.okhttp3:okhttp-tls", version.ref = "okhttp" }


### PR DESCRIPTION
Socket.dev flagged io.netty:netty-codec-http@4.1.135.Final as unmaintained/EoL: the 4.1.x branch is in security-fix-only mode and 4.2.x is now the actively maintained line. Netty is only a forced transitive override here (pulled in via grpc-netty), so this bumps the pin to 4.2.16.Final and adds a force for netty-handler-proxy, which was still resolving to 4.1.x despite the other netty modules being forced.

RESOLVES: OKTA-1236124