### PR TITLE
feat: Add support for ephemeral browsing in Custom Tabs

### DIFF
--- a/web-authentication-ui/src/main/java/com/okta/webauthenticationui/DefaultWebAuthenticationProvider.kt
+++ b/web-authentication-ui/src/main/java/com/okta/webauthenticationui/DefaultWebAuthenticationProvider.kt
@@ -22,6 +22,7 @@ import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import android.provider.Browser
+import androidx.browser.customtabs.CustomTabsClient
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.browser.customtabs.CustomTabsService
 import androidx.core.net.toUri
@@ -102,14 +103,23 @@ class DefaultWebAuthenticationProvider
         override fun launch(
             context: Context,
             url: HttpUrl,
+            isEphemeralBrowsing: Boolean,
         ): Exception? {
             val intentBuilder: CustomTabsIntent.Builder = CustomTabsIntent.Builder()
+            val packageBrowser = getBrowser(context)
+
+            if (isEphemeralBrowsing) {
+                packageBrowser?.let {
+                    if (CustomTabsClient.isEphemeralBrowsingSupported(context, it)) {
+                        intentBuilder.setEphemeralBrowsingEnabled(true)
+                    }
+                }
+            }
             customizeTabsIntent?.invoke(context, intentBuilder)
             @Suppress("DEPRECATION")
             eventCoordinator.sendEvent(CustomizeCustomTabsEvent(context, intentBuilder))
             val tabsIntent: CustomTabsIntent = intentBuilder.build()
 
-            val packageBrowser = getBrowser(context)
             if (packageBrowser != null) {
                 tabsIntent.intent.setPackage(packageBrowser)
             }

--- a/web-authentication-ui/src/main/java/com/okta/webauthenticationui/DefaultWebAuthenticationProvider.kt
+++ b/web-authentication-ui/src/main/java/com/okta/webauthenticationui/DefaultWebAuthenticationProvider.kt
@@ -103,12 +103,12 @@ class DefaultWebAuthenticationProvider
         override fun launch(
             context: Context,
             url: HttpUrl,
-            isEphemeralBrowsing: Boolean,
+            enableEphemeralBrowsing: Boolean,
         ): Exception? {
             val intentBuilder: CustomTabsIntent.Builder = CustomTabsIntent.Builder()
             val packageBrowser = getBrowser(context)
 
-            if (isEphemeralBrowsing) {
+            if (enableEphemeralBrowsing) {
                 packageBrowser?.let {
                     if (CustomTabsClient.isEphemeralBrowsingSupported(context, it)) {
                         intentBuilder.setEphemeralBrowsingEnabled(true)

--- a/web-authentication-ui/src/main/java/com/okta/webauthenticationui/RedirectCoordinator.kt
+++ b/web-authentication-ui/src/main/java/com/okta/webauthenticationui/RedirectCoordinator.kt
@@ -54,6 +54,7 @@ internal class DefaultRedirectCoordinator(
     @Volatile private var webAuthenticationProvider: WebAuthenticationProvider? = null
 
     private var emitErrorJob: Job? = null
+    private var isEphemeralBrowsing: Boolean = false
 
     private val flowMutex = Mutex()
 
@@ -63,6 +64,7 @@ internal class DefaultRedirectCoordinator(
     override suspend fun <T> initialize(
         webAuthenticationProvider: WebAuthenticationProvider,
         context: Context,
+        isEphemeralBrowsing: Boolean,
         initializer: suspend () -> RedirectInitializationResult<T>,
     ): RedirectInitializationResult<T> {
         currentCoroutineContext().ensureActive()
@@ -74,7 +76,7 @@ internal class DefaultRedirectCoordinator(
             this.webAuthenticationProvider = webAuthenticationProvider
             this.initializer = initializer
         }
-
+        this.isEphemeralBrowsing = isEphemeralBrowsing
         if (context is ComponentActivity) {
             if (!context.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
                 reset()
@@ -122,7 +124,7 @@ internal class DefaultRedirectCoordinator(
         webAuthenticationProvider = null
 
         if (localWebAuthenticationProvider != null) {
-            val exception = localWebAuthenticationProvider.launch(context, url)
+            val exception = localWebAuthenticationProvider.launch(context, url, isEphemeralBrowsing = isEphemeralBrowsing)
             if (exception == null) {
                 return true
             } else {
@@ -180,6 +182,7 @@ internal interface RedirectCoordinator {
     suspend fun <T> initialize(
         webAuthenticationProvider: WebAuthenticationProvider,
         context: Context,
+        isEphemeralBrowsing: Boolean = false,
         initializer: suspend () -> RedirectInitializationResult<T>,
     ): RedirectInitializationResult<T>
 

--- a/web-authentication-ui/src/main/java/com/okta/webauthenticationui/RedirectCoordinator.kt
+++ b/web-authentication-ui/src/main/java/com/okta/webauthenticationui/RedirectCoordinator.kt
@@ -54,7 +54,7 @@ internal class DefaultRedirectCoordinator(
     @Volatile private var webAuthenticationProvider: WebAuthenticationProvider? = null
 
     private var emitErrorJob: Job? = null
-    private var isEphemeralBrowsing: Boolean = false
+    private var enableEphemeralBrowsing: Boolean = false
 
     private val flowMutex = Mutex()
 
@@ -64,7 +64,7 @@ internal class DefaultRedirectCoordinator(
     override suspend fun <T> initialize(
         webAuthenticationProvider: WebAuthenticationProvider,
         context: Context,
-        isEphemeralBrowsing: Boolean,
+        enableEphemeralBrowsing: Boolean,
         initializer: suspend () -> RedirectInitializationResult<T>,
     ): RedirectInitializationResult<T> {
         currentCoroutineContext().ensureActive()
@@ -76,7 +76,7 @@ internal class DefaultRedirectCoordinator(
             this.webAuthenticationProvider = webAuthenticationProvider
             this.initializer = initializer
         }
-        this.isEphemeralBrowsing = isEphemeralBrowsing
+        this.enableEphemeralBrowsing = enableEphemeralBrowsing
         if (context is ComponentActivity) {
             if (!context.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
                 reset()
@@ -124,7 +124,7 @@ internal class DefaultRedirectCoordinator(
         webAuthenticationProvider = null
 
         if (localWebAuthenticationProvider != null) {
-            val exception = localWebAuthenticationProvider.launch(context, url, isEphemeralBrowsing = isEphemeralBrowsing)
+            val exception = localWebAuthenticationProvider.launch(context, url, enableEphemeralBrowsing = enableEphemeralBrowsing)
             if (exception == null) {
                 return true
             } else {
@@ -182,7 +182,7 @@ internal interface RedirectCoordinator {
     suspend fun <T> initialize(
         webAuthenticationProvider: WebAuthenticationProvider,
         context: Context,
-        isEphemeralBrowsing: Boolean = false,
+        enableEphemeralBrowsing: Boolean = false,
         initializer: suspend () -> RedirectInitializationResult<T>,
     ): RedirectInitializationResult<T>
 

--- a/web-authentication-ui/src/main/java/com/okta/webauthenticationui/WebAuthentication.kt
+++ b/web-authentication-ui/src/main/java/com/okta/webauthenticationui/WebAuthentication.kt
@@ -264,10 +264,10 @@ class WebAuthentication private constructor(
         context: Context,
         redirectUrl: String,
         extraRequestParameters: Map<String, String> = emptyMap(),
-        isEphemeralBrowsing: Boolean = false,
+        enableEphemeralBrowsing: Boolean = false,
         scope: String = defaultScopeValue.joinToString(" "),
     ): OAuth2ClientResult<Token> =
-        login(context, redirectUrl, scope.split(" "), isEphemeralBrowsing, extraRequestParameters)
+        login(context, redirectUrl, scope.split(" "), enableEphemeralBrowsing, extraRequestParameters)
             .mapToOAuth2ClientResult { it.toToken() }
 
     /**

--- a/web-authentication-ui/src/main/java/com/okta/webauthenticationui/WebAuthentication.kt
+++ b/web-authentication-ui/src/main/java/com/okta/webauthenticationui/WebAuthentication.kt
@@ -201,6 +201,7 @@ class WebAuthentication private constructor(
      * @param redirectUrl the redirect URL.
      * @param scope the scopes to request during sign in.
      * @param extraRequestParameters the extra key value pairs to send to the authorize endpoint.
+     * @param enableEphemeralBrowsing whether to enable ephemeral browsing mode, if supported by the browser.
      *  See [Authorize Documentation](https://developer.okta.com/docs/reference/api/oidc/#authorize) for parameter options.
      * @return a [Result] containing [TokenInfo] on success, or a failed [Result] wrapping a
      *  [FlowCancelledException] if the user dismissed the browser, a [FlowAlreadyInProgressException]
@@ -210,10 +211,11 @@ class WebAuthentication private constructor(
         context: Context,
         redirectUrl: String,
         scope: List<String>,
+        enableEphemeralBrowsing: Boolean = false,
         extraRequestParameters: Map<String, String> = emptyMap(),
     ): Result<TokenInfo> {
         val initializationResult =
-            redirectCoordinator.initialize(webAuthenticationProvider, context) {
+            redirectCoordinator.initialize(webAuthenticationProvider, context, enableEphemeralBrowsing) {
                 authorizationCodeFlow
                     .start(redirectUrl, scope, extraRequestParameters)
                     .mapCatching { flowContext ->
@@ -262,9 +264,10 @@ class WebAuthentication private constructor(
         context: Context,
         redirectUrl: String,
         extraRequestParameters: Map<String, String> = emptyMap(),
+        isEphemeralBrowsing: Boolean = false,
         scope: String = defaultScopeValue.joinToString(" "),
     ): OAuth2ClientResult<Token> =
-        login(context, redirectUrl, scope.split(" "), extraRequestParameters)
+        login(context, redirectUrl, scope.split(" "), isEphemeralBrowsing, extraRequestParameters)
             .mapToOAuth2ClientResult { it.toToken() }
 
     /**

--- a/web-authentication-ui/src/main/java/com/okta/webauthenticationui/WebAuthenticationProvider.kt
+++ b/web-authentication-ui/src/main/java/com/okta/webauthenticationui/WebAuthenticationProvider.kt
@@ -37,5 +37,6 @@ interface WebAuthenticationProvider {
     fun launch(
         context: Context,
         url: HttpUrl,
+        isEphemeralBrowsing: Boolean = false,
     ): Exception?
 }

--- a/web-authentication-ui/src/main/java/com/okta/webauthenticationui/WebAuthenticationProvider.kt
+++ b/web-authentication-ui/src/main/java/com/okta/webauthenticationui/WebAuthenticationProvider.kt
@@ -37,6 +37,6 @@ interface WebAuthenticationProvider {
     fun launch(
         context: Context,
         url: HttpUrl,
-        isEphemeralBrowsing: Boolean = false,
+        enableEphemeralBrowsing: Boolean = false,
     ): Exception?
 }

--- a/web-authentication-ui/src/test/java/com/okta/webauthenticationui/DefaultWebAuthenticationProviderTest.kt
+++ b/web-authentication-ui/src/test/java/com/okta/webauthenticationui/DefaultWebAuthenticationProviderTest.kt
@@ -45,7 +45,7 @@ class DefaultWebAuthenticationProviderTest {
     @Test fun testLaunch() {
         val activity = Robolectric.buildActivity(Activity::class.java)
         val webAuthenticationProvider = DefaultWebAuthenticationProvider(EventCoordinator(emptyList()))
-        assertThat(webAuthenticationProvider.launch(activity.get(), "https://example.com/not_used".toHttpUrl())).isNull()
+        assertThat(webAuthenticationProvider.launch(activity.get(), "https://example.com/not_used".toHttpUrl(), false)).isNull()
         val activityShadow = shadowOf(activity.get())
         val cctActivity = activityShadow.nextStartedActivity
         assertThat(cctActivity.action).isEqualTo("android.intent.action.VIEW")
@@ -58,21 +58,21 @@ class DefaultWebAuthenticationProviderTest {
         val activity = Robolectric.buildActivity(Activity::class.java)
         val eventHandler = RecordingEventHandler()
         val webAuthenticationProvider = DefaultWebAuthenticationProvider(EventCoordinator(eventHandler))
-        assertThat(webAuthenticationProvider.launch(activity.get(), "https://example.com/not_used".toHttpUrl())).isNull()
+        assertThat(webAuthenticationProvider.launch(activity.get(), "https://example.com/not_used".toHttpUrl(), false)).isNull()
 
         assertThat(eventHandler.size).isEqualTo(2)
 
         @Suppress("DEPRECATION")
-        assertThat(eventHandler[0]).isInstanceOf(CustomizeCustomTabsEvent::class.java)
+        assertThat(eventHandler[0]).isInstanceOf(CustomizeBrowserEvent::class.java)
         @Suppress("DEPRECATION")
-        assertThat((eventHandler[0] as CustomizeCustomTabsEvent).context).isNotNull()
+        assertThat((eventHandler[0] as CustomizeBrowserEvent).preferredBrowsers).hasSize(3)
         @Suppress("DEPRECATION")
-        assertThat((eventHandler[0] as CustomizeCustomTabsEvent).intentBuilder).isNotNull()
+        assertThat(eventHandler[1]).isInstanceOf(CustomizeCustomTabsEvent::class.java)
 
         @Suppress("DEPRECATION")
-        assertThat(eventHandler[1]).isInstanceOf(CustomizeBrowserEvent::class.java)
+        assertThat((eventHandler[1] as CustomizeCustomTabsEvent).context).isNotNull()
         @Suppress("DEPRECATION")
-        assertThat((eventHandler[1] as CustomizeBrowserEvent).preferredBrowsers).hasSize(3)
+        assertThat((eventHandler[1] as CustomizeCustomTabsEvent).intentBuilder).isNotNull()
     }
 
     @Test fun testLaunchWithEnabledBrowsers() {
@@ -85,7 +85,7 @@ class DefaultWebAuthenticationProviderTest {
         )
         val activity = Robolectric.buildActivity(Activity::class.java)
         val webAuthenticationProvider = DefaultWebAuthenticationProvider(EventCoordinator(emptyList()))
-        assertThat(webAuthenticationProvider.launch(activity.get(), "https://example.com/not_used".toHttpUrl())).isNull()
+        assertThat(webAuthenticationProvider.launch(activity.get(), "https://example.com/not_used".toHttpUrl(), false)).isNull()
         val activityShadow = shadowOf(activity.get())
         val cctActivity = activityShadow.nextStartedActivity
         assertThat(cctActivity.action).isEqualTo("android.intent.action.VIEW")
@@ -110,7 +110,7 @@ class DefaultWebAuthenticationProviderTest {
                 customizeTabsIntent = { _, _ -> callOrder.add("callback") }
             )
         val activity = Robolectric.buildActivity(Activity::class.java)
-        webAuthenticationProvider.launch(activity.get(), "https://example.com/not_used".toHttpUrl())
+        webAuthenticationProvider.launch(activity.get(), "https://example.com/not_used".toHttpUrl(), false)
         assertThat(callOrder).containsExactly("callback", "eventHandler").inOrder()
     }
 
@@ -121,7 +121,7 @@ class DefaultWebAuthenticationProviderTest {
                 customizeTabsIntent = { _, builder -> capturedBuilder = builder }
             )
         val activity = Robolectric.buildActivity(Activity::class.java)
-        webAuthenticationProvider.launch(activity.get(), "https://example.com/not_used".toHttpUrl())
+        webAuthenticationProvider.launch(activity.get(), "https://example.com/not_used".toHttpUrl(), false)
         assertThat(capturedBuilder).isNotNull()
     }
 
@@ -134,7 +134,7 @@ class DefaultWebAuthenticationProviderTest {
                 preferredBrowsers = listOf("my.custom.preferred.browser")
             )
         val activity = Robolectric.buildActivity(Activity::class.java)
-        assertThat(webAuthenticationProvider.launch(activity.get(), "https://example.com/not_used".toHttpUrl())).isNull()
+        assertThat(webAuthenticationProvider.launch(activity.get(), "https://example.com/not_used".toHttpUrl(), false)).isNull()
         val activityShadow = shadowOf(activity.get())
         val cctActivity = activityShadow.nextStartedActivity
         assertThat(cctActivity.action).isEqualTo("android.intent.action.VIEW")
@@ -149,7 +149,7 @@ class DefaultWebAuthenticationProviderTest {
         shadowOf(RuntimeEnvironment.getApplication()).checkActivities(true)
         val activity = Robolectric.buildActivity(Activity::class.java)
         val webAuthenticationProvider = DefaultWebAuthenticationProvider(EventCoordinator(emptyList()))
-        val exception = webAuthenticationProvider.launch(activity.get(), "https://example.com/not_used".toHttpUrl())
+        val exception = webAuthenticationProvider.launch(activity.get(), "https://example.com/not_used".toHttpUrl(), false)
         assertThat(exception).isInstanceOf(ActivityNotFoundException::class.java)
     }
 

--- a/web-authentication-ui/src/test/java/com/okta/webauthenticationui/RedirectCoordinatorTest.kt
+++ b/web-authentication-ui/src/test/java/com/okta/webauthenticationui/RedirectCoordinatorTest.kt
@@ -163,7 +163,7 @@ class RedirectCoordinatorTest {
             }
             val resultDeferred =
                 async(Dispatchers.IO) {
-                    subject.initialize(mock(), mock()) {
+                    subject.initialize(mock(), mock(), false) {
                         RedirectInitializationResult.Success(mock(), Any())
                     }
                 }
@@ -217,7 +217,7 @@ class RedirectCoordinatorTest {
                 initializerCountDownLatch.countDown()
             }
             launch(Dispatchers.IO) {
-                subject.initialize(webAuthenticationProvider, mock()) {
+                subject.initialize(webAuthenticationProvider, mock(), false) {
                     RedirectInitializationResult.Success(mock(), Any())
                 }
             }
@@ -236,7 +236,7 @@ class RedirectCoordinatorTest {
         testScope.runTest {
             val webAuthenticationProvider =
                 mock<WebAuthenticationProvider> {
-                    on { launch(any(), any()) } doReturn null
+                    on { launch(any(), any(), any()) } doReturn null
                 }
             val activityController = Robolectric.buildActivity(ComponentActivity::class.java)
             activityController.create().start().resume()
@@ -247,14 +247,14 @@ class RedirectCoordinatorTest {
                 initializerCountDownLatch.countDown()
             }
             launch(Dispatchers.IO) {
-                subject.initialize(webAuthenticationProvider, launchedFromActivity) {
+                subject.initialize(webAuthenticationProvider, launchedFromActivity, false) {
                     RedirectInitializationResult.Success(url, Any())
                 }
             }
             assertThat(initializerCountDownLatch.await(1, TimeUnit.SECONDS)).isTrue()
             subject.runInitializationFunction()
             assertThat(subject.launchWebAuthenticationProvider(launchedFromActivity, url)).isTrue()
-            verify(webAuthenticationProvider).launch(launchedFromActivity, url)
+            verify(webAuthenticationProvider).launch(launchedFromActivity, url, false)
             val foregroundActivity = shadowOf(launchedFromActivity).nextStartedActivity
             assertThat(foregroundActivity.component?.className).isEqualTo(ForegroundActivity::class.java.name)
         }
@@ -271,10 +271,10 @@ class RedirectCoordinatorTest {
                 .stop()
             val launchedFromActivity = activityController.get()
             val result =
-                subject.initialize(webAuthenticationProvider, launchedFromActivity) {
+                subject.initialize(webAuthenticationProvider, launchedFromActivity, false) {
                     RedirectInitializationResult.Success("https://example.com/oauth".toHttpUrl(), Any())
                 }
-            verify(webAuthenticationProvider, never()).launch(anyOrNull(), anyOrNull())
+            verify(webAuthenticationProvider, never()).launch(anyOrNull(), anyOrNull(), any())
             assertThat(result).isInstanceOf(RedirectInitializationResult.Error::class.java)
             val errorResult = result as RedirectInitializationResult.Error
             assertThat(errorResult.exception).hasMessageThat().isEqualTo("Activity is not resumed.")
@@ -284,21 +284,21 @@ class RedirectCoordinatorTest {
         testScope.runTest {
             val webAuthenticationProvider =
                 mock<WebAuthenticationProvider> {
-                    on { launch(any(), any()) } doReturn null
+                    on { launch(any(), any(), any()) } doReturn null
                 }
             val initializerCountDownLatch = CountDownLatch(1)
             subject.initializerContinuationListeningCallback = {
                 initializerCountDownLatch.countDown()
             }
             launch(Dispatchers.IO) {
-                subject.initialize(webAuthenticationProvider, mock()) {
+                subject.initialize(webAuthenticationProvider, mock(), false) {
                     RedirectInitializationResult.Success(mock(), Any())
                 }
             }
             assertThat(initializerCountDownLatch.await(1, TimeUnit.SECONDS)).isTrue()
             subject.runInitializationFunction()
             assertThat(subject.launchWebAuthenticationProvider(mock(), mock())).isTrue()
-            verify(webAuthenticationProvider).launch(any(), any())
+            verify(webAuthenticationProvider).launch(any(), any(), any())
         }
 
     @Test fun testLaunchWebAuthenticationProviderActivityNotFound(): Unit =
@@ -306,21 +306,21 @@ class RedirectCoordinatorTest {
             val resultDeferred = listenRedirectAsync()
             val webAuthenticationProvider =
                 mock<WebAuthenticationProvider> {
-                    on { launch(any(), any()) } doReturn ActivityNotFoundException("From Test!")
+                    on { launch(any(), any(), any()) } doReturn ActivityNotFoundException("From Test!")
                 }
             val initializerCountDownLatch = CountDownLatch(1)
             subject.initializerContinuationListeningCallback = {
                 initializerCountDownLatch.countDown()
             }
             launch(Dispatchers.IO) {
-                subject.initialize(webAuthenticationProvider, mock()) {
+                subject.initialize(webAuthenticationProvider, mock(), false) {
                     RedirectInitializationResult.Success(mock(), Any())
                 }
             }
             assertThat(initializerCountDownLatch.await(1, TimeUnit.SECONDS)).isTrue()
             subject.runInitializationFunction()
             assertThat(subject.launchWebAuthenticationProvider(mock(), mock())).isFalse()
-            verify(webAuthenticationProvider).launch(any(), any())
+            verify(webAuthenticationProvider).launch(any(), any(), any())
             val result = resultDeferred.await()
             assertThat(result).isInstanceOf(RedirectResult.Error::class.java)
             val error = result as RedirectResult.Error
@@ -332,7 +332,7 @@ class RedirectCoordinatorTest {
         testScope.runTest {
             val webAuthenticationProvider =
                 mock<WebAuthenticationProvider> {
-                    on { launch(any(), any()) } doReturn null
+                    on { launch(any(), any(), any()) } doReturn null
                 }
             val launchedFromActivity = Robolectric.buildActivity(Activity::class.java).get()
             subject.initializerContinuationListeningCallback = {
@@ -344,14 +344,14 @@ class RedirectCoordinatorTest {
                 launch(Dispatchers.IO) {
                     startedCountDownLatch.countDown()
                     assertThat(cancelledCountDownLatch.await(1, TimeUnit.SECONDS)).isTrue()
-                    subject.initialize(webAuthenticationProvider, launchedFromActivity) {
+                    subject.initialize(webAuthenticationProvider, launchedFromActivity, false) {
                         RedirectInitializationResult.Success("https://example.com/oauth".toHttpUrl(), Any())
                     }
                 }
             assertThat(startedCountDownLatch.await(1, TimeUnit.SECONDS)).isTrue()
             job.cancel()
             cancelledCountDownLatch.countDown()
-            verify(webAuthenticationProvider, never()).launch(any(), any())
+            verify(webAuthenticationProvider, never()).launch(any(), any(), any())
             val foregroundActivity = shadowOf(launchedFromActivity).nextStartedActivity
             assertThat(foregroundActivity).isNull()
         }
@@ -364,13 +364,13 @@ class RedirectCoordinatorTest {
             }
             val firstJob =
                 launch(Dispatchers.IO) {
-                    subject.initialize(mock(), mock()) {
+                    subject.initialize(mock(), mock(), false) {
                         RedirectInitializationResult.Success(mock(), Any())
                     }
                 }
             assertThat(initializerCountDownLatch.await(1, TimeUnit.SECONDS)).isTrue()
             val concurrentResult =
-                subject.initialize(mock(), mock()) {
+                subject.initialize(mock(), mock(), false) {
                     RedirectInitializationResult.Success(mock(), Any())
                 }
             assertThat(concurrentResult).isInstanceOf(RedirectInitializationResult.Error::class.java)


### PR DESCRIPTION
## Summary

This change adds optional support for **ephemeral browsing** in the web authentication flow.

## Issue

When a customer switches between ** type 1 account to type 2** or ** type 2 account to type 1** flows, the login screen can reuse an already active browser session instead of reflecting the updated user context. Because of that, it's picking previously logged-in information instead of forcing a fresh authentication experience.

## Solution

To address this, this PR introduces an **Ephemeral Browsing** option in the web authentication flow.

When enabled, the SDK will request an ephemeral browser session (when supported by the selected Custom Tabs browser). This helps prevent reuse of stale browser session data and ensures the authentication flow reflects the latest user context.

### What changed

- Added an  `enableEphemeralBrowsing` option through the web authentication flow APIs.
- Propagated the ephemeral browsing flag through:
  - `WebAuthentication`
  - `RedirectCoordinator`
  - `WebAuthenticationProvider`
  - `DefaultWebAuthenticationProvider`
- Enabled ephemeral browsing only when the selected browser supports it.
- Updated unit tests to cover the new API behavior and event flow expectations.

## Backward compatibility

This feature is **optional** and defaults to `false`.

That means:
- existing consumers of the library are **not affected**
- current integrations continue to behave exactly as before unless they explicitly opt in
- consumers who do not need this behavior do not need to make any code changes

## Benefits

- avoids stale session reuse across user/dealer switching scenarios
- improves correctness of authentication context
- preserves existing behavior for all current SDK consumers

## Testing

- Updated `web-authentication-ui` unit tests
- Verified affected build/test flows pass successfully