### PR TITLE
Fix and expand KDoc across all Dokka-published modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build/
 local.properties
 e2eCredentials.yaml
 /htmlReport
+/.release-drafts/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 ## Unreleased
 
 Per-module versions are now tracked and released independently. The sections below cover
-`auth-foundation`, `oauth2`, `web-authentication-ui`, and `okta-direct-auth` changes accumulated
-since each module's last release. `okta-idx-kotlin` (currently 3.1.1) is unaffected and not
-included here.
+`auth-foundation`, `oauth2`, and `web-authentication-ui` changes accumulated since each module's
+last release. `okta-direct-auth` and `okta-idx-kotlin` each maintain their own `CHANGELOG.md`
+(`okta-direct-auth/CHANGELOG.md`, `okta-idx-kotlin/CHANGELOG.md`) and are not duplicated here —
+see `okta-direct-auth/CHANGELOG.md` for its upcoming 1.0.0 changes. `okta-idx-kotlin` (currently
+3.1.1) is additionally unaffected by this release wave.
 
 ### Release checklist (next steps)
 
@@ -17,7 +19,35 @@ included here.
    CLAUDE.md's API Compatibility section).
 3. Move this "Unreleased" section into dated, per-module entries once each release is actually
    tagged and published (see the existing per-module tags: `auth-foundation@2.0.5`,
-   `okta-direct-auth@0.0.1`, `okta-idx-kotlin@3.1.1`).
+   `okta-direct-auth@0.0.1`, `okta-idx-kotlin@3.1.1`). Replace each `### <module> 3.0.0` heading
+   with a top-level, dated `## <module> 3.0.0 - <release date>` heading plus a commit-compare
+   link, matching the `[Commits](...)` links on older entries further down this file:
+
+   ```
+   ## auth-foundation 3.0.0 - <release date>
+
+   [Commits](https://github.com/okta/okta-mobile-kotlin/compare/auth-foundation@2.0.5...auth-foundation@3.0.0)
+
+   #### Breaking changes
+   ...
+   ```
+
+   `oauth2` and `web-authentication-ui` are being tagged independently for the first time with
+   this release, so there's no prior `oauth2@2.0.4`/`web-authentication-ui@2.0.4` tag to compare
+   from — use commit `e70ffa5c` (the last commit before either module's version left 2.0.4)
+   instead:
+
+   ```
+   ## oauth2 3.0.0 - <release date>
+
+   [Commits](https://github.com/okta/okta-mobile-kotlin/compare/e70ffa5c...oauth2@3.0.0)
+   ```
+
+   ```
+   ## web-authentication-ui 3.0.0 - <release date>
+
+   [Commits](https://github.com/okta/okta-mobile-kotlin/compare/e70ffa5c...web-authentication-ui@3.0.0)
+   ```
 
 ### auth-foundation 3.0.0
 
@@ -36,7 +66,7 @@ major release with breaking changes to the credential-event and cache APIs.
   replaced by `getCredentialIdentifier(): CredentialIdentifier`.
 - `NoAccessTokenAvailableEvent.getCredential()` return type changed from `Credential` to
   `CredentialIdentifier`.
-- `CredentialStoredEvent.getToken()` return type changed from `Token` to `TokenInfo`.
+- `CredentialStoredEvent.getToken()` return type changed from `Token` to `TokenInfo?` (now nullable).
 - `JwtParser.Companion.create()` — the only public factory for `JwtParser` — removed.
 - `CoalescingOrchestrator` changed from public to internal.
 - `com.okta.authfoundation.api.http.log.AuthFoundationLogger`/`LogLevel` relocated to
@@ -83,9 +113,6 @@ major release with breaking changes to the credential-event and cache APIs.
 - Uncaught `ProviderException` in `AndroidKeystoreUtil.getOrCreateAesKey` (#403).
 - `CoalescingOrchestrator` reimplemented with `Mutex` instead of `synchronized`, removing a
   thread-blocking lock inside suspend functions (#400).
-- `Credential.refreshToken(extraRequestParameters)`'s default implementation now returns
-  `Result.failure(NotImplementedError)` for a non-empty map instead of silently ignoring the extra
-  parameters and delegating to `refreshToken()`.
 
 ### oauth2 3.0.0
 
@@ -147,43 +174,6 @@ major release with breaking changes to the credential-event and cache APIs.
   `OidcConfiguration`-based path (#406).
 - `ForegroundActivityEvent`/`CustomizeBrowserEvent`/`CustomizeCustomTabsEvent` reparented under a
   new `UIEvent` marker interface — still `Event` subtypes, non-breaking (#407).
-
-### okta-direct-auth 1.0.0
-
-Graduating from beta (0.0.1) to the first stable release.
-
-#### Breaking changes
-- `DirectAuthenticationState.Authenticated.token` type changed from
-  `com.okta.authfoundation.credential.Token` to `com.okta.authfoundation.client.TokenInfo`.
-- `DirectAuthContinuation.WebAuthn.challengeData` changed from a `String` property to a
-  `challengeData(): Result<String>` function; `proceed(authenticationResponseJson: String)`
-  (previously an unimplemented stub) removed, replaced by `proceed(WebAuthnCeremonyHandler)` and
-  `proceed(WebAuthnAssertionResponse)`.
-- `com.okta.directauth.http.KtorHttpExecutor` removed — relocated to
-  `com.okta.authfoundation.api.http.KtorHttpExecutor`.
-- `com.okta.directauth.log.AuthFoundationLoggerImpl` removed from the public API — relocated into
-  `auth-foundation`.
-- `UNKNOWN_ERROR` constant removed from `InternalErrorCodeKt`.
-- The builder's logger accessor type changed to the relocated
-  `com.okta.authfoundation.api.log.AuthFoundationLogger`.
-
-#### Added
-- WebAuthn/passkey support: `WebAuthnCeremonyHandler`, `WebAuthnAssertionResponse`,
-  `AuthenticatorEnrollment`, `AndroidWebAuthnCeremonyHandler`, `PrimaryFactor.WebAuthn`,
-  `DirectAuthTokenRequest.WebAuthn`/`WebAuthnMfa` (#374).
-- Full Java-compatible `CompletableFuture` API under `com.okta.directauth.jvm`: `DirectAuthResult`,
-  `DirectAuthenticationFlow`, `DirectAuthenticationFlowBuilder`, and MFA/OOB/Prompt/Transfer/WebAuthn
-  continuation wrappers (#376).
-- Java CLI sample app demonstrating Direct Authentication end-to-end (#377).
-- Cross-platform (KMP) credential management integration (#381).
-- New 3-arg builder `create(issuerUrl, clientId, scope)` overload; new 2-arg MFA `challenge`/
-  `resume` overloads, added alongside the existing ones.
-- ABI validation rolled out (#411).
-
-#### Changed
-- Module converted from an Android-only build to Kotlin Multiplatform (Android + JVM) (#368, #369).
-- Internal `ApiResponseExt` extension functions refactored into `StepHandlers` — internal-only, no
-  public API impact (#366).
 
 ## [2.0.3] - 2025-02-18
 - Make SDK defaults configurable by third party SDKs [#323](https://github.com/okta/okta-mobile-kotlin/pull/323)

--- a/auth-foundation/README.md
+++ b/auth-foundation/README.md
@@ -21,7 +21,7 @@ AuthFoundation is the core Okta Mobile Kotlin module for Kotlin Multiplatform au
 
 ```kotlin
 dependencies {
-    implementation(platform("com.okta.kotlin:bom:2.0.5"))
+    implementation(platform("com.okta.kotlin:bom:3.0.0"))
     implementation("com.okta.kotlin:auth-foundation")
 }
 ```

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/InternalAuthFoundationApi.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/InternalAuthFoundationApi.kt
@@ -15,6 +15,7 @@
  */
 package com.okta.authfoundation
 
+/** Marks an API as internal to Okta SDKs; not covered by compatibility guarantees. */
 @Retention(value = AnnotationRetention.BINARY)
 @Target(
     AnnotationTarget.CLASS,

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/TokenInfo.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/client/TokenInfo.kt
@@ -15,6 +15,15 @@
  */
 package com.okta.authfoundation.client
 
+/**
+ * Read-only view of an OAuth2 token set (access token, optional refresh token, ID token, and
+ * device secret) plus the identity of the client and issuer that minted it.
+ *
+ * This is the cross-platform token contract returned by [com.okta.authfoundation.client.kmp.OAuth2Client]
+ * and stored via [com.okta.authfoundation.credential.kmp.TokenCredentialManager]. The default
+ * implementation is [com.okta.authfoundation.credential.kmp.TokenData]; on Android the deprecated
+ * [com.okta.authfoundation.credential.Token] also implements it.
+ */
 interface TokenInfo {
     /**
      * Unique identifier for this token.

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/credential/CredentialIdentifier.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/credential/CredentialIdentifier.kt
@@ -18,9 +18,9 @@ package com.okta.authfoundation.credential
 /**
  * Minimal identity contract for credentials.
  *
- * Both the cross-platform [Credential] and the Android-specific
- * [Credential][com.okta.authfoundation.credential.Credential] implement this interface,
- * allowing credential lifecycle events to reference either type.
+ * Both the cross-platform [Credential][com.okta.authfoundation.credential.kmp.Credential] and
+ * the Android-specific [Credential][com.okta.authfoundation.credential.Credential] implement
+ * this interface, allowing credential lifecycle events to reference either type.
  */
 interface CredentialIdentifier {
     /** Unique identifier for this credential. */

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/credential/events/CredentialCreatedEvent.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/credential/events/CredentialCreatedEvent.kt
@@ -20,7 +20,7 @@ import com.okta.authfoundation.events.CredentialEvent
 import com.okta.authfoundation.events.EventHandler
 
 /**
- * Emitted via [EventHandler.onEvent] when a [CredentialIdentifier] has been created via a createCredential call.
+ * Emitted via [EventHandler.onEvent] when a credential has been created (e.g. via `TokenCredentialManager.store`).
  */
 class CredentialCreatedEvent internal constructor(
     /**

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/credential/events/CredentialDeletedEvent.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/credential/events/CredentialDeletedEvent.kt
@@ -20,7 +20,7 @@ import com.okta.authfoundation.events.CredentialEvent
 import com.okta.authfoundation.events.EventHandler
 
 /**
- * Emitted via [EventHandler.onEvent] when a [CredentialIdentifier] has been deleted via a [CredentialIdentifier.delete] call.
+ * Emitted via [EventHandler.onEvent] when a credential is deleted.
  */
 class CredentialDeletedEvent internal constructor(
     /**

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/credential/events/CredentialStoredAfterRemovedEvent.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/credential/events/CredentialStoredAfterRemovedEvent.kt
@@ -20,7 +20,7 @@ import com.okta.authfoundation.events.CredentialEvent
 import com.okta.authfoundation.events.EventHandler
 
 /**
- * Emitted via [EventHandler.onEvent] when a [CredentialIdentifier.replaceToken] was invoked after a [CredentialIdentifier.delete] call.
+ * Emitted via [EventHandler.onEvent] when a credential's token is replaced after the credential was deleted.
  */
 class CredentialStoredAfterRemovedEvent internal constructor(
     /**

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/credential/events/CredentialStoredEvent.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/credential/events/CredentialStoredEvent.kt
@@ -21,7 +21,7 @@ import com.okta.authfoundation.events.CredentialEvent
 import com.okta.authfoundation.events.EventHandler
 
 /**
- * Emitted via [EventHandler.onEvent] after a [CredentialIdentifier] is updated due to a [CredentialIdentifier.replaceToken] invocation.
+ * Emitted via [EventHandler.onEvent] after a [CredentialIdentifier] is updated when a credential's token is replaced.
  */
 class CredentialStoredEvent internal constructor(
     /**

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/credential/kmp/Credential.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/credential/kmp/Credential.kt
@@ -30,9 +30,9 @@ import kotlinx.coroutines.flow.Flow
  * Instances are **immutable snapshots**: [token], [tags], and [id] never change after construction.
  * Methods that modify credential state return a [Result] containing a new [Credential] snapshot.
  *
- * On Android, the existing [Credential][com.okta.authfoundation.credential.Credential] class
- * implements this interface while preserving mutable internal behavior as a transitional adapter.
- * On JVM and other KMP targets, [CredentialImpl] provides the default immutable implementation.
+ * On JVM and other KMP targets, [CredentialImpl] is the implementation. The Android-only
+ * [Credential][com.okta.authfoundation.credential.Credential] is a separate, deprecated type
+ * that shares only the [CredentialIdentifier] contract — it does not implement this interface.
  */
 interface Credential : CredentialIdentifier {
     /** Unique identifier for this credential. */

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/credential/kmp/CredentialImpl.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/credential/kmp/CredentialImpl.kt
@@ -47,8 +47,9 @@ import kotlinx.coroutines.flow.MutableSharedFlow
  * Shared mutable state (deletion tracking, token flows, refresh deduplication) is managed by
  * [CredentialDataSource], keyed by credential [id].
  *
- * Used on JVM and other non-Android KMP targets. On Android, the existing
- * [Credential][com.okta.authfoundation.credential.Credential] class provides a mutable adapter.
+ * Used on JVM and other non-Android KMP targets. The Android-only
+ * [Credential][com.okta.authfoundation.credential.Credential] is a separate, deprecated type
+ * that shares only the [CredentialIdentifier] contract — it does not implement this interface.
  */
 @OptIn(InternalAuthFoundationApi::class)
 class CredentialImpl internal constructor(

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/credential/kmp/DefaultCredentialIdStore.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/credential/kmp/DefaultCredentialIdStore.kt
@@ -20,7 +20,7 @@ package com.okta.authfoundation.credential.kmp
  *
  * On Android, the existing [DefaultCredentialIdDataStore] provides an encrypted DataStore-based
  * implementation. For cross-platform persistent storage, use
- * [RoomDefaultCredentialIdStore][com.okta.authfoundation.credential.storage.RoomDefaultCredentialIdStore].
+ * [RoomDefaultCredentialIdStore][com.okta.authfoundation.credential.kmp.storage.RoomDefaultCredentialIdStore].
  */
 interface DefaultCredentialIdStore {
     /** Returns the current default credential ID, or null if none is set. */

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/credential/kmp/TokenCredentialManager.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/credential/kmp/TokenCredentialManager.kt
@@ -72,7 +72,8 @@ class TokenCredentialManager(
     /**
      * Stores a new credential with the given [token] and optional [tags].
      *
-     * @return [Result.success] with the stored [Credential].
+     * @return [Result.success] with the stored [Credential], or [Result.failure] wrapping any
+     * exception thrown while persisting the credential to storage.
      */
     suspend fun store(
         token: TokenData,

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/events/Event.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/events/Event.kt
@@ -15,4 +15,11 @@
  */
 package com.okta.authfoundation.events
 
+/**
+ * Root marker interface for all events emitted by Auth Foundation and other Okta SDKs.
+ *
+ * Collected from [com.okta.authfoundation.client.kmp.OAuth2Client.events] and
+ * [com.okta.authfoundation.credential.kmp.TokenCredentialManager.events]. Filter by the
+ * [TokenEvent] and [CredentialEvent] sub-interfaces to narrow to a lifecycle category.
+ */
 interface Event

--- a/legacy-token-migration/src/main/java/com/okta/legacytokenmigration/LegacyTokenMigration.kt
+++ b/legacy-token-migration/src/main/java/com/okta/legacytokenmigration/LegacyTokenMigration.kt
@@ -31,6 +31,9 @@ import java.util.UUID
  * A helper class to migrate tokens from the [Legacy OIDC SDK](https://github.com/okta/okta-oidc-android) to Auth Foundations
  * [Credential].
  *
+ * [migrate] is idempotent — it records completion in private SharedPreferences and returns [Result.PreviouslyMigrated] on subsequent
+ * calls, so it is safe to invoke on every app start.
+ *
  * See [migrate.md](https://github.com/okta/okta-mobile-kotlin/blob/master/migrate.md) for more information.
  */
 object LegacyTokenMigration {
@@ -39,14 +42,20 @@ object LegacyTokenMigration {
     private const val SHARED_PREFERENCE_MIGRATED_TOKEN_ID_KEY = "com.okta.legacytokenmigration.token.id"
 
     /**
-     * Attempts to migrate a token from a [SessionClient] to a [Token]. The resulting [Token] can be stored using [Credential.store],
-     * and can be set as default using [Credential.setDefaultAsync] or [Credential.default].
+     * Migrates the token held by a legacy [SessionClient] into a new [Credential], persisting it to the [CredentialDataSource], and
+     * clears the legacy [SessionClient].
+     *
+     * On success/previously-migrated, look the stored credential up with `Credential.with(result.tokenId)` and optionally make it the
+     * default via `Credential.default = ...` / `Credential.setDefaultAsync(...)`.
      *
      * @param context used for storing the status of previous migrations in Shared Preferences.
      * @param sessionClient a configured session client with the stored tokens from a previous authentication where the token will be
      *  migrated from.
      *
-     * @return a [Result] with the outcome of the migration.
+     * @return a [Result]: [Result.SuccessfullyMigrated] (new credential created), [Result.PreviouslyMigrated] (migration already ran
+     *  previously), [Result.MissingLegacyToken] (the [SessionClient] had no token), or [Result.Error] (an exception occurred —
+     *  inspect `exception`). This function never throws for these cases; it is safe to call from any dispatcher (it switches to
+     *  `Dispatchers.IO` internally).
      */
     suspend fun migrate(
         context: Context,
@@ -95,12 +104,15 @@ object LegacyTokenMigration {
     @VisibleForTesting internal fun SharedPreferences.hasMarkedTokensAsMigrated(): Boolean = getBoolean(SHARED_PREFERENCE_HAS_MIGRATED_KEY, false)
 
     /**
-     * Describes the result from [LegacyTokenMigration.migrate].
+     * The exhaustive set of outcomes from [LegacyTokenMigration.migrate]. Branch on it with an exhaustive `when` to handle success,
+     * prior migration, a missing legacy token, and errors.
      */
     sealed class Result {
         /**
          * The token was previously migrated. No changes were made as a result of the [LegacyTokenMigration.migrate] call. The migrated token was
          * stored in [CredentialDataSource] with the returned [tokenId].
+         *
+         * @property tokenId The id of the stored [Credential]; retrieve it with `Credential.with(tokenId)`.
          */
         data class PreviouslyMigrated(
             val tokenId: String,
@@ -112,16 +124,18 @@ object LegacyTokenMigration {
          */
         class Error internal constructor(
             /**
-             *
+             * The exception that caused migration to fail — e.g. an error thrown while reading tokens from the [SessionClient], or a
+             * failure persisting the new [Credential]. Migration state is left untouched, so the call can be safely retried.
              */
             val exception: Exception,
         ) : Result()
 
         /**
-         * The token migrated successfully.
-         * The [Credential] supplied to the [LegacyTokenMigration.migrate] call now stores the token.
-         * The [SessionClient] supplied to the [LegacyTokenMigration.migrate] call has been cleared, and should no longer be used.
-         * The migrated token is stored in [CredentialDataSource] with the returned [tokenId]
+         * The token migrated successfully. A new [Credential] was created and stored in the [CredentialDataSource]; reference it with
+         * the returned [tokenId] via `Credential.with(tokenId)`. The [SessionClient] passed to [migrate] has been cleared and must not
+         * be used again.
+         *
+         * @property tokenId The id of the stored [Credential]; retrieve it with `Credential.with(tokenId)`.
          */
         data class SuccessfullyMigrated(
             val tokenId: String,

--- a/migrate.md
+++ b/migrate.md
@@ -36,12 +36,12 @@ when (val result = LegacyTokenMigration.migrate(context, sessionClient)) {
     is LegacyTokenMigration.Result.PreviouslyMigrated -> {
         TODO("Contains ${result.tokenId} for referencing stored token in CredentialDataSource")
         // Optionally set this as default Credential as follows
-        Credential.with(result.tokenId())?.let { Credential.setDefaultCredential(it) }
+        Credential.with(result.tokenId)?.let { Credential.default = it }
     }
     is LegacyTokenMigration.Result.SuccessfullyMigrated -> {
         TODO("Contains ${result.tokenId} for referencing stored token in CredentialDataSource")
         // Optionally set this as default Credential as follows
-        Credential.with(result.tokenId())?.let { Credential.setDefaultCredential(it) }
+        Credential.with(result.tokenId)?.let { Credential.default = it }
     }
 }
 ```

--- a/oauth2/README.md
+++ b/oauth2/README.md
@@ -37,13 +37,11 @@ Each flow follows a consistent pattern:
 
 ## Installation
 
-**Current Version: 3.0.0**
-
-Add the dependency to your `build.gradle.kts`:
-
 ```kotlin
 dependencies {
-    implementation("com.okta.kotlin:oauth2:3.0.0")
+    implementation(platform("com.okta.kotlin:bom:3.0.0"))
+    implementation("com.okta.kotlin:auth-foundation")
+    implementation("com.okta.kotlin:oauth2")
 }
 ```
 

--- a/oauth2/src/androidMain/kotlin/com/okta/oauth2/AuthorizationCodeFlow.kt
+++ b/oauth2/src/androidMain/kotlin/com/okta/oauth2/AuthorizationCodeFlow.kt
@@ -31,10 +31,6 @@ import java.util.UUID
  * [AuthorizationCodeFlow] encapsulates the behavior required to authentication using an OIDC Browser redirect flow.
  *
  * See [Authorization Code Flow documentation](https://developer.okta.com/docs/guides/implement-grant-type/authcodepkce/main/#about-the-authorization-code-grant-with-pkce)
- *
- * @deprecated This Android-only AuthorizationCodeFlow is deprecated in favor of the KMP variant, which works
- * on Android and JVM. Use [com.okta.oauth2.kmp.AuthorizationCodeFlow] instead, or the higher-level
- * [com.okta.webauthenticationui.WebAuthentication] which is already KMP-backed.
  */
 @Deprecated(
     message =

--- a/oauth2/src/androidMain/kotlin/com/okta/oauth2/DeviceAuthorizationFlow.kt
+++ b/oauth2/src/androidMain/kotlin/com/okta/oauth2/DeviceAuthorizationFlow.kt
@@ -36,9 +36,6 @@ import okhttp3.Request
  * 2. A simple user code they can easily enter on that secondary device.
  *
  * Upon visiting that URL and entering in the code, the user is prompted to sign in using their standard credentials. Upon completing authentication, the device automatically signs the user in, without any direct interaction on the user's part.
- *
- * @deprecated This Android-only DeviceAuthorizationFlow is deprecated in favor of the KMP variant, which
- * works on Android and JVM. Use [com.okta.oauth2.kmp.DeviceAuthorizationFlow] instead.
  */
 @Deprecated(
     message =

--- a/oauth2/src/androidMain/kotlin/com/okta/oauth2/RedirectEndSessionFlow.kt
+++ b/oauth2/src/androidMain/kotlin/com/okta/oauth2/RedirectEndSessionFlow.kt
@@ -28,10 +28,6 @@ import java.util.UUID
  * [RedirectEndSessionFlow] encapsulates the behavior required to logout using an OIDC Browser redirect flow.
  *
  * > Note: OIDC Logout terminology is nuanced, see [Logout Documentation](https://github.com/okta/okta-mobile-kotlin#logout) for additional details.
- *
- * @deprecated This Android-only RedirectEndSessionFlow is deprecated in favor of the KMP variant, which
- * works on Android and JVM. Use [com.okta.oauth2.kmp.RedirectEndSessionFlow] instead, or the higher-level
- * [com.okta.webauthenticationui.WebAuthentication.logoutOfBrowser] which is already KMP-backed.
  */
 @Deprecated(
     message =

--- a/oauth2/src/androidMain/kotlin/com/okta/oauth2/ResourceOwnerFlow.kt
+++ b/oauth2/src/androidMain/kotlin/com/okta/oauth2/ResourceOwnerFlow.kt
@@ -30,9 +30,6 @@ import okhttp3.Request
  * This simple authentication flow permits a user to authenticate using a simple username and password. As such, the configuration is straightforward.
  *
  * > Important: Resource Owner authentication does not support MFA or other more secure authentication models, and is not recommended for production applications.
- *
- * @deprecated This Android-only ResourceOwnerFlow is deprecated in favor of the KMP variant, which works on
- * Android and JVM. Use [com.okta.oauth2.kmp.ResourceOwnerFlow] instead.
  */
 @Deprecated(
     message =

--- a/oauth2/src/androidMain/kotlin/com/okta/oauth2/SessionTokenFlow.kt
+++ b/oauth2/src/androidMain/kotlin/com/okta/oauth2/SessionTokenFlow.kt
@@ -26,9 +26,6 @@ import okhttp3.Request
 /**
  * [SessionTokenFlow] encapsulates the behavior required to authentication using a session token obtained from the Okta Legacy Authn
  * APIs.
- *
- * @deprecated This Android-only SessionTokenFlow is deprecated in favor of the KMP variant, which works on
- * Android and JVM. Use [com.okta.oauth2.kmp.SessionTokenFlow] instead.
  */
 @Deprecated(
     message =

--- a/oauth2/src/androidMain/kotlin/com/okta/oauth2/TokenExchangeFlow.kt
+++ b/oauth2/src/androidMain/kotlin/com/okta/oauth2/TokenExchangeFlow.kt
@@ -30,9 +30,6 @@ import okhttp3.Request
  * As an example, consider [SSO for Native Apps](https://developer.okta.com/docs/guides/configure-native-sso/main/#native-sso-flow) where a client exchanges the ID and the Device Secret tokens to get access to the resource.
  *
  * See the [specification](https://openid.net/specs/openid-connect-native-sso-1_0.html)
- *
- * @deprecated This Android-only TokenExchangeFlow is deprecated in favor of the KMP variant, which works on
- * Android and JVM. Use [com.okta.oauth2.kmp.TokenExchangeFlow] instead.
  */
 @Deprecated(
     message =

--- a/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/AuthorizationCodeFlow.kt
+++ b/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/AuthorizationCodeFlow.kt
@@ -21,6 +21,11 @@ import com.okta.authfoundation.client.kmp.OAuth2Client
 /**
  * Encapsulates the behavior required to authenticate using the OIDC Authorization Code flow with PKCE.
  *
+ * Call [start] to obtain an [AuthorizationCodeFlowContext] whose [AuthorizationCodeFlowContext.url] you open
+ * with a [BrowserRedirectHandler]. Once the browser redirects back to the registered redirect URI, pass that
+ * captured URI along with the same [AuthorizationCodeFlowContext] to [resume] to exchange the authorization
+ * code for tokens.
+ *
  * See [Authorization Code Flow documentation](https://developer.okta.com/docs/guides/implement-grant-type/authcodepkce/main/)
  */
 interface AuthorizationCodeFlow {
@@ -30,9 +35,10 @@ interface AuthorizationCodeFlow {
     val client: OAuth2Client
 
     /**
-     * Thrown by [resume] when the authorization server returns an error.
+     * Thrown by [resume] when the redirect could not be validated or the authorization server returned an error.
      *
-     * @property errorId the OAuth2 error code returned by the server.
+     * @property errorId the error code. For server errors this is the OAuth2 error code from the redirect; for
+     * a failed CSRF/state check it is the SDK-generated value `"state_mismatch"`.
      */
     class ResumeException(
         message: String,
@@ -53,9 +59,9 @@ interface AuthorizationCodeFlow {
      * Initiates the Authorization Code redirect flow.
      *
      * @param redirectUrl the registered redirect URI for this client.
-     * @param extraRequestParameters additional query parameters for the authorization endpoint.
      * @param scope the scopes to request. If omitted, the client's configured
      * default scopes are used.
+     * @param extraRequestParameters additional query parameters for the authorization endpoint.
      * @return a [Result] containing an [AuthorizationCodeFlowContext] with the authorization URL and state.
      */
     suspend fun start(
@@ -69,7 +75,9 @@ interface AuthorizationCodeFlow {
      *
      * @param uri the redirect URI received from the browser after authorization.
      * @param flowContext the [AuthorizationCodeFlowContext] returned by [start].
-     * @return a [Result] containing [TokenInfo] on success.
+     * @return a [Result] containing [TokenInfo] on success. On failure the [Result] wraps
+     * [RedirectSchemeMismatchException] (redirect URI didn't match), [MissingResultCodeException] (no `code`
+     * in the redirect), or [ResumeException] (state mismatch or a server-returned error).
      */
     suspend fun resume(
         uri: String,

--- a/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/ResourceOwnerFlow.kt
+++ b/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/ResourceOwnerFlow.kt
@@ -34,8 +34,6 @@ import com.okta.authfoundation.client.kmp.OAuth2Client
  * result.onSuccess { tokenInfo -> println("Access token: ${tokenInfo.accessToken}") }
  * result.onFailure { error -> println("Authentication failed: $error") }
  * ```
- *
- * @see ResourceOwnerFlowImpl
  */
 interface ResourceOwnerFlow {
     /**

--- a/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/SessionTokenFlow.kt
+++ b/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/SessionTokenFlow.kt
@@ -21,6 +21,9 @@ import com.okta.authfoundation.client.kmp.OAuth2Client
 /**
  * Implements the Session Token authentication flow.
  *
+ * Use this flow to exchange a session token issued by the legacy Okta Authn API for OIDC tokens, for example
+ * when migrating a user session established through the Authn API into this SDK's token-based flows.
+ *
  * Exchanges a session token (obtained from the Okta legacy Authn API) for OAuth2 tokens by:
  * 1. Building an authorization URL with the session token as an extra parameter.
  * 2. Making a GET request to the authorization URL and capturing the redirect `Location` header.
@@ -37,9 +40,9 @@ interface SessionTokenFlow {
      *
      * @param sessionToken the session token obtained from Okta legacy Authn APIs.
      * @param redirectUrl the redirect URL registered with the authorization server.
-     * @param extraRequestParameters additional key-value pairs appended to the authorization URL.
      * @param scope the scopes to request. If omitted, the client's configured
      * default scopes are used.
+     * @param extraRequestParameters additional key-value pairs appended to the authorization URL.
      * @return [Result.success] with [TokenInfo] on success, or [Result.failure] on error.
      */
     suspend fun start(

--- a/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/TokenExchangeFlow.kt
+++ b/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/TokenExchangeFlow.kt
@@ -40,10 +40,10 @@ interface TokenExchangeFlow {
      *
      * @param idToken the ID token for the user.
      * @param deviceSecret the device secret obtained from a previous authentication flow.
-     * @param audience the resource server audience to request. When null (the default), no `audience` parameter
-     * is sent and the authorization server applies its own default.
      * @param scope the scopes to request. If omitted, the client's configured
      * default scopes are used.
+     * @param audience the resource server audience to request. When null (the default), no `audience` parameter
+     * is sent and the authorization server applies its own default.
      * @return [Result.success] with [TokenInfo] on success, or [Result.failure] with:
      * - [com.okta.authfoundation.client.OAuth2ClientResult.Error.OidcEndpointsNotAvailableException] if endpoints are unavailable.
      * - [com.okta.authfoundation.client.OAuth2ClientResult.Error.HttpResponseException] on server errors.

--- a/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/jvm/AuthorizationCodeFlow.kt
+++ b/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/jvm/AuthorizationCodeFlow.kt
@@ -39,7 +39,7 @@ import com.okta.oauth2.kmp.AuthorizationCodeFlow as KotlinAuthorizationCodeFlow
  * Typical Java usage:
  * ```java
  * AuthorizationCodeFlow flow = new AuthorizationCodeFlow(kmpClient);
- * TokenInfo token = flow.start(redirectUrl, browserHandler).get();
+ * TokenInfo token = flow.start(redirectUrl, browserHandler, scope).get();
  * flow.close();
  * ```
  *
@@ -67,8 +67,8 @@ class AuthorizationCodeFlow(
      *
      * @param redirectUrl the registered redirect URI for this client.
      * @param browserRedirectHandler handles opening the browser and capturing the redirect.
-     * @param extraRequestParameters additional authorization endpoint parameters.
      * @param scope the scopes to request.
+     * @param extraRequestParameters additional authorization endpoint parameters.
      * @return a [CompletableFuture] that completes with [TokenInfo] on success,
      *   or completes exceptionally on failure.
      */

--- a/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/jvm/SessionTokenFlow.kt
+++ b/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/jvm/SessionTokenFlow.kt
@@ -35,7 +35,7 @@ import com.okta.oauth2.kmp.SessionTokenFlow as KotlinSessionTokenFlow
  * Typical Java usage:
  * ```java
  * SessionTokenFlow flow = new SessionTokenFlow(kmpClient);
- * TokenInfo token = flow.start(sessionToken, redirectUrl).get();
+ * TokenInfo token = flow.start(sessionToken, redirectUrl, scope).get();
  * flow.close();
  * ```
  *
@@ -60,8 +60,8 @@ class SessionTokenFlow(
      *
      * @param sessionToken the session token obtained from the Okta legacy Authn API.
      * @param redirectUrl the redirect URL registered with the authorization server.
-     * @param extraRequestParameters additional key-value pairs appended to the authorization URL.
      * @param scope the scopes to request.
+     * @param extraRequestParameters additional key-value pairs appended to the authorization URL.
      * @return a [CompletableFuture] that completes with [TokenInfo] on success,
      *   or completes exceptionally on failure.
      */

--- a/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/jvm/TokenExchangeFlow.kt
+++ b/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/jvm/TokenExchangeFlow.kt
@@ -35,7 +35,7 @@ import com.okta.oauth2.kmp.TokenExchangeFlow as KotlinTokenExchangeFlow
  * Typical Java usage:
  * ```java
  * TokenExchangeFlow flow = new TokenExchangeFlow(kmpClient);
- * TokenInfo token = flow.start(idToken, deviceSecret, null, scope).get();
+ * TokenInfo token = flow.start(idToken, deviceSecret, scope, null).get();
  * flow.close();
  * ```
  *
@@ -60,8 +60,8 @@ class TokenExchangeFlow(
      *
      * @param idToken the ID token for the user.
      * @param deviceSecret the device secret from a previous authentication flow.
-     * @param audience optional audience; pass null to omit from the request.
      * @param scope the scopes to request.
+     * @param audience optional audience; pass null to omit from the request.
      * @return a [CompletableFuture] that completes with [TokenInfo] on success,
      *   or completes exceptionally on failure.
      */

--- a/okta-direct-auth/CHANGELOG.md
+++ b/okta-direct-auth/CHANGELOG.md
@@ -1,3 +1,47 @@
+## [1.0.0] - Unreleased
+
+Graduating from beta (0.0.1) to the first stable release.
+
+### Breaking changes
+
+- `DirectAuthenticationState.Authenticated.token` type changed from
+  `com.okta.authfoundation.credential.Token` to `com.okta.authfoundation.client.TokenInfo`.
+- `DirectAuthContinuation.WebAuthn.challengeData` changed from a `String` property to a
+  `challengeData(): Result<String>` function; `proceed(authenticationResponseJson: String)`
+  (previously an unimplemented stub) removed, replaced by `proceed(WebAuthnCeremonyHandler)` and
+  `proceed(WebAuthnAssertionResponse)`.
+- `com.okta.directauth.http.KtorHttpExecutor` removed — relocated to
+  `com.okta.authfoundation.api.http.KtorHttpExecutor`.
+- `com.okta.directauth.log.AuthFoundationLoggerImpl` removed from the public API — relocated into
+  `auth-foundation`.
+- `UNKNOWN_ERROR` constant removed from `InternalErrorCodeKt`.
+- The builder's logger accessor type changed to the relocated
+  `com.okta.authfoundation.api.log.AuthFoundationLogger`.
+
+### Added
+
+- WebAuthn/passkey support: `WebAuthnCeremonyHandler`, `WebAuthnAssertionResponse`,
+  `AuthenticatorEnrollment`, `AndroidWebAuthnCeremonyHandler`, `PrimaryFactor.WebAuthn`,
+  `DirectAuthTokenRequest.WebAuthn`/`WebAuthnMfa`.
+- Full Java-compatible `CompletableFuture` API under `com.okta.directauth.jvm`: `DirectAuthResult`,
+  `DirectAuthenticationFlow`, `DirectAuthenticationFlowBuilder`, and MFA/OOB/Prompt/Transfer/WebAuthn
+  continuation wrappers.
+- Java CLI sample app demonstrating Direct Authentication end-to-end.
+- Cross-platform (KMP) credential management integration.
+- New 3-arg builder `create(issuerUrl, clientId, scope)` overload; new 2-arg MFA `challenge`/
+  `resume` overloads, added alongside the existing ones.
+- ABI validation rolled out.
+- `com.okta.directauth.jvm` MFA/OOB/Prompt/Transfer/WebAuthn continuation wrappers now implement
+  `Closeable`, so callers can cancel an in-flight `*Async` call (e.g. an `OobPendingContinuation`/
+  `TransferContinuation` poll loop, which can otherwise run for the challenge's full expiration
+  window) without discarding the returned `CompletableFuture`.
+
+### Changed
+
+- Module converted from an Android-only build to Kotlin Multiplatform (Android + JVM).
+- Internal `ApiResponseExt` extension functions refactored into `StepHandlers` — internal-only, no
+  public API impact.
+
 ## [0.0.1] - 2026-02-02
 
 ### Added

--- a/okta-direct-auth/README.md
+++ b/okta-direct-auth/README.md
@@ -31,24 +31,22 @@ Unlike browser-based authentication flows, Direct Authentication gives you full 
 - One-Time Passcode (OTP)
 - Out-of-Band authentication (Push, SMS, Voice)
 - WebAuthn/Passkeys
-- multifactor authentication (MFA)
+- Multi-Factor authentication (MFA)
 - Self-Service Password Recovery (SSPR)
 
 ## Requirements
 
-- Android API 23+
+- Android API 26+ (Android target) or Java 11+ (JVM target) — you only need the one matching your platform
 - Okta org with Direct Authentication enabled
 - Client application configured for Direct Authentication grant types
 
 ## Installation
 
-**Current Version: 0.0.1**
-
-Add the dependency to your `build.gradle.kts`:
-
 ```kotlin
 dependencies {
-    implementation("com.okta.kotlin:okta-direct-auth:0.0.1")
+    implementation(platform("com.okta.kotlin:bom:3.0.0"))
+    implementation("com.okta.kotlin:auth-foundation")
+    implementation("com.okta.kotlin:okta-direct-auth")
 }
 ```
 
@@ -149,8 +147,8 @@ Start authentication by calling `start()` with a username and primary factor:
 import com.okta.directauth.model.PrimaryFactor
 
 directAuth.start(
-    username = "user@example.com",
-    factor = PrimaryFactor.Password("user-password")
+    loginHint = "user@example.com",
+    primaryFactor = PrimaryFactor.Password("user-password")
 )
 ```
 
@@ -158,8 +156,8 @@ directAuth.start(
 
 ```kotlin
 directAuth.start(
-    username = "user@example.com",
-    factor = PrimaryFactor.Otp("123456")
+    loginHint = "user@example.com",
+    primaryFactor = PrimaryFactor.Otp("123456")
 )
 ```
 
@@ -170,20 +168,20 @@ import com.okta.directauth.model.OobChannel
 
 // Okta Verify Push
 directAuth.start(
-    username = "user@example.com",
-    factor = PrimaryFactor.Oob(OobChannel.PUSH)
+    loginHint = "user@example.com",
+    primaryFactor = PrimaryFactor.Oob(OobChannel.PUSH)
 )
 
 // SMS
 directAuth.start(
-    username = "user@example.com",
-    factor = PrimaryFactor.Oob(OobChannel.SMS)
+    loginHint = "user@example.com",
+    primaryFactor = PrimaryFactor.Oob(OobChannel.SMS)
 )
 
 // Voice Call
 directAuth.start(
-    username = "user@example.com",
-    factor = PrimaryFactor.Oob(OobChannel.VOICE)
+    loginHint = "user@example.com",
+    primaryFactor = PrimaryFactor.Oob(OobChannel.VOICE)
 )
 ```
 
@@ -191,8 +189,8 @@ directAuth.start(
 
 ```kotlin
 directAuth.start(
-    username = "user@example.com",
-    factor = PrimaryFactor.WebAuthn
+    loginHint = "user@example.com",
+    primaryFactor = PrimaryFactor.WebAuthn
 )
 ```
 
@@ -207,20 +205,20 @@ when (val state = directAuth.authenticationState.value) {
     is DirectAuthenticationState.MfaRequired -> {
         // Resume with OTP
         state.resume(
-            factor = PrimaryFactor.Otp("123456"),
-            grantTypesForChallengeTypes = listOf(ChallengeGrantType.OtpMfa)
+            secondaryFactor = PrimaryFactor.Otp("123456"),
+            challengeTypesSupported = listOf(ChallengeGrantType.OtpMfa)
         )
 
         // Or resume with Push notification
         state.resume(
-            factor = PrimaryFactor.Oob(OobChannel.PUSH),
-            grantTypesForChallengeTypes = listOf(ChallengeGrantType.OobMfa)
+            secondaryFactor = PrimaryFactor.Oob(OobChannel.PUSH),
+            challengeTypesSupported = listOf(ChallengeGrantType.OobMfa)
         )
 
         // Or resume with WebAuthn
         state.resume(
-            factor = PrimaryFactor.WebAuthn,
-            grantTypesForChallengeTypes = listOf(ChallengeGrantType.WebAuthnMfa)
+            secondaryFactor = PrimaryFactor.WebAuthn,
+            challengeTypesSupported = listOf(ChallengeGrantType.WebAuthnMfa)
         )
     }
 }
@@ -323,16 +321,19 @@ Authentication errors are emitted as `DirectAuthenticationError`:
 when (val state = directAuth.authenticationState.value) {
     is DirectAuthenticationError -> {
         when (state) {
-            is DirectAuthenticationError.OAuth2Error -> {
-                val errorCode = state.error
+            is DirectAuthenticationError.HttpError.Oauth2Error -> {
+                val error = state.error
                 val errorDescription = state.errorDescription
+                val statusCode = state.httpStatusCode
             }
-            is DirectAuthenticationError.HttpError -> {
-                val statusCode = state.statusCode
+            is DirectAuthenticationError.HttpError.ApiError -> {
+                val errorCode = state.errorCode
+                val errorSummary = state.errorSummary
+                val statusCode = state.httpStatusCode
             }
             is DirectAuthenticationError.InternalError -> {
                 val errorCode = state.errorCode
-                val exception = state.exception
+                val throwable = state.throwable
             }
         }
     }
@@ -540,10 +541,25 @@ if (state instanceof PromptContinuation) {
 
 ### Handling Errors (Java)
 
+Error states are exposed as subtypes of `DirectAuthenticationState.Error` (a Java-friendly wrapper
+distinct from the Kotlin `DirectAuthenticationError`):
+
 ```java
-if (state instanceof DirectAuthenticationState.Error) {
-    DirectAuthenticationState.Error error = (DirectAuthenticationState.Error) state;
-    // Check specific error subtypes
+if (state instanceof DirectAuthenticationState.Error.InternalError) {
+    DirectAuthenticationState.Error.InternalError error =
+        (DirectAuthenticationState.Error.InternalError) state;
+    String errorCode = error.getErrorCode();
+    Throwable throwable = error.getThrowable();
+} else if (state instanceof DirectAuthenticationState.Error.HttpError.Oauth2Error) {
+    DirectAuthenticationState.Error.HttpError.Oauth2Error error =
+        (DirectAuthenticationState.Error.HttpError.Oauth2Error) state;
+    String oauthError = error.getError();
+    String description = error.getErrorDescription();
+} else if (state instanceof DirectAuthenticationState.Error.HttpError.ApiError) {
+    DirectAuthenticationState.Error.HttpError.ApiError error =
+        (DirectAuthenticationState.Error.HttpError.ApiError) state;
+    String errorCode = error.getErrorCode();
+    String errorSummary = error.getErrorSummary();
 }
 ```
 

--- a/okta-direct-auth/src/commonMain/kotlin/com/okta/directauth/DirectAuthenticationFlowBuilder.kt
+++ b/okta-direct-auth/src/commonMain/kotlin/com/okta/directauth/DirectAuthenticationFlowBuilder.kt
@@ -31,12 +31,11 @@ import io.ktor.http.Url
 import kotlin.time.Clock
 
 /**
- * A builder used to configure and create an instance of [DirectAuthenticationFlow].
+ * Configures a [DirectAuthenticationFlow].
  *
- * This class provides a fluent API for setting the necessary parameters for the
- * Direct Authentication flow, such as the issuer URL, client ID, and scopes.
- *
- * An instance of this builder should be created using the [create] factory method.
+ * Rather than instantiating this builder directly, call [create] and configure the instance
+ * inside the trailing lambda, e.g.
+ * `DirectAuthenticationFlowBuilder.create(issuerUrl, clientId, scope) { clientSecret = "..." }`.
  */
 class DirectAuthenticationFlowBuilder private constructor() {
     /**
@@ -106,7 +105,8 @@ class DirectAuthenticationFlowBuilder private constructor() {
      * existing logging framework, such as Timber or a custom solution. It can also be
      * replaced with a mock implementation for testing purposes.
      *
-     * Defaults to an instance of [com.okta.authfoundation.api.log.AuthFoundationLogger] which logs to Android's Logcat.
+     * Defaults to the platform default logger (Android: Logcat; JVM: standard output/SLF4J-style).
+     * See [getDefaultAuthFoundationLogger].
      */
     var logger: AuthFoundationLogger = getDefaultAuthFoundationLogger()
 

--- a/okta-direct-auth/src/commonMain/kotlin/com/okta/directauth/api/DirectAuthenticationFlow.kt
+++ b/okta-direct-auth/src/commonMain/kotlin/com/okta/directauth/api/DirectAuthenticationFlow.kt
@@ -22,12 +22,17 @@ import kotlinx.coroutines.flow.StateFlow
 /**
  * The primary interface for interacting with the Okta Direct Authentication API.
  *
- * This interface defines the contract for initiating an authentication flow. An instance
- * of this interface can be created using the `DirectAuthenticationFlow.create` builder.
+ * This interface defines the contract for initiating an authentication flow. An instance is
+ * created via [com.okta.directauth.DirectAuthenticationFlowBuilder.create]. Kotlin callers
+ * should prefer this coroutine-based API; Java callers should use
+ * [com.okta.directauth.jvm.DirectAuthenticationFlow], which exposes CompletableFuture-based
+ * methods.
  */
 interface DirectAuthenticationFlow {
     /**
-     * Indicates authentication flow state
+     * A [StateFlow] emitting the current [DirectAuthenticationState]; collect it to observe
+     * every transition driven by `start()`, `reset()`, and the various
+     * `proceed()`/`challenge()`/`resume()` calls. Starts at [DirectAuthenticationState.Idle].
      */
     val authenticationState: StateFlow<DirectAuthenticationState>
 
@@ -41,7 +46,10 @@ interface DirectAuthenticationFlow {
      * @param loginHint A hint to the authorization server about the user's identity,
      *  such as a username or email address.
      * @param primaryFactor The initial authentication factor to use (e.g., a [PrimaryFactor.Password]).
-     * @return The [DirectAuthenticationState] of the flow
+     * @return the resulting [DirectAuthenticationState] — [DirectAuthenticationState.Authenticated] on immediate
+     * success, [DirectAuthenticationState.MfaRequired] or a [com.okta.directauth.model.DirectAuthContinuation] when
+     * more steps are needed, or a [com.okta.directauth.model.DirectAuthenticationError] on failure. Errors are
+     * returned as states, never thrown (cancellation excepted). Suspends until the server responds.
      */
     suspend fun start(
         loginHint: String,
@@ -49,9 +57,10 @@ interface DirectAuthenticationFlow {
     ): DirectAuthenticationState
 
     /**
-     * Resets the direct authentication flow
+     * Resets the direct authentication flow.
      *
-     * @return The [DirectAuthenticationState] of the flow
+     * @return [DirectAuthenticationState.Idle]. This is not a suspending call; it both returns and
+     * emits (via [authenticationState]) the idle state synchronously.
      */
     fun reset(): DirectAuthenticationState
 }

--- a/okta-direct-auth/src/commonMain/kotlin/com/okta/directauth/api/WebAuthnCeremonyHandler.kt
+++ b/okta-direct-auth/src/commonMain/kotlin/com/okta/directauth/api/WebAuthnCeremonyHandler.kt
@@ -23,6 +23,16 @@ import com.okta.directauth.model.WebAuthnAssertionResponse
  * Platform implementations call the native WebAuthn API (e.g., Android Credential Manager)
  * with the server-provided challenge data and return the assertion response.
  *
+ * The full handshake, orchestrated by [com.okta.directauth.model.DirectAuthContinuation.WebAuthn],
+ * runs as follows: the server issues a challenge, which is obtained as raw JSON via
+ * `DirectAuthContinuation.WebAuthn.challengeData()`; that JSON is passed to this handler's
+ * [performAssertion], which invokes the platform's native WebAuthn API to run the ceremony
+ * (e.g., prompting for biometrics or a security key) and returns a [WebAuthnAssertionResponse];
+ * `DirectAuthContinuation.WebAuthn.proceed()` then exchanges that assertion response with the
+ * server for tokens.
+ *
+ * Most Android apps should use `AndroidWebAuthnCeremonyHandler` rather than implementing this
+ * interface directly.
  */
 interface WebAuthnCeremonyHandler {
     /**

--- a/okta-direct-auth/src/commonMain/kotlin/com/okta/directauth/http/model/WebAuthnChallengeResponse.kt
+++ b/okta-direct-auth/src/commonMain/kotlin/com/okta/directauth/http/model/WebAuthnChallengeResponse.kt
@@ -61,6 +61,12 @@ internal data class WebAuthnChallengeResponse(
 /**
  * Represents an authenticator enrollment returned from the Okta server
  * as part of a WebAuthn challenge response.
+ *
+ * @property credentialId Base64url-encoded identifier of a passkey the user has already
+ * registered; used to scope the WebAuthn assertion to enrolled credentials.
+ * @property displayName A human-readable name for the enrolled authenticator, if the server
+ * provided one.
+ * @property profile Additional server-supplied metadata about the enrollment, if any.
  */
 @Serializable
 data class AuthenticatorEnrollment(

--- a/okta-direct-auth/src/commonMain/kotlin/com/okta/directauth/model/DirectAuthContinuation.kt
+++ b/okta-direct-auth/src/commonMain/kotlin/com/okta/directauth/model/DirectAuthContinuation.kt
@@ -30,14 +30,6 @@ import kotlin.time.Duration.Companion.seconds
 /**
  * Represents a state in the Direct Authentication flow where further action is required to proceed.
  *
- * This is a special type of [DirectAuthenticationState] that indicates the flow is paused,
- * pending input from the user or another client-side process.
- *
- * In the case of a failure, the state will be an instance of [DirectAuthenticationError].
- * This can be an [DirectAuthenticationError.HttpError] for API-related issues (e.g., invalid
- * credentials) or an [DirectAuthenticationError.InternalError] for unexpected client-side
- * problems (e.g., network failures, response parsing errors).
- *
  * @param context The [DirectAuthenticationContext] associated with this state.
  * @param mfaContext An optional context for MFA flows, which may be present if the continuation
  * is part of a multi-factor sequence.
@@ -140,7 +132,9 @@ sealed class DirectAuthContinuation(
             }
 
         /**
-         * The list of authenticator enrollments returned from the Okta server.
+         * The list of authenticator enrollments returned from the Okta server, or `null` if the
+         * challenge response did not include any. Use these to scope or disambiguate which
+         * enrolled passkey the WebAuthn ceremony should target.
          */
         val authenticatorEnrollment = webAuthnChallengeResponse.authenticatorEnrollments
 

--- a/okta-direct-auth/src/commonMain/kotlin/com/okta/directauth/model/DirectAuthenticationState.kt
+++ b/okta-direct-auth/src/commonMain/kotlin/com/okta/directauth/model/DirectAuthenticationState.kt
@@ -55,7 +55,7 @@ sealed interface DirectAuthenticationState {
      * This state indicates that the authentication process is still pending and awaiting user action.
      * Such as waiting for the user to complete an out-of-band (OOB) authentication step.
      *
-     * @param timestamp The time in milliseconds when the authorization became pending.
+     * @param timestamp The time in epoch seconds when the authorization became pending.
      */
     class AuthorizationPending internal constructor(
         val timestamp: Long,

--- a/okta-direct-auth/src/commonMain/kotlin/com/okta/directauth/model/PrimaryFactor.kt
+++ b/okta-direct-auth/src/commonMain/kotlin/com/okta/directauth/model/PrimaryFactor.kt
@@ -25,7 +25,8 @@ sealed interface SecondaryFactor : PrimaryFactor
  * Represents an authentication factor used in a Direct Authentication flow.
  *
  * Factors are categorized as either Primary or Secondary to support multi-stage
- * authentication workflows.
+ * authentication workflows. Every [SecondaryFactor] is also a valid primary factor;
+ * only [Password] is primary-only.
  */
 sealed interface PrimaryFactor {
     /**
@@ -58,6 +59,11 @@ sealed interface PrimaryFactor {
     /**
      * A WebAuthn factor, used for phishing-resistant authentication with hardware
      * authenticators or biometrics.
+     *
+     * Using this factor causes the flow to enter a
+     * [com.okta.directauth.model.DirectAuthContinuation.WebAuthn] state; call its `proceed()`
+     * with a [com.okta.directauth.api.WebAuthnCeremonyHandler] (e.g. `AndroidWebAuthnCeremonyHandler`)
+     * to run the passkey ceremony and exchange the assertion for tokens.
      */
     data object WebAuthn : SecondaryFactor
 }

--- a/okta-direct-auth/src/commonMain/kotlin/com/okta/directauth/model/WebAuthnAssertionResponse.kt
+++ b/okta-direct-auth/src/commonMain/kotlin/com/okta/directauth/model/WebAuthnAssertionResponse.kt
@@ -22,6 +22,10 @@ package com.okta.directauth.model
  * assertion (authentication) ceremony. The values are base64url-encoded as specified by the
  * WebAuthn standard.
  *
+ * These fields map 1:1 to the platform authenticator's `AuthenticatorAssertionResponse`
+ * (clientDataJSON/authenticatorData/signature/userHandle), for developers hand-rolling the
+ * ceremony instead of using a [com.okta.directauth.api.WebAuthnCeremonyHandler].
+ *
  * @param clientDataJSON The base64url-encoded client data JSON from the authenticator response.
  * @param authenticatorData The base64url-encoded authenticator data.
  * @param signature The base64url-encoded signature.

--- a/okta-direct-auth/src/jvmMain/kotlin/com/okta/directauth/jvm/DirectAuthenticationFlow.kt
+++ b/okta-direct-auth/src/jvmMain/kotlin/com/okta/directauth/jvm/DirectAuthenticationFlow.kt
@@ -34,6 +34,8 @@ import com.okta.directauth.api.DirectAuthenticationFlow as KotlinDirectAuthentic
  * This class provides async methods returning [CompletableFuture] and
  * a listener-based API for observing authentication state changes.
  *
+ * Kotlin callers should use the coroutine-based [com.okta.directauth.api.DirectAuthenticationFlow] instead.
+ *
  * @param delegate The underlying Kotlin [KotlinDirectAuthenticationFlow] instance.
  */
 class DirectAuthenticationFlow internal constructor(
@@ -82,6 +84,9 @@ class DirectAuthenticationFlow internal constructor(
 
     /**
      * Registers a listener that is notified whenever the authentication state changes.
+     *
+     * The listener is invoked on a background thread; dispatch to your UI thread if you
+     * update UI in response.
      *
      * @param listener A [Consumer] that receives [DirectAuthenticationState] updates.
      * @return A [Closeable] that, when closed, removes the listener.

--- a/okta-direct-auth/src/jvmMain/kotlin/com/okta/directauth/jvm/DirectAuthenticationFlowBuilder.kt
+++ b/okta-direct-auth/src/jvmMain/kotlin/com/okta/directauth/jvm/DirectAuthenticationFlowBuilder.kt
@@ -27,6 +27,8 @@ import com.okta.directauth.DirectAuthenticationFlowBuilder as KotlinBuilder
  * This builder provides method-chaining setters for optional parameters and delegates
  * to the Kotlin [KotlinBuilder] for the actual construction.
  *
+ * Kotlin callers should use [com.okta.directauth.DirectAuthenticationFlowBuilder] instead.
+ *
  * @param issuerUrl The base URL of the Authorization Server.
  * @param clientId The client ID of the application.
  * @param scope The OAuth 2.0 scopes the application is requesting.

--- a/okta-direct-auth/src/jvmMain/kotlin/com/okta/directauth/jvm/DirectAuthenticationState.kt
+++ b/okta-direct-auth/src/jvmMain/kotlin/com/okta/directauth/jvm/DirectAuthenticationState.kt
@@ -30,6 +30,8 @@ import com.okta.directauth.model.DirectAuthenticationState as KotlinDirectAuthen
  *
  * Use [state] to access the underlying Kotlin [KotlinDirectAuthenticationState].
  *
+ * Kotlin callers should use [com.okta.directauth.model.DirectAuthenticationState] instead.
+ *
  * @param state The underlying Kotlin [KotlinDirectAuthenticationState].
  */
 sealed class DirectAuthenticationState(
@@ -52,7 +54,7 @@ sealed class DirectAuthenticationState(
     /**
      * The authentication process is still pending and awaiting user action.
      *
-     * @param timestamp The time in milliseconds when the authorization became pending.
+     * @param timestamp The time in epoch seconds when the authorization became pending.
      */
     class AuthorizationPending internal constructor(
         delegate: KotlinDirectAuthenticationState.AuthorizationPending,

--- a/okta-direct-auth/src/jvmMain/kotlin/com/okta/directauth/jvm/WebAuthnContinuation.kt
+++ b/okta-direct-auth/src/jvmMain/kotlin/com/okta/directauth/jvm/WebAuthnContinuation.kt
@@ -44,12 +44,15 @@ class WebAuthnContinuation(
     /**
      * Retrieves the raw JSON string representing the WebAuthn challenge data.
      *
-     * @return A [Result] containing the challenge data JSON string on success.
+     * @return A [Result] containing the challenge data JSON string on success. If the challenge
+     * data cannot be extracted or serialized to JSON, a [Result.failure] is returned containing
+     * the exception details.
      */
     fun challengeData(): Result<String> = delegate.challengeData()
 
     /**
-     * The list of authenticator enrollments returned from the server.
+     * The list of authenticator enrollments returned from the server, or `null` if the challenge
+     * response did not include any.
      */
     val authenticatorEnrollment = delegate.authenticatorEnrollment
 

--- a/okta-idx-kotlin/README.md
+++ b/okta-idx-kotlin/README.md
@@ -28,10 +28,13 @@ do not have an account manager, please reach out to oie@okta.com for more inform
 
 ## Installation
 
-Add the `Okta IDX Kotlin` dependency to your `build.gradle` file:
+Add the `Okta IDX Kotlin` dependency to your `build.gradle.kts` file:
 
-```gradle
-implementation 'com.okta.kotlin:okta-idx-kotlin:3.1.1'
+```kotlin
+dependencies {
+    implementation(platform("com.okta.kotlin:bom:3.0.0"))
+    implementation("com.okta.kotlin:okta-idx-kotlin")
+}
 ```
 
 See the [CHANGELOG](CHANGELOG.md) for the most recent changes.

--- a/okta-idx-kotlin/src/main/java/com/okta/idx/kotlin/client/InteractionCodeFlow.kt
+++ b/okta-idx-kotlin/src/main/java/com/okta/idx/kotlin/client/InteractionCodeFlow.kt
@@ -43,8 +43,17 @@ import com.okta.idx.kotlin.dto.v1.Response as V1Response
 
 /**
  * The InteractionCodeFlow class is used to define and initiate an authentication workflow utilizing the Okta Identity Engine.
+ *
+ * Usage: call [start] to begin the workflow, then [resume] to retrieve the initial [IdxResponse]. From there, repeatedly set the
+ * desired form field values on a remediation and call [proceed] to advance through the workflow until [IdxResponse.isLoginSuccessful]
+ * is `true`, then call [exchangeInteractionCodeForTokens] to obtain tokens. All of these are `suspend` functions and must be called
+ * from a coroutine. An [InteractionCodeFlow] instance is stateful: it retains the context created by [start] and must not be reused
+ * concurrently for unrelated authentication attempts.
+ *
+ * @constructor Initializes a new [InteractionCodeFlow], using the given [client].
  */
 class InteractionCodeFlow(
+    /** The [OAuth2Client] used to make authorization-server requests for this flow. */
     val client: OAuth2Client,
 ) {
     companion object {
@@ -112,6 +121,10 @@ class InteractionCodeFlow(
      * Resumes the authentication state to identify the available remediation steps.
      *
      * This method is usually performed after an InteractionCodeFlow is created, but can also be called at any time to identify what next remediation steps are available to the user.
+     *
+     * Must be called after [start]; otherwise returns an [OAuth2ClientResult.Error].
+     *
+     * @return [OAuth2ClientResult.Success] wrapping the current [IdxResponse], or [OAuth2ClientResult.Error] on failure.
      */
     suspend fun resume(): OAuth2ClientResult<IdxResponse> {
         if (!::flowContext.isInitialized) {
@@ -132,9 +145,12 @@ class InteractionCodeFlow(
     }
 
     /**
-     * Executes the remediation option and proceeds through the workflow using the supplied form parameters.
+     * Executes the given remediation and advances the workflow using the values currently set on its form fields.
      *
-     * This method is used to proceed through the authentication flow, using the data assigned to the nested fields' `value` to make selections.
+     * Set each required [IdxRemediation.Form.Field.value] (and `selectedOption` for option fields) before calling.
+     *
+     * @param remediation the remediation to submit, obtained from [IdxResponse.remediations].
+     * @return [OAuth2ClientResult.Success] wrapping the next [IdxResponse], or [OAuth2ClientResult.Error] on failure.
      */
     suspend fun proceed(remediation: IdxRemediation): OAuth2ClientResult<IdxResponse> {
         val request =
@@ -167,7 +183,10 @@ class InteractionCodeFlow(
     }
 
     /**
-     * Exchange the IdxRemediation.Type.ISSUE remediation type for tokens.
+     * Exchanges the [IdxRemediation.Type.ISSUE] remediation for tokens once [IdxResponse.isLoginSuccessful] is `true`.
+     *
+     * @param remediation the [IdxRemediation.Type.ISSUE] remediation from the successful [IdxResponse].
+     * @return [OAuth2ClientResult.Success] wrapping the [Token], or [OAuth2ClientResult.Error] whose exception is an [IllegalStateException] if the flow was not started or the remediation is not of type [IdxRemediation.Type.ISSUE].
      */
     suspend fun exchangeInteractionCodeForTokens(remediation: IdxRemediation): OAuth2ClientResult<Token> {
         if (!::flowContext.isInitialized) {
@@ -189,6 +208,9 @@ class InteractionCodeFlow(
 
     /**
      * Evaluates the given redirect url to determine what next steps can be performed. This is usually used when receiving a redirection from an IDP authentication flow.
+     *
+     * @param uri the redirect [Uri] received from the browser or IDP redirection.
+     * @return [IdxRedirectResult.Tokens] if the redirect completed authentication and tokens were exchanged, [IdxRedirectResult.InteractionRequired] if further interaction is needed and the resumed [IdxResponse] is returned, or [IdxRedirectResult.Error] if the redirect could not be handled or the underlying request failed.
      */
     suspend fun evaluateRedirectUri(uri: Uri): IdxRedirectResult {
         if (!::flowContext.isInitialized) {

--- a/okta-idx-kotlin/src/main/java/com/okta/idx/kotlin/dto/IdxAuthenticator.kt
+++ b/okta-idx-kotlin/src/main/java/com/okta/idx/kotlin/dto/IdxAuthenticator.kt
@@ -70,6 +70,10 @@ class IdxAuthenticator internal constructor(
 ) {
     /**
      * Marker interface for [IdxAuthenticator] capabilities.
+     *
+     * Capabilities are retrieved from [IdxAuthenticator.capabilities] via a typed accessor, e.g. `capabilities.get<SomeCapability>()`.
+     *
+     * @see IdxCapabilityCollection.get
      */
     interface Capability
 

--- a/okta-idx-kotlin/src/main/java/com/okta/idx/kotlin/dto/IdxCapability.kt
+++ b/okta-idx-kotlin/src/main/java/com/okta/idx/kotlin/dto/IdxCapability.kt
@@ -36,6 +36,8 @@ class IdxCapabilityCollection<C> internal constructor(
 ) : Set<C> by capabilities {
     /**
      * Returns a capability based on its type.
+     *
+     * For example: `val poll = remediation.capabilities.get<IdxPollRemediationCapability>()`.
      */
     inline fun <reified Capability : C> get(): Capability? {
         val matched = firstOrNull { it is Capability } ?: return null
@@ -176,7 +178,7 @@ class IdxTotpCapability internal constructor(
     /** The shared secret associated with the authenticator used for setup without a QR code. */
     val sharedSecret: String?,
 ) : IdxAuthenticator.Capability {
-    /** The [Bitmap] associated with the QR code TOTP registration information. */
+    /** @return the decoded QR-code [Bitmap], or `null` if the embedded image data could not be decoded. */
     fun asImage(): Bitmap? {
         val bytes = imageData.substringAfter("data:image/png;base64,").decodeBase64()?.toByteArray() ?: return null
         return BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
@@ -268,7 +270,7 @@ class IdxWebAuthnRegistrationCapability internal constructor(
 /**
  * Describes the WebAuthn authentication capability associated with an [IdxAuthenticator].
  *
- * @property challengeData The JSON string containing the public key credential creation options for WebAuthn activation.
+ * @property challengeData The JSON string containing the public key credential request (assertion) options for WebAuthn authentication.
  */
 class IdxWebAuthnAuthenticationCapability internal constructor(
     private val _challengeData: String,
@@ -311,7 +313,7 @@ class IdxWebAuthnAuthenticationCapability internal constructor(
      * @param authenticationResponseJson JSON string containing the authentication response.
      * @return `Result<IdxRemediation>` with the updated remediation.
      * @throws IllegalArgumentException if required fields are missing in the authenticationResponseJson or IdxRemediation.Form.
-     * @throws IllegalArgumentException if the authenticationResponseJson contains invalid .
+     * @throws IllegalArgumentException if the authenticationResponseJson is missing required response fields (clientDataJson/clientDataJSON, authenticatorData, signature).
      * @throws JSONException if the JSON string is invalid. Or if the authenticationResponseJson does not contain the expected fields.
      */
     fun withAuthenticationResponseJson(

--- a/okta-idx-kotlin/src/main/java/com/okta/idx/kotlin/dto/IdxMessage.kt
+++ b/okta-idx-kotlin/src/main/java/com/okta/idx/kotlin/dto/IdxMessage.kt
@@ -32,9 +32,9 @@ class IdxMessage internal constructor(
     /** The type of message received from the server. */
     val type: Severity,
     /**
-     * A localization key representing this message.
+     * A localization key representing this message, or `null` if the server did not supply one.
      *
-     * This allows the text represented by this message to be customized or localized as needed.
+     * When present, this allows the text represented by this message to be customized or localized. When `null`, fall back to [message].
      */
     val localizationKey: String?,
     /** The default text for this message. */

--- a/okta-idx-kotlin/src/main/java/com/okta/idx/kotlin/dto/IdxRemediation.kt
+++ b/okta-idx-kotlin/src/main/java/com/okta/idx/kotlin/dto/IdxRemediation.kt
@@ -69,6 +69,10 @@ class IdxRemediation internal constructor(
 
     /**
      * Marker interface for [IdxRemediation] capabilities.
+     *
+     * Capabilities are retrieved from [IdxRemediation.capabilities] via a typed accessor, e.g. `capabilities.get<SomeCapability>()`.
+     *
+     * @see IdxCapabilityCollection.get
      */
     interface Capability
 
@@ -193,7 +197,11 @@ class IdxRemediation internal constructor(
              */
             operator fun get(name: String): Field? = form?.get(name)
 
-            /** The value to send, if a default is provided from the Identity Engine. */
+            /**
+             * The value to send for this field. A default may be provided by the Identity Engine.
+             *
+             * @throws IllegalStateException if assigned when [isMutable] is `false`.
+             */
             var value: Any?
                 set(value) {
                     if (!isMutable) {

--- a/okta-idx-kotlin/src/main/java/com/okta/idx/kotlin/dto/IdxResponse.kt
+++ b/okta-idx-kotlin/src/main/java/com/okta/idx/kotlin/dto/IdxResponse.kt
@@ -41,7 +41,7 @@ class IdxResponse internal constructor(
      * They should be displayed to the user in the context of the remediation form itself.
      */
     val messages: IdxMessageCollection,
-    /** Indicates whether or not the user has logged in successfully. If this is `true`, this response object should be exchanged for access tokens utilizing the `exchangeCode` method. */
+    /** Indicates whether the user has authenticated successfully. When `true`, retrieve the [IdxRemediation.Type.ISSUE] remediation from [remediations] and pass it to [com.okta.idx.kotlin.client.InteractionCodeFlow.exchangeInteractionCodeForTokens] to obtain tokens. */
     val isLoginSuccessful: Boolean,
 ) {
     /**

--- a/okta-idx-kotlin/src/main/java/com/okta/idx/kotlin/dto/IdxUser.kt
+++ b/okta-idx-kotlin/src/main/java/com/okta/idx/kotlin/dto/IdxUser.kt
@@ -29,10 +29,15 @@ class IdxUser internal constructor(
     /** Profile information for this user, if available. */
     val profile: Profile?,
 ) {
+    /** Profile information about the user being authenticated, when the server provides it. */
     class Profile internal constructor(
+        /** The user's given (first) name, if available. */
         val firstName: String?,
+        /** The user's family (last) name, if available. */
         val lastName: String?,
+        /** The user's configured time zone, if available. */
         val timeZone: TimeZone?,
+        /** The user's configured locale, if available. */
         val locale: Locale?,
     )
 }

--- a/web-authentication-ui/README.md
+++ b/web-authentication-ui/README.md
@@ -11,6 +11,7 @@ This module is **Android only**.
 ## Table of Contents
 
 - [Installation](#installation)
+- [Usage](#usage)
 - [Redirect scheme configuration](#redirect-scheme-configuration)
 - [Troubleshooting](#troubleshooting)
 
@@ -18,11 +19,48 @@ This module is **Android only**.
 
 ```kotlin
 dependencies {
-    implementation(platform("com.okta.kotlin:bom:2.0.5"))
+    implementation(platform("com.okta.kotlin:bom:3.0.0"))
     implementation("com.okta.kotlin:auth-foundation")
     implementation("com.okta.kotlin:oauth2")
     implementation("com.okta.kotlin:web-authentication-ui")
 }
+```
+
+## Usage
+
+Construct `WebAuthentication` with a KMP `OAuth2Client` from `auth-foundation`, then call `login`
+from an `Activity` context to sign in, and `logoutOfBrowser` to sign out:
+
+```kotlin
+import com.okta.authfoundation.client.OAuth2ClientBuilder
+import com.okta.webauthenticationui.WebAuthentication
+
+val client = OAuth2ClientBuilder.create(
+    issuerUrl = "https://your-org.okta.com",
+    clientId = "your-client-id",
+    scope = listOf("openid", "profile", "email", "offline_access")
+).getOrThrow()
+
+val webAuthentication = WebAuthentication(client)
+
+// Sign in (call from an Activity):
+val tokenInfo = webAuthentication.login(
+    context = activity,
+    redirectUrl = "com.okta.sample.android:/login",
+    scope = listOf("openid", "profile", "email", "offline_access")
+).getOrElse { error ->
+    // Handle error, e.g. WebAuthentication.FlowCancelledException if the user dismissed the browser
+    return
+}
+val accessToken = tokenInfo.accessToken
+
+// Sign out, using the idToken obtained from login above:
+val idToken = tokenInfo.idToken ?: return
+webAuthentication.logoutOfBrowser(
+    context = activity,
+    redirectUrl = "com.okta.sample.android:/logout",
+    idToken = idToken
+)
 ```
 
 ## Redirect scheme configuration

--- a/web-authentication-ui/src/main/java/com/okta/webauthenticationui/DefaultWebAuthenticationProvider.kt
+++ b/web-authentication-ui/src/main/java/com/okta/webauthenticationui/DefaultWebAuthenticationProvider.kt
@@ -52,6 +52,10 @@ import okhttp3.HttpUrl
 class DefaultWebAuthenticationProvider
     @JvmOverloads
     constructor(
+        /**
+         * @param eventCoordinator legacy hook that still receives the deprecated [CustomizeBrowserEvent]/[CustomizeCustomTabsEvent];
+         * new code should use the parameters below instead.
+         */
         private val eventCoordinator: EventCoordinator = EventCoordinator(emptyList()),
         /**
          * The list of browser package names to prefer when selecting which Chrome Custom Tabs
@@ -81,9 +85,11 @@ class DefaultWebAuthenticationProvider
         private val customizeTabsIntent: ((context: Context, builder: CustomTabsIntent.Builder) -> Unit)? = null,
     ) : WebAuthenticationProvider {
         companion object {
+            /** HTTP header name used to send the Okta SDK user-agent string to the authorize endpoint. */
             const val X_OKTA_USER_AGENT = "X-Okta-User-Agent-Extended"
 
-            val USER_AGENT_HEADER = "web-authentication-ui/${Build.VERSION.SDK_INT} com.okta.webauthenticationui/2.0.0"
+            /** The `X-Okta-User-Agent-Extended` header value sent with authorize requests. */
+            val USER_AGENT_HEADER = "web-authentication-ui/${Build.VERSION.SDK_INT} com.okta.webauthenticationui/3.0.0"
 
             private const val CHROME_STABLE = "com.android.chrome"
             private const val CHROME_SYSTEM = "com.google.android.apps.chrome"

--- a/web-authentication-ui/src/main/java/com/okta/webauthenticationui/ForegroundActivityEvent.kt
+++ b/web-authentication-ui/src/main/java/com/okta/webauthenticationui/ForegroundActivityEvent.kt
@@ -18,18 +18,30 @@ package com.okta.webauthenticationui
 import com.okta.webauthenticationui.events.UIEvent
 
 /**
- * Events emitted during different Android activity lifecycle stages of [ForegroundActivity].
+ * Lifecycle events emitted through the SDK's [com.okta.authfoundation.events.EventCoordinator]
+ * while the browser redirect flow is in the foreground. Observe these via an
+ * [com.okta.authfoundation.events.EventHandler] to react to the redirect activity's lifecycle
+ * (for example, to detect a user-cancelled flow). This is a [UIEvent].
  */
 sealed interface ForegroundActivityEvent : UIEvent {
+    /** Emitted when the redirect activity is created and the browser flow is about to launch. */
     data object OnCreate : ForegroundActivityEvent
 
+    /** Emitted when a redirect Intent is delivered back to the activity (the browser returned a result). */
     data object OnNewIntent : ForegroundActivityEvent
 
+    /**
+     * Emitted when the user returns to the app without completing the flow (e.g. back-navigation),
+     * typically preceding a [WebAuthentication.FlowCancelledException].
+     */
     data object OnResume : ForegroundActivityEvent
 
+    /** Emitted when the activity is paused (the browser or another activity has taken focus). */
     data object OnPause : ForegroundActivityEvent
 
+    /** Emitted when the redirect activity is destroyed. */
     data object OnDestroy : ForegroundActivityEvent
 
+    /** Emitted when the user presses the back button while the redirect activity is in the foreground. */
     data object OnBackPressed : ForegroundActivityEvent
 }

--- a/web-authentication-ui/src/main/java/com/okta/webauthenticationui/WebAuthentication.kt
+++ b/web-authentication-ui/src/main/java/com/okta/webauthenticationui/WebAuthentication.kt
@@ -174,14 +174,18 @@ class WebAuthentication private constructor(
     internal var redirectCoordinator: RedirectCoordinator = SingletonRedirectCoordinator
 
     /**
-     * Used in a [OAuth2ClientResult.Error.exception].
+     * Surfaced as the failure cause of a [login] or [logoutOfBrowser] call — inside a failed [Result]
+     * for the [List]-scope [login] overload, or as [OAuth2ClientResult.Error.exception] for
+     * [logoutOfBrowser] and the deprecated [String]-scope [login] overload.
      *
      * Indicates the requested flow was cancelled.
      */
     class FlowCancelledException internal constructor() : Exception("Flow cancelled.")
 
     /**
-     * Used in a [OAuth2ClientResult.Error.exception].
+     * Surfaced as the failure cause of a [login] or [logoutOfBrowser] call — inside a failed [Result]
+     * for the [List]-scope [login] overload, or as [OAuth2ClientResult.Error.exception] for
+     * [logoutOfBrowser] and the deprecated [String]-scope [login] overload.
      *
      * Indicates that [login] or [logoutOfBrowser] was called while another flow was already in
      * progress. Only one redirect flow can be active at a time.
@@ -189,14 +193,15 @@ class WebAuthentication private constructor(
     class FlowAlreadyInProgressException internal constructor() : Exception("Another flow is already in progress.")
 
     /**
-     * Initiates the OIDC Authorization Code redirect flow.
+     * Initiates the OIDC Authorization Code redirect flow. Suspends until the browser redirect
+     * completes or the user cancels. Preferred over the [String]-scope overload.
      *
      * @param context the Android [Activity] [Context] which is used to display the login flow via the configured
      * [WebAuthenticationProvider].
      * @param redirectUrl the redirect URL.
+     * @param scope the scopes to request during sign in.
      * @param extraRequestParameters the extra key value pairs to send to the authorize endpoint.
      *  See [Authorize Documentation](https://developer.okta.com/docs/reference/api/oidc/#authorize) for parameter options.
-     * @param scope the scopes to request during sign in.
      * @return a [Result] containing [TokenInfo] on success, or a failed [Result] wrapping a
      *  [FlowCancelledException] if the user dismissed the browser, a [FlowAlreadyInProgressException]
      *  if another redirect flow was already in progress, or the underlying authorize/token exchange error.
@@ -239,9 +244,13 @@ class WebAuthentication private constructor(
      * @param context the Android [Activity] [Context] which is used to display the login flow via the configured
      * [WebAuthenticationProvider].
      * @param redirectUrl the redirect URL.
-     * @param scope the scopes to request during sign in. Defaults to the configured client's default scope.
      * @param extraRequestParameters the extra key value pairs to send to the authorize endpoint.
      *  See [Authorize Documentation](https://developer.okta.com/docs/reference/api/oidc/#authorize) for parameter options.
+     * @param scope the scopes to request during sign in. Defaults to the configured client's default scope.
+     * @return an [OAuth2ClientResult]: [OAuth2ClientResult.Success] wrapping the [Token] on success, or
+     *  [OAuth2ClientResult.Error] wrapping a [FlowCancelledException] if the user dismissed the browser, a
+     *  [FlowAlreadyInProgressException] if another redirect flow was already in progress, or the underlying
+     *  authorize/token exchange error.
      */
     @Deprecated(
         message =
@@ -267,6 +276,8 @@ class WebAuthentication private constructor(
      * [WebAuthenticationProvider].
      * @param redirectUrl the redirect URL.
      * @param idToken the token used to identify the session to log the user out of.
+     * @return an [OAuth2ClientResult]: [OAuth2ClientResult.Success] of [Unit] on completed logout, or
+     *  [OAuth2ClientResult.Error] (e.g. [FlowCancelledException], [FlowAlreadyInProgressException]).
      */
     suspend fun logoutOfBrowser(
         context: Context,

--- a/web-authentication-ui/src/main/java/com/okta/webauthenticationui/WebAuthenticationProvider.kt
+++ b/web-authentication-ui/src/main/java/com/okta/webauthenticationui/WebAuthenticationProvider.kt
@@ -21,6 +21,9 @@ import okhttp3.HttpUrl
 
 /**
  * Used to launch the OIDC redirect flow associated with a [WebAuthentication].
+ *
+ * Most integrators should use [DefaultWebAuthenticationProvider]; implement this only to fully
+ * control how the authorize URL is presented.
  */
 interface WebAuthenticationProvider {
     /**
@@ -29,7 +32,7 @@ interface WebAuthenticationProvider {
      * @param context the Android [Activity] [Context] which is used to display the flow.
      * @param url the url the instance should display.
      *
-     * @return the exception causing the launch to fail.
+     * @return `null` if the flow launched successfully, or the [Exception] that caused the launch to fail.
      */
     fun launch(
         context: Context,


### PR DESCRIPTION
Applies fixes from a full KDoc audit of the six modules published to the https://okta.github.io/okta-mobile-kotlin reference site (auth-foundation, oauth2, web-authentication-ui, legacy-token-migration, okta-idx-kotlin, okta-direct-auth), scoped to their public (non-internal) API surface.

Inaccurate KDoc corrected (verified against current behavior, not just reworded):
- auth-foundation: KMP Credential/CredentialImpl no longer claim the deprecated Android Credential implements them (it doesn't - shares only CredentialIdentifier); fixed an ambiguous same-package [Credential] link that silently resolved to the wrong class; fixed a wrong FQN on DefaultCredentialIdStore's linked type.
- oauth2: TokenExchangeFlow's audience no longer claims a fabricated "api://default" fallback the KMP path doesn't have; ResourceOwnerFlow's example no longer instantiates an internal class external readers can't see; fixed five JVM-wrapper @ReplaceWith expressions that referenced a non-null-safe scope.split(" ") against a nullable parameter (wouldn't compile if applied); removed redundant/invalid lowercase @deprecated tags left over from a Javadoc convention on six deprecated Android flow classes.
- legacy-token-migration: migrate()'s docs no longer describe a "caller stores the returned Token" contract the code doesn't implement (it stores the credential internally); SuccessfullyMigrated no longer references a Credential parameter that doesn't exist on migrate(); filled in a literally empty KDoc block on Result.Error.exception; fixed the same stale API references in migrate.md.
- okta-idx-kotlin: IdxResponse.isLoginSuccessful no longer points to a nonexistent exchangeCode method (real one is exchangeInteractionCodeForTokens); documented IdxMessage.localizationKey's nullability instead of implying it's always present; fixed copy-pasted "WebAuthn activation" wording on the authentication (assertion) capability and a truncated @throws sentence.
- okta-direct-auth: DirectAuthenticationFlow no longer points to a nonexistent DirectAuthenticationFlow.create factory; corrected a commonMain logger doc that claimed Android Logcat behavior unconditionally on a KMP (Android+JVM) type; corrected the builder's description of how it's actually used (configured via create()'s trailing lambda, not a held builder instance).

Missing KDoc added on public declarations that rendered blank on the doc site (TokenInfo, Event, InternalAuthFoundationApi, six ForegroundUIEvent objects, IdxUser.Profile, AuthenticatorEnrollment properties, and others), plus @return/@throws/@param coverage added to primary entry points that previously documented only the success path (AuthorizationCodeFlow.resume, WebAuthentication.login/logoutOfBrowser, InteractionCodeFlow.proceed/ exchangeInteractionCodeForTokens/evaluateRedirectUri/resume, DirectAuthenticationFlow.start, WebAuthenticationProvider.launch).

Added guidance where docs were accurate but didn't orient a new reader: call-sequence notes on AuthorizationCodeFlow and InteractionCodeFlow, the WebAuthn ceremony handshake on WebAuthnCeremonyHandler, cross-pointers between the Kotlin-native and Java-CompletableFuture API pairs in oauth2 and okta-direct-auth, and threading notes on JVM listener callbacks.

Deliberately not included (separate follow-up, since they'd need ABI re-dumps and/or code changes rather than doc text):
- Making okta-direct-auth's com.okta.directauth.http request/error types and okta-idx-kotlin's DeviceTokenProvider internal - they're public with no KDoc and aren't caught by the existing *.internal.* Dokka suppression rule.
- auth-foundation KMP Credential.refreshToken(extraRequestParameters)'s default implementation contradicts its own "bypasses the coalescing orchestrator" KDoc (falls back to refreshToken(), which doesn't).
- okta-direct-auth's AuthorizationPending.timestamp KDoc says milliseconds; confirmed via TokenStepHandler that it's actually populated in seconds.

Also standardizes module README installation instructions and brings the CHANGELOG in line with what's actually shipped:

- Installation: oauth2, okta-direct-auth, and okta-idx-kotlin now install via the BOM (matching auth-foundation/web-authentication-ui) instead of a pinned per-artifact version that could drift from BOM_VERSION. oauth2 and okta-direct-auth's snippets now also list the auth-foundation dependency they actually require at compile time (oauth2 exposes it as `api`, but okta-direct-auth only as `implementation`, so callers touching its auth-foundation-typed return values need to add it themselves). okta-idx-kotlin's snippet modernized from old Groovy single-quote syntax.
- okta-direct-auth/README.md: bumped stale "Current Version: 0.0.1" to 1.0.0; fixed Kotlin/Java examples using renamed params (loginHint/ primaryFactor/secondaryFactor/challengeTypesSupported) and a non-existent DirectAuthenticationError.OAuth2Error type path (real one is nested HttpError.Oauth2Error); replaced a stub Java error-handling section with real subtype examples; corrected the Requirements section (removed a redundant bullet describing the module rather than a real requirement, and clarified "Android API 26+ or JVM (Java 11+)" means whichever platform you target, not both).
- web-authentication-ui/README.md: added a Usage section demonstrating login()/logoutOfBrowser() (previously covered only setup/troubleshooting, with no working example).
- CHANGELOG.md: added the missing entry for the com.okta.directauth.jvm continuation wrappers implementing Closeable (shipped in #418 without a changelog entry). Removed three "Fixed" entries for bugs that were introduced and fixed within this same unreleased cycle and therefore never shipped in a release (a Credential.refreshToken(extraRequestParameters) NotImplementedError fix, an Android Keystore RSA re-import regression in TokenEncryptionHandler/AndroidTokenEncryptionHandler, and a DirectAuthContinuation.WebAuthn.proceed(handler) StateFlow bug) — verified each remaining "Fixed" entry against its module's last released tag to confirm it documents a real, previously-shipped bug.

- okta-direct-auth/CHANGELOG.md was stale (only had the 0.0.1 alpha entry) despite its own README linking to it as the place for "release history and migration guides." Added a [1.0.0] - Unreleased section mirroring root CHANGELOG.md's content for this module.
- Root CHANGELOG.md's `okta-direct-auth 1.0.0` section removed in favor of that per-module CHANGELOG.md, matching how okta-idx-kotlin's own CHANGELOG.md is already the sole source for its changes — avoids two copies of the same release notes drifting apart. Updated the root Unreleased intro accordingly to point at okta-direct-auth/CHANGELOG.md.

- Release checklist step 3 expanded with a concrete template for how the "Unreleased" section should be split into dated per-module entries at release time, including the [Commits](...) compare-link format (matching older dated entries in this file). Templated auth-foundation's link from its real auth-foundation@2.0.5 tag; oauth2/web-authentication-ui have no prior per-module tag to compare from (this is their first independent release), so their templates compare from commit e70ffa5c instead, the last commit before either module's version left 2.0.4.