### PR TITLE
Add closable

### DIFF
--- a/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/credential/TokenEncryptionHandler.kt
+++ b/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/credential/TokenEncryptionHandler.kt
@@ -193,13 +193,14 @@ class DefaultTokenEncryptionHandler(
         token: Token,
         security: Credential.Security,
     ): TokenEncryptionHandler.EncryptionResult {
-        val publicRsaKey = keyStore.getCertificate(security.keyAlias)?.publicKey ?: throw KeyPermanentlyInvalidatedException()
+        val certificatePublicKey = keyStore.getCertificate(security.keyAlias)?.publicKey ?: throw KeyPermanentlyInvalidatedException()
 
         // workaround for using public key from
         // https://developer.android.com/reference/android/security/keystore/KeyGenParameterSpec.html#known-issues
-        KeyFactory
-            .getInstance(publicRsaKey.algorithm)
-            .generatePublic(X509EncodedKeySpec(publicRsaKey.encoded))
+        val publicRsaKey =
+            KeyFactory
+                .getInstance(certificatePublicKey.algorithm)
+                .generatePublic(X509EncodedKeySpec(certificatePublicKey.encoded))
 
         val serializedToken =
             OidcConfiguration.defaultJson().encodeToString(Token.serializer(), token)

--- a/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/credential/kmp/AndroidTokenEncryptionHandler.kt
+++ b/auth-foundation/src/androidMain/kotlin/com/okta/authfoundation/credential/kmp/AndroidTokenEncryptionHandler.kt
@@ -108,15 +108,16 @@ class AndroidTokenEncryptionHandler(
 
     override suspend fun encrypt(plaintext: ByteArray): EncryptionResult {
         ensureKeyExists()
-        val publicRsaKey =
+        val certificatePublicKey =
             keyStore.getCertificate(keyAlias)?.publicKey
                 ?: throw KeyPermanentlyInvalidatedException("No public key found for alias $keyAlias")
 
         // workaround for using public key from
         // https://developer.android.com/reference/android/security/keystore/KeyGenParameterSpec.html#known-issues
-        KeyFactory
-            .getInstance(publicRsaKey.algorithm)
-            .generatePublic(X509EncodedKeySpec(publicRsaKey.encoded))
+        val publicRsaKey =
+            KeyFactory
+                .getInstance(certificatePublicKey.algorithm)
+                .generatePublic(X509EncodedKeySpec(certificatePublicKey.encoded))
 
         val envelope = KeystoreEnvelopeCrypto.encrypt(plaintext, publicRsaKey)
         return EncryptionResult(envelope.ciphertext, envelope.extras)

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/credential/kmp/CredentialDataSource.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/credential/kmp/CredentialDataSource.kt
@@ -39,7 +39,7 @@ import java.util.concurrent.ConcurrentHashMap
  * @param storage the [TokenStorage] for persisting tokens.
  * @param eventsFlow optional shared flow for async broadcast of [TokenStorageAccessErrorEvent].
  * @param onStorageError optional callback invoked when a storage operation throws. Return `true`
- *   to clear storage and retry the failed operation once; return `false` to rethrow.
+ *   to retry the failed operation once; return `false` to rethrow.
  */
 internal class CredentialDataSource(
     private val storage: TokenStorage,

--- a/okta-direct-auth-java-cli-sample/src/main/java/com/okta/directauth/cli/viewmodel/AuthViewModel.java
+++ b/okta-direct-auth-java-cli-sample/src/main/java/com/okta/directauth/cli/viewmodel/AuthViewModel.java
@@ -369,12 +369,17 @@ public final class AuthViewModel implements Closeable {
     } catch (Exception e) {
       CliLogger.error(TAG, "Operation timed out or failed", e);
       notifyError("Operation timed out or failed");
+      // future.get(timeout) only stops waiting — it doesn't cancel the underlying work. Close the
+      // continuation so an OobPendingContinuation/TransferContinuation poll loop doesn't keep
+      // running in the background for its full expirationInSeconds.
+      closeIfCloseable(currentAuthState);
       return null;
     }
   }
 
   @Override
   public void close() {
+    closeIfCloseable(currentAuthState);
     signInFlow.close();
     if (recoveryFlow != null) {
       recoveryFlow.close();
@@ -383,7 +388,11 @@ public final class AuthViewModel implements Closeable {
 
   private void handleAuthState(DirectAuthenticationState state) {
     CliLogger.debug(TAG, "Auth state received: " + state.getClass().getSimpleName());
+    DirectAuthenticationState previous = this.currentAuthState;
     this.currentAuthState = state;
+    if (previous != state) {
+      closeIfCloseable(previous);
+    }
     notifyAuthStateChanged(state);
 
     if (state instanceof DirectAuthenticationState.Authenticated) {
@@ -433,6 +442,22 @@ public final class AuthViewModel implements Closeable {
   private void notifyError(String message) {
     for (AuthViewModelListener listener : listeners) {
       listener.onError(message);
+    }
+  }
+
+  /**
+   * Closes {@code state} if it's a {@link Closeable} continuation wrapper, cancelling any in-flight
+   * {@code *Async} call it's backing.
+   *
+   * @param state the state to close, or null
+   */
+  private static void closeIfCloseable(DirectAuthenticationState state) {
+    if (state instanceof Closeable) {
+      try {
+        ((Closeable) state).close();
+      } catch (IOException ignored) {
+        // These wrappers never actually throw; Closeable's method signature just declares it.
+      }
     }
   }
 

--- a/okta-direct-auth/api/jvm/okta-direct-auth.api
+++ b/okta-direct-auth/api/jvm/okta-direct-auth.api
@@ -223,36 +223,41 @@ public final class com/okta/directauth/jvm/DirectAuthenticationState$Error$Inter
 public final class com/okta/directauth/jvm/DirectAuthenticationState$Idle : com/okta/directauth/jvm/DirectAuthenticationState {
 }
 
-public final class com/okta/directauth/jvm/MfaRequired : com/okta/directauth/jvm/DirectAuthenticationState {
+public final class com/okta/directauth/jvm/MfaRequired : com/okta/directauth/jvm/DirectAuthenticationState, java/io/Closeable {
 	public fun <init> (Lcom/okta/directauth/model/DirectAuthenticationState$MfaRequired;)V
 	public final fun challengeAsync (Lcom/okta/directauth/model/SecondaryFactor;)Ljava/util/concurrent/CompletableFuture;
 	public final fun challengeAsync (Lcom/okta/directauth/model/SecondaryFactor;Ljava/util/List;)Ljava/util/concurrent/CompletableFuture;
+	public fun close ()V
 	public final fun resumeAsync (Lcom/okta/directauth/model/SecondaryFactor;)Ljava/util/concurrent/CompletableFuture;
 	public final fun resumeAsync (Lcom/okta/directauth/model/SecondaryFactor;Ljava/util/List;)Ljava/util/concurrent/CompletableFuture;
 }
 
-public final class com/okta/directauth/jvm/OobPendingContinuation : com/okta/directauth/jvm/DirectAuthenticationState {
+public final class com/okta/directauth/jvm/OobPendingContinuation : com/okta/directauth/jvm/DirectAuthenticationState, java/io/Closeable {
 	public fun <init> (Lcom/okta/directauth/model/DirectAuthContinuation$OobPending;)V
+	public fun close ()V
 	public final fun getExpirationInSeconds ()I
 	public final fun proceedAsync ()Ljava/util/concurrent/CompletableFuture;
 }
 
-public final class com/okta/directauth/jvm/PromptContinuation : com/okta/directauth/jvm/DirectAuthenticationState {
+public final class com/okta/directauth/jvm/PromptContinuation : com/okta/directauth/jvm/DirectAuthenticationState, java/io/Closeable {
 	public fun <init> (Lcom/okta/directauth/model/DirectAuthContinuation$Prompt;)V
+	public fun close ()V
 	public final fun getExpirationInSeconds ()I
 	public final fun proceedAsync (Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
 }
 
-public final class com/okta/directauth/jvm/TransferContinuation : com/okta/directauth/jvm/DirectAuthenticationState {
+public final class com/okta/directauth/jvm/TransferContinuation : com/okta/directauth/jvm/DirectAuthenticationState, java/io/Closeable {
 	public fun <init> (Lcom/okta/directauth/model/DirectAuthContinuation$Transfer;)V
+	public fun close ()V
 	public final fun getBindingCode ()Ljava/lang/String;
 	public final fun getExpirationInSeconds ()I
 	public final fun proceedAsync ()Ljava/util/concurrent/CompletableFuture;
 }
 
-public final class com/okta/directauth/jvm/WebAuthnContinuation : com/okta/directauth/jvm/DirectAuthenticationState {
+public final class com/okta/directauth/jvm/WebAuthnContinuation : com/okta/directauth/jvm/DirectAuthenticationState, java/io/Closeable {
 	public fun <init> (Lcom/okta/directauth/model/DirectAuthContinuation$WebAuthn;)V
 	public final fun challengeData-d1pmJ48 ()Ljava/lang/Object;
+	public fun close ()V
 	public final fun getAuthenticatorEnrollment ()Ljava/util/List;
 	public final fun proceedAsync (Lcom/okta/directauth/api/WebAuthnCeremonyHandler;)Ljava/util/concurrent/CompletableFuture;
 	public final fun proceedAsync (Lcom/okta/directauth/model/WebAuthnAssertionResponse;)Ljava/util/concurrent/CompletableFuture;

--- a/okta-direct-auth/src/commonMain/kotlin/com/okta/directauth/model/DirectAuthContinuation.kt
+++ b/okta-direct-auth/src/commonMain/kotlin/com/okta/directauth/model/DirectAuthContinuation.kt
@@ -156,7 +156,9 @@ sealed class DirectAuthContinuation(
         suspend fun proceed(handler: WebAuthnCeremonyHandler): DirectAuthenticationState {
             val data =
                 challengeData().getOrElse {
-                    return DirectAuthenticationError.InternalError(EXCEPTION, "Challenge data retrieval failed: ${it.message}", it)
+                    val error = DirectAuthenticationError.InternalError(EXCEPTION, "Challenge data retrieval failed: ${it.message}", it)
+                    context.authenticationStateFlow.value = error
+                    return error
                 }
             val assertionResponse =
                 handler.performAssertion(data).getOrElse {

--- a/okta-direct-auth/src/jvmMain/kotlin/com/okta/directauth/jvm/MfaRequired.kt
+++ b/okta-direct-auth/src/jvmMain/kotlin/com/okta/directauth/jvm/MfaRequired.kt
@@ -20,7 +20,9 @@ import com.okta.directauth.model.SecondaryFactor
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.future.future
+import java.io.Closeable
 import java.util.concurrent.CompletableFuture
 import com.okta.directauth.model.DirectAuthenticationState as KotlinDirectAuthenticationState
 
@@ -29,11 +31,14 @@ import com.okta.directauth.model.DirectAuthenticationState as KotlinDirectAuthen
  *
  * Provides async methods for MFA challenge and resume operations.
  *
+ * Must be [closed][close] when no longer needed to release coroutine resources.
+ *
  * @param delegate The underlying Kotlin [KotlinDirectAuthenticationState.MfaRequired] instance.
  */
 class MfaRequired(
     private val delegate: KotlinDirectAuthenticationState.MfaRequired,
-) : com.okta.directauth.jvm.DirectAuthenticationState(delegate) {
+) : com.okta.directauth.jvm.DirectAuthenticationState(delegate),
+    Closeable {
     private val coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
     /**
@@ -87,4 +92,14 @@ class MfaRequired(
         coroutineScope.future {
             delegate.resume(secondaryFactor, challengeTypesSupported).toJvm()
         }
+
+    /**
+     * Closes this continuation, cancelling any in-flight [challengeAsync]/[resumeAsync] call.
+     *
+     * The pending [CompletableFuture] will complete exceptionally with
+     * [java.util.concurrent.CancellationException].
+     */
+    override fun close() {
+        coroutineScope.cancel()
+    }
 }

--- a/okta-direct-auth/src/jvmMain/kotlin/com/okta/directauth/jvm/OobPendingContinuation.kt
+++ b/okta-direct-auth/src/jvmMain/kotlin/com/okta/directauth/jvm/OobPendingContinuation.kt
@@ -19,7 +19,9 @@ import com.okta.directauth.model.DirectAuthContinuation
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.future.future
+import java.io.Closeable
 import java.util.concurrent.CompletableFuture
 
 /**
@@ -27,11 +29,16 @@ import java.util.concurrent.CompletableFuture
  *
  * Provides an async method for polling the status of an OOB authentication.
  *
+ * Must be [closed][close] when no longer needed to release coroutine resources — in particular,
+ * to stop an in-flight [proceedAsync] poll loop, which can otherwise run for up to
+ * [expirationInSeconds] seconds.
+ *
  * @param delegate The underlying Kotlin [DirectAuthContinuation.OobPending] instance.
  */
 class OobPendingContinuation(
     private val delegate: DirectAuthContinuation.OobPending,
-) : DirectAuthenticationState(delegate) {
+) : DirectAuthenticationState(delegate),
+    Closeable {
     private val coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
     /**
@@ -48,4 +55,14 @@ class OobPendingContinuation(
         coroutineScope.future {
             delegate.proceed().toJvm()
         }
+
+    /**
+     * Closes this continuation, cancelling the in-flight [proceedAsync] poll if any.
+     *
+     * The pending [CompletableFuture] will complete exceptionally with
+     * [java.util.concurrent.CancellationException].
+     */
+    override fun close() {
+        coroutineScope.cancel()
+    }
 }

--- a/okta-direct-auth/src/jvmMain/kotlin/com/okta/directauth/jvm/PromptContinuation.kt
+++ b/okta-direct-auth/src/jvmMain/kotlin/com/okta/directauth/jvm/PromptContinuation.kt
@@ -19,7 +19,9 @@ import com.okta.directauth.model.DirectAuthContinuation
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.future.future
+import java.io.Closeable
 import java.util.concurrent.CompletableFuture
 
 /**
@@ -27,11 +29,14 @@ import java.util.concurrent.CompletableFuture
  *
  * Provides an async method for submitting a user-provided code.
  *
+ * Must be [closed][close] when no longer needed to release coroutine resources.
+ *
  * @param delegate The underlying Kotlin [DirectAuthContinuation.Prompt] instance.
  */
 class PromptContinuation(
     private val delegate: DirectAuthContinuation.Prompt,
-) : DirectAuthenticationState(delegate) {
+) : DirectAuthenticationState(delegate),
+    Closeable {
     private val coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
     /**
@@ -49,4 +54,14 @@ class PromptContinuation(
         coroutineScope.future {
             delegate.proceed(code).toJvm()
         }
+
+    /**
+     * Closes this continuation, cancelling the in-flight [proceedAsync] call if any.
+     *
+     * The pending [CompletableFuture] will complete exceptionally with
+     * [java.util.concurrent.CancellationException].
+     */
+    override fun close() {
+        coroutineScope.cancel()
+    }
 }

--- a/okta-direct-auth/src/jvmMain/kotlin/com/okta/directauth/jvm/TransferContinuation.kt
+++ b/okta-direct-auth/src/jvmMain/kotlin/com/okta/directauth/jvm/TransferContinuation.kt
@@ -19,7 +19,9 @@ import com.okta.directauth.model.DirectAuthContinuation
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.future.future
+import java.io.Closeable
 import java.util.concurrent.CompletableFuture
 
 /**
@@ -27,11 +29,16 @@ import java.util.concurrent.CompletableFuture
  *
  * Provides an async method for polling the status of an out-of-band authentication.
  *
+ * Must be [closed][close] when no longer needed to release coroutine resources — in particular,
+ * to stop an in-flight [proceedAsync] poll loop, which can otherwise run for up to
+ * [expirationInSeconds] seconds.
+ *
  * @param delegate The underlying Kotlin [DirectAuthContinuation.Transfer] instance.
  */
 class TransferContinuation(
     private val delegate: DirectAuthContinuation.Transfer,
-) : DirectAuthenticationState(delegate) {
+) : DirectAuthenticationState(delegate),
+    Closeable {
     private val coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
     /**
@@ -53,4 +60,14 @@ class TransferContinuation(
         coroutineScope.future {
             delegate.proceed().toJvm()
         }
+
+    /**
+     * Closes this continuation, cancelling the in-flight [proceedAsync] poll if any.
+     *
+     * The pending [CompletableFuture] will complete exceptionally with
+     * [java.util.concurrent.CancellationException].
+     */
+    override fun close() {
+        coroutineScope.cancel()
+    }
 }

--- a/okta-direct-auth/src/jvmMain/kotlin/com/okta/directauth/jvm/WebAuthnContinuation.kt
+++ b/okta-direct-auth/src/jvmMain/kotlin/com/okta/directauth/jvm/WebAuthnContinuation.kt
@@ -21,7 +21,9 @@ import com.okta.directauth.model.WebAuthnAssertionResponse
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.future.future
+import java.io.Closeable
 import java.util.concurrent.CompletableFuture
 
 /**
@@ -29,11 +31,14 @@ import java.util.concurrent.CompletableFuture
  *
  * Provides async methods for completing a WebAuthn ceremony.
  *
+ * Must be [closed][close] when no longer needed to release coroutine resources.
+ *
  * @param delegate The underlying Kotlin [DirectAuthContinuation.WebAuthn] instance.
  */
 class WebAuthnContinuation(
     private val delegate: DirectAuthContinuation.WebAuthn,
-) : DirectAuthenticationState(delegate) {
+) : DirectAuthenticationState(delegate),
+    Closeable {
     private val coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
     /**
@@ -69,4 +74,14 @@ class WebAuthnContinuation(
         coroutineScope.future {
             delegate.proceed(assertionResponse).toJvm()
         }
+
+    /**
+     * Closes this continuation, cancelling the in-flight [proceedAsync] call if any.
+     *
+     * The pending [CompletableFuture] will complete exceptionally with
+     * [java.util.concurrent.CancellationException].
+     */
+    override fun close() {
+        coroutineScope.cancel()
+    }
 }


### PR DESCRIPTION
The Java continuation wrappers need a closable to close the
internal scopes. Update the samples on how this is used.
Add back the KeygenParameterSpec workaround on Android.
In DirectAuthContinuation fix a issue where the flow was not updated.