### PR TITLE
Add Chrome Auth Tab support to web-authentication-ui

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
       - checkout
       - android/restore_gradle_cache
       - android/run_tests:
-          test_command: ./gradlew :okta-direct-auth:testAndroidHostTest :auth-foundation:testAndroidHostTest --no-daemon
+          test_command: ./gradlew :okta-direct-auth:testAndroidHostTest :auth-foundation:testAndroidHostTest :oauth2:testAndroidHostTest --no-daemon
       - android/save_gradle_cache
       - run:
           name: Save test results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## web-authentication-ui Unreleased
+
+#### Added
+- `DefaultWebAuthenticationProvider` now launches via Chrome's Auth Tab (`androidx.browser.auth.AuthTabIntent`)
+  when the resolved browser supports it, falling back to Chrome Custom Tabs otherwise. New
+  `customizeAuthTabIntent` constructor parameter, symmetric with the existing `customizeTabsIntent`
+  (#372).
+
 ## auth-foundation 3.0.0 - 2026-08-05
 
 [Commits](https://github.com/okta/okta-mobile-kotlin/compare/auth-foundation@2.0.5...auth-foundation@3.0.0)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <queries>
+        <intent>
+            <action android:name="android.support.customtabs.action.CustomTabsService" />
+        </intent>
+    </queries>
+
     <application
         android:name=".SampleApplication"
         android:icon="@mipmap/ic_launcher"

--- a/web-authentication-ui/api/web-authentication-ui.api
+++ b/web-authentication-ui/api/web-authentication-ui.api
@@ -1,4 +1,4 @@
-public final class com/okta/webauthenticationui/DefaultWebAuthenticationProvider : com/okta/webauthenticationui/WebAuthenticationProvider {
+public final class com/okta/webauthenticationui/DefaultWebAuthenticationProvider : com/okta/webauthenticationui/AuthTabWebAuthenticationProvider, com/okta/webauthenticationui/WebAuthenticationProvider {
 	public static final field Companion Lcom/okta/webauthenticationui/DefaultWebAuthenticationProvider$Companion;
 	public static final field X_OKTA_USER_AGENT Ljava/lang/String;
 	public fun <init> ()V
@@ -6,10 +6,12 @@ public final class com/okta/webauthenticationui/DefaultWebAuthenticationProvider
 	public fun <init> (Lcom/okta/authfoundation/events/EventCoordinator;Ljava/util/List;)V
 	public fun <init> (Lcom/okta/authfoundation/events/EventCoordinator;Ljava/util/List;I)V
 	public fun <init> (Lcom/okta/authfoundation/events/EventCoordinator;Ljava/util/List;ILkotlin/jvm/functions/Function2;)V
-	public synthetic fun <init> (Lcom/okta/authfoundation/events/EventCoordinator;Ljava/util/List;ILkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/okta/authfoundation/events/EventCoordinator;Ljava/util/List;ILkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)V
+	public synthetic fun <init> (Lcom/okta/authfoundation/events/EventCoordinator;Ljava/util/List;ILkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getPreferredBrowsers ()Ljava/util/List;
 	public final fun getQueryIntentServicesFlags ()I
 	public fun launch (Landroid/content/Context;Lokhttp3/HttpUrl;)Ljava/lang/Exception;
+	public fun launchAuthTab (Landroid/content/Context;Lokhttp3/HttpUrl;Ljava/lang/String;Landroidx/activity/result/ActivityResultLauncher;)Ljava/lang/Exception;
 }
 
 public final class com/okta/webauthenticationui/DefaultWebAuthenticationProvider$Companion {

--- a/web-authentication-ui/build.gradle.kts
+++ b/web-authentication-ui/build.gradle.kts
@@ -21,6 +21,7 @@ android {
         consumerProguardFiles("consumer-rules.pro")
 
         buildConfigField("String", "SDK_VERSION", "\"okta-web-authentication-ui-kotlin/$WEB_AUTHENTICATION_UI_VERSION\"")
+        buildConfigField("String", "VERSION", "\"$WEB_AUTHENTICATION_UI_VERSION\"")
     }
 
     buildTypes {

--- a/web-authentication-ui/src/main/java/com/okta/webauthenticationui/AuthTabWebAuthenticationProvider.kt
+++ b/web-authentication-ui/src/main/java/com/okta/webauthenticationui/AuthTabWebAuthenticationProvider.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.webauthenticationui
+
+import android.content.Context
+import android.content.Intent
+import androidx.activity.result.ActivityResultLauncher
+import okhttp3.HttpUrl
+
+/**
+ * Optional capability for [WebAuthenticationProvider] implementations that can launch the OIDC
+ * redirect flow via Chrome's Auth Tab (`androidx.browser.auth.AuthTabIntent`) instead of standard
+ * Custom Tabs.
+ *
+ * Kept internal: [RedirectCoordinator] prefers this over [WebAuthenticationProvider.launch] when a
+ * provider implements it, but never needs to know whether a given launch actually used Auth Tab or
+ * fell back to Custom Tabs — that decision belongs entirely to the implementation of [launchAuthTab].
+ */
+internal interface AuthTabWebAuthenticationProvider {
+    /**
+     * Launches the OIDC redirect flow via Auth Tab, or falls back to
+     * [WebAuthenticationProvider.launch] if the resolved browser doesn't support it.
+     *
+     * @param context the Android [android.app.Activity] [Context] which is used to display the flow.
+     * @param url to authorize url the instance should display.
+     * @param redirectUrl the redirect URI registered for this flow, used to configure Auth Tab's
+     * redirect matching (scheme, or host+path for `https`).
+     * @param launcher the launcher returned by `AuthTabIntent.registerActivityResultLauncher`, used to
+     * launch the Auth Tab and receive its result.
+     *
+     * @return `null` if the flow launched successfully, or the [Exception] that caused the launch to fail.
+     */
+    fun launchAuthTab(
+        context: Context,
+        url: HttpUrl,
+        redirectUrl: String,
+        launcher: ActivityResultLauncher<Intent>,
+    ): Exception?
+}

--- a/web-authentication-ui/src/main/java/com/okta/webauthenticationui/DefaultWebAuthenticationProvider.kt
+++ b/web-authentication-ui/src/main/java/com/okta/webauthenticationui/DefaultWebAuthenticationProvider.kt
@@ -22,6 +22,9 @@ import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import android.provider.Browser
+import androidx.activity.result.ActivityResultLauncher
+import androidx.browser.auth.AuthTabIntent
+import androidx.browser.customtabs.CustomTabsClient
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.browser.customtabs.CustomTabsService
 import androidx.core.net.toUri
@@ -32,12 +35,14 @@ import okhttp3.HttpUrl
 
 /**
  * Default [WebAuthenticationProvider] implementation that launches the OIDC redirect flow using
- * Chrome Custom Tabs.
+ * Chrome Custom Tabs, preferring Chrome's Auth Tab (a Custom Tabs variant purpose-built for auth
+ * redirect flows) when the resolved browser supports it.
  *
  * Browser selection and tab appearance are configured via constructor parameters rather than event
  * handlers. Use [preferredBrowsers] to control which browser is chosen, [queryIntentServicesFlags]
- * to adjust the package-manager query, and [customizeTabsIntent] to style the Chrome Custom Tab
- * (toolbar color, animations, close button icon, etc.).
+ * to adjust the package-manager query, [customizeTabsIntent] to style the Chrome Custom Tab
+ * (toolbar color, animations, close button icon, etc.), and [customizeAuthTabIntent] for the
+ * equivalent Auth Tab customization.
  *
  * ```kotlin
  * val provider = DefaultWebAuthenticationProvider(
@@ -83,13 +88,28 @@ class DefaultWebAuthenticationProvider
          * ```
          */
         private val customizeTabsIntent: ((context: Context, builder: CustomTabsIntent.Builder) -> Unit)? = null,
-    ) : WebAuthenticationProvider {
+        /**
+         * Optional callback to customize the [androidx.browser.auth.AuthTabIntent.Builder] before
+         * the Auth Tab is launched. Only invoked when the resolved browser supports Auth Tab; has no
+         * effect when falling back to Chrome Custom Tabs.
+         *
+         * ```kotlin
+         * DefaultWebAuthenticationProvider(
+         *     customizeAuthTabIntent = { _, builder ->
+         *         builder.setEphemeralBrowsingEnabled(true)
+         *     }
+         * )
+         * ```
+         */
+        private val customizeAuthTabIntent: ((context: Context, builder: AuthTabIntent.Builder) -> Unit)? = null,
+    ) : WebAuthenticationProvider,
+        AuthTabWebAuthenticationProvider {
         companion object {
             /** HTTP header name used to send the Okta SDK user-agent string to the authorize endpoint. */
             const val X_OKTA_USER_AGENT = "X-Okta-User-Agent-Extended"
 
             /** The `X-Okta-User-Agent-Extended` header value sent with authorize requests. */
-            val USER_AGENT_HEADER = "web-authentication-ui/${Build.VERSION.SDK_INT} com.okta.webauthenticationui/3.0.0"
+            val USER_AGENT_HEADER = "web-authentication-ui/${Build.VERSION.SDK_INT} com.okta.webauthenticationui/${BuildConfig.VERSION}"
 
             private const val CHROME_STABLE = "com.android.chrome"
             private const val CHROME_SYSTEM = "com.google.android.apps.chrome"
@@ -123,6 +143,41 @@ class DefaultWebAuthenticationProvider
                 return null
             } catch (e: ActivityNotFoundException) {
                 return e
+            }
+        }
+
+        override fun launchAuthTab(
+            context: Context,
+            url: HttpUrl,
+            redirectUrl: String,
+            launcher: ActivityResultLauncher<Intent>,
+        ): Exception? {
+            val packageBrowser = getBrowser(context)
+            if (packageBrowser == null || !CustomTabsClient.isAuthTabSupported(context, packageBrowser)) {
+                return launch(context, url)
+            }
+
+            val intentBuilder = AuthTabIntent.Builder()
+            customizeAuthTabIntent?.invoke(context, intentBuilder)
+            val authTabIntent = intentBuilder.build()
+            authTabIntent.intent.setPackage(packageBrowser)
+
+            val headers = Bundle()
+            headers.putString(X_OKTA_USER_AGENT, USER_AGENT_HEADER)
+            authTabIntent.intent.putExtra(Browser.EXTRA_HEADERS, headers)
+
+            val redirectUri = redirectUrl.toUri()
+            val authorizeUri = url.toString().toUri()
+
+            return try {
+                if (redirectUri.scheme == "https" || redirectUri.scheme == "http") {
+                    authTabIntent.launch(launcher, authorizeUri, redirectUri.host.orEmpty(), redirectUri.path.orEmpty())
+                } else {
+                    authTabIntent.launch(launcher, authorizeUri, redirectUri.scheme.orEmpty())
+                }
+                null
+            } catch (e: ActivityNotFoundException) {
+                e
             }
         }
 

--- a/web-authentication-ui/src/main/java/com/okta/webauthenticationui/ForegroundActivity.kt
+++ b/web-authentication-ui/src/main/java/com/okta/webauthenticationui/ForegroundActivity.kt
@@ -19,9 +19,11 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.viewModels
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatActivity
+import androidx.browser.auth.AuthTabIntent
 import androidx.lifecycle.Observer
 import com.okta.authfoundation.AuthFoundationDefaults
 
@@ -46,6 +48,14 @@ internal class ForegroundActivity : AppCompatActivity() {
 
     @VisibleForTesting
     val viewModel by viewModels<ForegroundViewModel>()
+
+    // Must be registered unconditionally before the activity is created, per the AuthTabIntent contract.
+    @VisibleForTesting
+    val authTabLauncher: ActivityResultLauncher<Intent> =
+        AuthTabIntent.registerActivityResultLauncher(this) { result ->
+            viewModel.onAuthTabResult(result.resultCode, result.resultUri)
+            finish()
+        }
 
     private val eventCoordinator = AuthFoundationDefaults.eventCoordinator
 
@@ -110,7 +120,7 @@ internal class ForegroundActivity : AppCompatActivity() {
                 }
 
                 is ForegroundViewModel.State.LaunchBrowser -> {
-                    viewModel.launchBrowser(this, state.urlString)
+                    viewModel.launchBrowser(this, state.urlString, authTabLauncher)
                 }
 
                 ForegroundViewModel.State.AwaitingInitialization -> {

--- a/web-authentication-ui/src/main/java/com/okta/webauthenticationui/ForegroundViewModel.kt
+++ b/web-authentication-ui/src/main/java/com/okta/webauthenticationui/ForegroundViewModel.kt
@@ -16,9 +16,12 @@
 package com.okta.webauthenticationui
 
 import android.app.Activity
+import android.content.Intent
 import android.net.Uri
 import android.os.Parcelable
+import androidx.activity.result.ActivityResultLauncher
 import androidx.annotation.VisibleForTesting
+import androidx.browser.auth.AuthTabIntent
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
@@ -76,9 +79,10 @@ internal class ForegroundViewModel(
     fun launchBrowser(
         activity: Activity,
         urlString: String,
+        authTabLauncher: ActivityResultLauncher<Intent>,
     ) {
         savedStateHandle[LIVE_DATA_KEY] = State.AwaitingBrowserCallback
-        if (!redirectCoordinator.launchWebAuthenticationProvider(activity, urlString.toHttpUrl())) {
+        if (!redirectCoordinator.launchWebAuthenticationProvider(activity, urlString.toHttpUrl(), authTabLauncher)) {
             activity.finish()
         }
     }
@@ -92,6 +96,22 @@ internal class ForegroundViewModel(
 
     fun onRedirect(data: Uri?) {
         redirectCoordinator.emit(data)
+    }
+
+    /**
+     * Handles the result of a launched Auth Tab. [resultCode]/[resultUri] are the unwrapped fields of
+     * `AuthTabIntent.AuthResult` — passed as primitives (rather than the result type itself) since that
+     * type has a package-private constructor and can't be constructed from tests.
+     */
+    fun onAuthTabResult(
+        resultCode: Int,
+        resultUri: Uri?,
+    ) {
+        if (resultCode == AuthTabIntent.RESULT_OK) {
+            redirectCoordinator.emit(resultUri)
+        } else {
+            redirectCoordinator.emit(null)
+        }
     }
 
     fun flowCancelled() {

--- a/web-authentication-ui/src/main/java/com/okta/webauthenticationui/RedirectCoordinator.kt
+++ b/web-authentication-ui/src/main/java/com/okta/webauthenticationui/RedirectCoordinator.kt
@@ -16,8 +16,10 @@
 package com.okta.webauthenticationui
 
 import android.content.Context
+import android.content.Intent
 import android.net.Uri
 import androidx.activity.ComponentActivity
+import androidx.activity.result.ActivityResultLauncher
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.Lifecycle
 import com.okta.authfoundation.AuthFoundationDefaults
@@ -53,6 +55,8 @@ internal class DefaultRedirectCoordinator(
 
     @Volatile private var webAuthenticationProvider: WebAuthenticationProvider? = null
 
+    @Volatile private var redirectUrl: String? = null
+
     private var emitErrorJob: Job? = null
 
     private val flowMutex = Mutex()
@@ -63,6 +67,7 @@ internal class DefaultRedirectCoordinator(
     override suspend fun <T> initialize(
         webAuthenticationProvider: WebAuthenticationProvider,
         context: Context,
+        redirectUrl: String,
         initializer: suspend () -> RedirectInitializationResult<T>,
     ): RedirectInitializationResult<T> {
         currentCoroutineContext().ensureActive()
@@ -72,6 +77,7 @@ internal class DefaultRedirectCoordinator(
             }
             isFlowActive = true
             this.webAuthenticationProvider = webAuthenticationProvider
+            this.redirectUrl = redirectUrl
             this.initializer = initializer
         }
 
@@ -117,12 +123,20 @@ internal class DefaultRedirectCoordinator(
     override fun launchWebAuthenticationProvider(
         context: Context,
         url: HttpUrl,
+        authTabLauncher: ActivityResultLauncher<Intent>,
     ): Boolean {
         val localWebAuthenticationProvider = webAuthenticationProvider
+        val localRedirectUrl = redirectUrl
         webAuthenticationProvider = null
+        redirectUrl = null
 
-        if (localWebAuthenticationProvider != null) {
-            val exception = localWebAuthenticationProvider.launch(context, url)
+        if (localWebAuthenticationProvider != null && localRedirectUrl != null) {
+            val exception =
+                if (localWebAuthenticationProvider is AuthTabWebAuthenticationProvider) {
+                    localWebAuthenticationProvider.launchAuthTab(context, url, localRedirectUrl, authTabLauncher)
+                } else {
+                    localWebAuthenticationProvider.launch(context, url)
+                }
             if (exception == null) {
                 return true
             } else {
@@ -173,6 +187,7 @@ internal class DefaultRedirectCoordinator(
         redirectContinuation = null
         redirectContinuationListeningCallback = null
         webAuthenticationProvider = null
+        redirectUrl = null
     }
 }
 
@@ -180,6 +195,7 @@ internal interface RedirectCoordinator {
     suspend fun <T> initialize(
         webAuthenticationProvider: WebAuthenticationProvider,
         context: Context,
+        redirectUrl: String,
         initializer: suspend () -> RedirectInitializationResult<T>,
     ): RedirectInitializationResult<T>
 
@@ -190,6 +206,7 @@ internal interface RedirectCoordinator {
     fun launchWebAuthenticationProvider(
         context: Context,
         url: HttpUrl,
+        authTabLauncher: ActivityResultLauncher<Intent>,
     ): Boolean
 
     fun emitError(exception: Exception)

--- a/web-authentication-ui/src/main/java/com/okta/webauthenticationui/WebAuthentication.kt
+++ b/web-authentication-ui/src/main/java/com/okta/webauthenticationui/WebAuthentication.kt
@@ -213,7 +213,7 @@ class WebAuthentication private constructor(
         extraRequestParameters: Map<String, String> = emptyMap(),
     ): Result<TokenInfo> {
         val initializationResult =
-            redirectCoordinator.initialize(webAuthenticationProvider, context) {
+            redirectCoordinator.initialize(webAuthenticationProvider, context, redirectUrl) {
                 authorizationCodeFlow
                     .start(redirectUrl, scope, extraRequestParameters)
                     .mapCatching { flowContext ->
@@ -285,7 +285,7 @@ class WebAuthentication private constructor(
         idToken: String,
     ): OAuth2ClientResult<Unit> {
         val initializationResult =
-            redirectCoordinator.initialize(webAuthenticationProvider, context) {
+            redirectCoordinator.initialize(webAuthenticationProvider, context, redirectUrl) {
                 redirectEndSessionFlow
                     .start(idToken, redirectUrl)
                     .mapCatching { flowContext ->

--- a/web-authentication-ui/src/test/java/com/okta/webauthenticationui/DefaultWebAuthenticationProviderTest.kt
+++ b/web-authentication-ui/src/test/java/com/okta/webauthenticationui/DefaultWebAuthenticationProviderTest.kt
@@ -18,12 +18,16 @@ package com.okta.webauthenticationui
 import android.app.Activity
 import android.content.ActivityNotFoundException
 import android.content.Intent
+import android.content.IntentFilter
 import android.content.pm.ActivityInfo
 import android.content.pm.ResolveInfo
 import android.content.pm.ServiceInfo
 import android.net.Uri
 import android.provider.Browser
+import androidx.activity.result.ActivityResultLauncher
+import androidx.browser.auth.AuthTabIntent
 import androidx.browser.customtabs.CustomTabsService
+import androidx.core.net.toUri
 import com.google.common.truth.Truth.assertThat
 import com.okta.authfoundation.events.Event
 import com.okta.authfoundation.events.EventCoordinator
@@ -34,6 +38,13 @@ import com.okta.webauthenticationui.events.CustomizeCustomTabsEvent
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
@@ -151,6 +162,116 @@ class DefaultWebAuthenticationProviderTest {
         val webAuthenticationProvider = DefaultWebAuthenticationProvider(EventCoordinator(emptyList()))
         val exception = webAuthenticationProvider.launch(activity.get(), "https://example.com/not_used".toHttpUrl())
         assertThat(exception).isInstanceOf(ActivityNotFoundException::class.java)
+    }
+
+    @Test fun testLaunchAuthTabWhenSupported() {
+        installAuthTabProvider("com.android.chrome")
+        val activity = Robolectric.buildActivity(Activity::class.java)
+        val webAuthenticationProvider = DefaultWebAuthenticationProvider(EventCoordinator(emptyList()))
+        val launcher = mock<ActivityResultLauncher<Intent>>()
+        val exception =
+            webAuthenticationProvider.launchAuthTab(
+                activity.get(),
+                "https://example.com/authorize".toHttpUrl(),
+                "unitTest:/callback",
+                launcher
+            )
+        assertThat(exception).isNull()
+
+        val captor = argumentCaptor<Intent>()
+        verify(launcher).launch(captor.capture())
+        val intent = captor.firstValue
+        assertThat(intent.`package`).isEqualTo("com.android.chrome")
+        assertThat(intent.data).isEqualTo("https://example.com/authorize".toUri())
+        assertThat(intent.getStringExtra(AuthTabIntent.EXTRA_REDIRECT_SCHEME)).isEqualTo("unitTest")
+        val headers = intent.extras!!.getBundle(Browser.EXTRA_HEADERS)
+        assertThat(headers!!.getString(DefaultWebAuthenticationProvider.X_OKTA_USER_AGENT)).isEqualTo(DefaultWebAuthenticationProvider.USER_AGENT_HEADER)
+    }
+
+    @Test fun testLaunchAuthTabWithHttpsRedirect() {
+        installAuthTabProvider("com.android.chrome")
+        val activity = Robolectric.buildActivity(Activity::class.java)
+        val webAuthenticationProvider = DefaultWebAuthenticationProvider(EventCoordinator(emptyList()))
+        val launcher = mock<ActivityResultLauncher<Intent>>()
+        webAuthenticationProvider.launchAuthTab(
+            activity.get(),
+            "https://example.com/authorize".toHttpUrl(),
+            "https://app.example.com/callback",
+            launcher
+        )
+
+        val captor = argumentCaptor<Intent>()
+        verify(launcher).launch(captor.capture())
+        val intent = captor.firstValue
+        assertThat(intent.getStringExtra(AuthTabIntent.EXTRA_HTTPS_REDIRECT_HOST)).isEqualTo("app.example.com")
+        assertThat(intent.getStringExtra(AuthTabIntent.EXTRA_HTTPS_REDIRECT_PATH)).isEqualTo("/callback")
+    }
+
+    @Test fun testLaunchAuthTabFallsBackToCustomTabsWhenUnsupported() {
+        installCustomTabsProvider("com.android.chrome")
+        val activity = Robolectric.buildActivity(Activity::class.java)
+        val webAuthenticationProvider = DefaultWebAuthenticationProvider(EventCoordinator(emptyList()))
+        val launcher = mock<ActivityResultLauncher<Intent>>()
+        val exception =
+            webAuthenticationProvider.launchAuthTab(
+                activity.get(),
+                "https://example.com/authorize".toHttpUrl(),
+                "unitTest:/callback",
+                launcher
+            )
+        assertThat(exception).isNull()
+        verifyNoInteractions(launcher)
+
+        val activityShadow = shadowOf(activity.get())
+        val cctActivity = activityShadow.nextStartedActivity
+        assertThat(cctActivity.action).isEqualTo("android.intent.action.VIEW")
+        assertThat(cctActivity.`package`).isEqualTo("com.android.chrome")
+    }
+
+    @Test fun testLaunchAuthTabCausesActivityNotFound() {
+        installAuthTabProvider("com.android.chrome")
+        val activity = Robolectric.buildActivity(Activity::class.java)
+        val webAuthenticationProvider = DefaultWebAuthenticationProvider(EventCoordinator(emptyList()))
+        val launcher = mock<ActivityResultLauncher<Intent>>()
+        doThrow(ActivityNotFoundException("From Test!")).whenever(launcher).launch(any())
+        val exception =
+            webAuthenticationProvider.launchAuthTab(
+                activity.get(),
+                "https://example.com/authorize".toHttpUrl(),
+                "unitTest:/callback",
+                launcher
+            )
+        assertThat(exception).isInstanceOf(ActivityNotFoundException::class.java)
+        assertThat(exception).hasMessageThat().isEqualTo("From Test!")
+    }
+
+    @Test fun testCustomizeAuthTabIntentCallback_BuilderMutationApplied() {
+        installAuthTabProvider("com.android.chrome")
+        var capturedBuilder: AuthTabIntent.Builder? = null
+        val webAuthenticationProvider =
+            DefaultWebAuthenticationProvider(
+                customizeAuthTabIntent = { _, builder -> capturedBuilder = builder }
+            )
+        val activity = Robolectric.buildActivity(Activity::class.java)
+        webAuthenticationProvider.launchAuthTab(
+            activity.get(),
+            "https://example.com/authorize".toHttpUrl(),
+            "unitTest:/callback",
+            mock()
+        )
+        assertThat(capturedBuilder).isNotNull()
+    }
+
+    private fun installAuthTabProvider(packageName: String) {
+        installBrowser(packageName)
+        val intent = Intent().setAction(CustomTabsService.ACTION_CUSTOM_TABS_CONNECTION)
+        val resolveInfo = ResolveInfo()
+        resolveInfo.serviceInfo = ServiceInfo()
+        resolveInfo.serviceInfo.packageName = packageName
+        resolveInfo.filter = IntentFilter().apply { addCategory(CustomTabsService.CATEGORY_AUTH_TAB) }
+        val packageManager = shadowOf(RuntimeEnvironment.getApplication().packageManager)
+        @Suppress("DEPRECATION")
+        packageManager.addResolveInfoForIntent(intent, resolveInfo)
     }
 
     // Copyright 2019 Google Inc. All Rights Reserved.

--- a/web-authentication-ui/src/test/java/com/okta/webauthenticationui/ForegroundActivityTest.kt
+++ b/web-authentication-ui/src/test/java/com/okta/webauthenticationui/ForegroundActivityTest.kt
@@ -71,7 +71,7 @@ class ForegroundActivityTest {
         val activity = controller.get()
         val redirectCoordinator =
             mock<RedirectCoordinator> {
-                on { launchWebAuthenticationProvider(any(), any()) } doReturn true
+                on { launchWebAuthenticationProvider(any(), any(), any()) } doReturn true
                 onBlocking { runInitializationFunction() } doAnswer {
                     RedirectInitializationResult.Success(mockUrl, Any())
                 }
@@ -79,7 +79,7 @@ class ForegroundActivityTest {
         ForegroundViewModel.redirectCoordinator = redirectCoordinator
         controller.create().resume()
 
-        verify(redirectCoordinator).launchWebAuthenticationProvider(any(), any())
+        verify(redirectCoordinator).launchWebAuthenticationProvider(any(), any(), any())
         assertThat(activity.isFinishing).isFalse()
         verify(redirectCoordinator, never()).emit(anyOrNull())
         verify(redirectCoordinator, never()).emitError(any())
@@ -93,18 +93,18 @@ class ForegroundActivityTest {
         val deferred = CompletableDeferred<RedirectInitializationResult<Any>>()
         val redirectCoordinator =
             mock<RedirectCoordinator> {
-                on { launchWebAuthenticationProvider(any(), any()) } doReturn true
+                on { launchWebAuthenticationProvider(any(), any(), any()) } doReturn true
                 onBlocking { runInitializationFunction() } doSuspendableAnswer {
                     deferred.await()
                 }
             }
         ForegroundViewModel.redirectCoordinator = redirectCoordinator
         controller.create().resume().pause()
-        verify(redirectCoordinator, never()).launchWebAuthenticationProvider(any(), any())
+        verify(redirectCoordinator, never()).launchWebAuthenticationProvider(any(), any(), any())
         deferred.complete(RedirectInitializationResult.Success(mockUrl, Any()))
         controller.resume()
 
-        verify(redirectCoordinator).launchWebAuthenticationProvider(any(), any())
+        verify(redirectCoordinator).launchWebAuthenticationProvider(any(), any(), any())
         assertThat(activity.isFinishing).isFalse()
         verify(redirectCoordinator, never()).emit(anyOrNull())
         verify(redirectCoordinator, never()).emitError(any())
@@ -117,7 +117,7 @@ class ForegroundActivityTest {
         val activity = controller.get()
         val redirectCoordinator =
             mock<RedirectCoordinator> {
-                on { launchWebAuthenticationProvider(any(), any()) } doReturn false
+                on { launchWebAuthenticationProvider(any(), any(), any()) } doReturn false
                 onBlocking { runInitializationFunction() } doAnswer {
                     RedirectInitializationResult.Success(mockUrl, Any())
                 }
@@ -136,7 +136,7 @@ class ForegroundActivityTest {
         val activity = controller.get()
         val redirectCoordinator =
             mock<RedirectCoordinator> {
-                on { launchWebAuthenticationProvider(any(), any()) } doReturn true
+                on { launchWebAuthenticationProvider(any(), any(), any()) } doReturn true
                 onBlocking { runInitializationFunction() } doAnswer {
                     RedirectInitializationResult.Success(mockUrl, Any())
                 }
@@ -157,7 +157,7 @@ class ForegroundActivityTest {
         val activity = controller.get()
         val redirectCoordinator =
             mock<RedirectCoordinator> {
-                on { launchWebAuthenticationProvider(any(), any()) } doReturn true
+                on { launchWebAuthenticationProvider(any(), any(), any()) } doReturn true
                 onBlocking { runInitializationFunction() } doAnswer {
                     RedirectInitializationResult.Success(mockUrl, Any())
                 }
@@ -181,7 +181,7 @@ class ForegroundActivityTest {
         val activity = controller.get()
         val redirectCoordinator =
             mock<RedirectCoordinator> {
-                on { launchWebAuthenticationProvider(any(), any()) } doReturn true
+                on { launchWebAuthenticationProvider(any(), any(), any()) } doReturn true
                 onBlocking { runInitializationFunction() } doAnswer {
                     RedirectInitializationResult.Error<Any>(IllegalStateException("From Test!"))
                 }
@@ -189,7 +189,7 @@ class ForegroundActivityTest {
         ForegroundViewModel.redirectCoordinator = redirectCoordinator
         controller.create().resume()
 
-        verify(redirectCoordinator, never()).launchWebAuthenticationProvider(any(), any())
+        verify(redirectCoordinator, never()).launchWebAuthenticationProvider(any(), any(), any())
         assertThat(activity.isFinishing).isTrue()
         verify(redirectCoordinator, never()).emit(anyOrNull())
         verify(redirectCoordinator, never()).emitError(any())
@@ -202,7 +202,7 @@ class ForegroundActivityTest {
         val controller = Robolectric.buildActivity(ForegroundActivity::class.java, intent)
         val redirectCoordinator =
             mockk<RedirectCoordinator> {
-                every { launchWebAuthenticationProvider(any(), any()) } returns true
+                every { launchWebAuthenticationProvider(any(), any(), any()) } returns true
                 coEvery { runInitializationFunction() } answers {
                     RedirectInitializationResult.Success(mockUrl, Any())
                 }

--- a/web-authentication-ui/src/test/java/com/okta/webauthenticationui/ForegroundViewModelTest.kt
+++ b/web-authentication-ui/src/test/java/com/okta/webauthenticationui/ForegroundViewModelTest.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.webauthenticationui
+
+import android.app.Activity
+import android.content.Intent
+import android.net.Uri
+import androidx.activity.result.ActivityResultLauncher
+import androidx.browser.auth.AuthTabIntent
+import androidx.lifecycle.SavedStateHandle
+import com.google.common.truth.Truth.assertThat
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Uses primitive-typed [ForegroundViewModel.onAuthTabResult] arguments rather than a real
+ * `AuthTabIntent.AuthResult` — that type has a package-private constructor and can't be constructed
+ * or mocked from this module, which is exactly why [ForegroundActivity] unwraps it before calling in.
+ */
+@RunWith(RobolectricTestRunner::class)
+class ForegroundViewModelTest {
+    private lateinit var redirectCoordinator: RedirectCoordinator
+    private lateinit var viewModel: ForegroundViewModel
+
+    @Before fun setup() {
+        redirectCoordinator =
+            mock<RedirectCoordinator> {
+                onBlocking { runInitializationFunction() } doReturn
+                    RedirectInitializationResult.Error<Any>(IllegalStateException("Not used in this test."))
+            }
+        ForegroundViewModel.redirectCoordinator = redirectCoordinator
+        viewModel = ForegroundViewModel(SavedStateHandle())
+    }
+
+    @After fun tearDown() {
+        ForegroundViewModel.redirectCoordinator = SingletonRedirectCoordinator
+    }
+
+    @Test fun testOnAuthTabResult_ResultOk_EmitsUri() {
+        val uri = Uri.parse("unitTest:/callback?code=abc")
+        viewModel.onAuthTabResult(AuthTabIntent.RESULT_OK, uri)
+        verify(redirectCoordinator).emit(uri)
+    }
+
+    @Test fun testOnAuthTabResult_ResultCanceled_EmitsNull() {
+        viewModel.onAuthTabResult(AuthTabIntent.RESULT_CANCELED, null)
+        verify(redirectCoordinator).emit(null)
+    }
+
+    @Test fun testOnAuthTabResult_VerificationFailed_EmitsNull() {
+        viewModel.onAuthTabResult(AuthTabIntent.RESULT_VERIFICATION_FAILED, null)
+        verify(redirectCoordinator).emit(null)
+    }
+
+    @Test fun testOnAuthTabResult_VerificationTimedOut_EmitsNull() {
+        viewModel.onAuthTabResult(AuthTabIntent.RESULT_VERIFICATION_TIMED_OUT, null)
+        verify(redirectCoordinator).emit(null)
+    }
+
+    @Test fun testOnAuthTabResult_UnknownCode_EmitsNull() {
+        viewModel.onAuthTabResult(AuthTabIntent.RESULT_UNKNOWN_CODE, null)
+        verify(redirectCoordinator).emit(null)
+    }
+
+    @Test fun testLaunchBrowser_PassesAuthTabLauncherThrough() {
+        val activity = Robolectric.buildActivity(Activity::class.java).create().get()
+        val launcher = mock<ActivityResultLauncher<Intent>>()
+        whenever(redirectCoordinator.launchWebAuthenticationProvider(any(), any(), any())).thenReturn(true)
+
+        viewModel.launchBrowser(activity, "https://example.com/authorize", launcher)
+
+        verify(redirectCoordinator).launchWebAuthenticationProvider(activity, "https://example.com/authorize".toHttpUrl(), launcher)
+        assertThat(activity.isFinishing).isFalse()
+    }
+
+    @Test fun testLaunchBrowser_FinishesActivityWhenLaunchFails() {
+        val activity = Robolectric.buildActivity(Activity::class.java).create().get()
+        val launcher = mock<ActivityResultLauncher<Intent>>()
+        whenever(redirectCoordinator.launchWebAuthenticationProvider(any(), any(), any())).thenReturn(false)
+
+        viewModel.launchBrowser(activity, "https://example.com/authorize", launcher)
+
+        assertThat(activity.isFinishing).isTrue()
+    }
+}

--- a/web-authentication-ui/src/test/java/com/okta/webauthenticationui/RedirectCoordinatorTest.kt
+++ b/web-authentication-ui/src/test/java/com/okta/webauthenticationui/RedirectCoordinatorTest.kt
@@ -17,8 +17,11 @@ package com.okta.webauthenticationui
 
 import android.app.Activity
 import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
 import android.net.Uri
 import androidx.activity.ComponentActivity
+import androidx.activity.result.ActivityResultLauncher
 import com.google.common.truth.Truth.assertThat
 import com.okta.authfoundation.AuthFoundationDefaults
 import io.mockk.every
@@ -47,6 +50,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
@@ -163,7 +167,7 @@ class RedirectCoordinatorTest {
             }
             val resultDeferred =
                 async(Dispatchers.IO) {
-                    subject.initialize(mock(), mock()) {
+                    subject.initialize(mock(), mock(), "https://example.com/redirect") {
                         RedirectInitializationResult.Success(mock(), Any())
                     }
                 }
@@ -190,7 +194,7 @@ class RedirectCoordinatorTest {
     @Test fun testLaunchWebAuthenticationProviderWithoutInitialize(): Unit =
         testScope.runTest {
             val resultDeferred = listenRedirectAsync()
-            assertThat(subject.launchWebAuthenticationProvider(mock(), "https://example.com".toHttpUrl())).isFalse()
+            assertThat(subject.launchWebAuthenticationProvider(mock(), "https://example.com".toHttpUrl(), mock())).isFalse()
             val result = resultDeferred.await()
             assertThat(result).isInstanceOf(RedirectResult.Error::class.java)
             val error = result as RedirectResult.Error
@@ -217,7 +221,7 @@ class RedirectCoordinatorTest {
                 initializerCountDownLatch.countDown()
             }
             launch(Dispatchers.IO) {
-                subject.initialize(webAuthenticationProvider, mock()) {
+                subject.initialize(webAuthenticationProvider, mock(), "https://example.com/redirect") {
                     RedirectInitializationResult.Success(mock(), Any())
                 }
             }
@@ -247,13 +251,13 @@ class RedirectCoordinatorTest {
                 initializerCountDownLatch.countDown()
             }
             launch(Dispatchers.IO) {
-                subject.initialize(webAuthenticationProvider, launchedFromActivity) {
+                subject.initialize(webAuthenticationProvider, launchedFromActivity, "https://example.com/redirect") {
                     RedirectInitializationResult.Success(url, Any())
                 }
             }
             assertThat(initializerCountDownLatch.await(1, TimeUnit.SECONDS)).isTrue()
             subject.runInitializationFunction()
-            assertThat(subject.launchWebAuthenticationProvider(launchedFromActivity, url)).isTrue()
+            assertThat(subject.launchWebAuthenticationProvider(launchedFromActivity, url, mock())).isTrue()
             verify(webAuthenticationProvider).launch(launchedFromActivity, url)
             val foregroundActivity = shadowOf(launchedFromActivity).nextStartedActivity
             assertThat(foregroundActivity.component?.className).isEqualTo(ForegroundActivity::class.java.name)
@@ -271,7 +275,7 @@ class RedirectCoordinatorTest {
                 .stop()
             val launchedFromActivity = activityController.get()
             val result =
-                subject.initialize(webAuthenticationProvider, launchedFromActivity) {
+                subject.initialize(webAuthenticationProvider, launchedFromActivity, "https://example.com/redirect") {
                     RedirectInitializationResult.Success("https://example.com/oauth".toHttpUrl(), Any())
                 }
             verify(webAuthenticationProvider, never()).launch(anyOrNull(), anyOrNull())
@@ -291,14 +295,39 @@ class RedirectCoordinatorTest {
                 initializerCountDownLatch.countDown()
             }
             launch(Dispatchers.IO) {
-                subject.initialize(webAuthenticationProvider, mock()) {
+                subject.initialize(webAuthenticationProvider, mock(), "https://example.com/redirect") {
                     RedirectInitializationResult.Success(mock(), Any())
                 }
             }
             assertThat(initializerCountDownLatch.await(1, TimeUnit.SECONDS)).isTrue()
             subject.runInitializationFunction()
-            assertThat(subject.launchWebAuthenticationProvider(mock(), mock())).isTrue()
+            assertThat(subject.launchWebAuthenticationProvider(mock(), mock(), mock())).isTrue()
             verify(webAuthenticationProvider).launch(any(), any())
+        }
+
+    @Test fun testLaunchWebAuthenticationProviderPrefersAuthTab(): Unit =
+        testScope.runTest {
+            val webAuthenticationProvider =
+                mock<WebAuthenticationProvider>(extraInterfaces = arrayOf(AuthTabWebAuthenticationProvider::class))
+            val authTabProvider = webAuthenticationProvider as AuthTabWebAuthenticationProvider
+            whenever(authTabProvider.launchAuthTab(any(), any(), any(), any())).thenReturn(null)
+            val context = mock<Context>()
+            val url = "https://example.com/oauth".toHttpUrl()
+            val launcher = mock<ActivityResultLauncher<Intent>>()
+            val initializerCountDownLatch = CountDownLatch(1)
+            subject.initializerContinuationListeningCallback = {
+                initializerCountDownLatch.countDown()
+            }
+            launch(Dispatchers.IO) {
+                subject.initialize(webAuthenticationProvider, mock(), "https://example.com/redirect") {
+                    RedirectInitializationResult.Success(mock(), Any())
+                }
+            }
+            assertThat(initializerCountDownLatch.await(1, TimeUnit.SECONDS)).isTrue()
+            subject.runInitializationFunction()
+            assertThat(subject.launchWebAuthenticationProvider(context, url, launcher)).isTrue()
+            verify(authTabProvider).launchAuthTab(context, url, "https://example.com/redirect", launcher)
+            verify(webAuthenticationProvider, never()).launch(any(), any())
         }
 
     @Test fun testLaunchWebAuthenticationProviderActivityNotFound(): Unit =
@@ -313,13 +342,13 @@ class RedirectCoordinatorTest {
                 initializerCountDownLatch.countDown()
             }
             launch(Dispatchers.IO) {
-                subject.initialize(webAuthenticationProvider, mock()) {
+                subject.initialize(webAuthenticationProvider, mock(), "https://example.com/redirect") {
                     RedirectInitializationResult.Success(mock(), Any())
                 }
             }
             assertThat(initializerCountDownLatch.await(1, TimeUnit.SECONDS)).isTrue()
             subject.runInitializationFunction()
-            assertThat(subject.launchWebAuthenticationProvider(mock(), mock())).isFalse()
+            assertThat(subject.launchWebAuthenticationProvider(mock(), mock(), mock())).isFalse()
             verify(webAuthenticationProvider).launch(any(), any())
             val result = resultDeferred.await()
             assertThat(result).isInstanceOf(RedirectResult.Error::class.java)
@@ -344,7 +373,7 @@ class RedirectCoordinatorTest {
                 launch(Dispatchers.IO) {
                     startedCountDownLatch.countDown()
                     assertThat(cancelledCountDownLatch.await(1, TimeUnit.SECONDS)).isTrue()
-                    subject.initialize(webAuthenticationProvider, launchedFromActivity) {
+                    subject.initialize(webAuthenticationProvider, launchedFromActivity, "https://example.com/redirect") {
                         RedirectInitializationResult.Success("https://example.com/oauth".toHttpUrl(), Any())
                     }
                 }
@@ -364,13 +393,13 @@ class RedirectCoordinatorTest {
             }
             val firstJob =
                 launch(Dispatchers.IO) {
-                    subject.initialize(mock(), mock()) {
+                    subject.initialize(mock(), mock(), "https://example.com/redirect") {
                         RedirectInitializationResult.Success(mock(), Any())
                     }
                 }
             assertThat(initializerCountDownLatch.await(1, TimeUnit.SECONDS)).isTrue()
             val concurrentResult =
-                subject.initialize(mock(), mock()) {
+                subject.initialize(mock(), mock(), "https://example.com/redirect") {
                     RedirectInitializationResult.Success(mock(), Any())
                 }
             assertThat(concurrentResult).isInstanceOf(RedirectInitializationResult.Error::class.java)


### PR DESCRIPTION
DefaultWebAuthenticationProvider now launches the OIDC redirect via [Chrome's Auth Tab ](https://developer.chrome.com/docs/android/custom-tabs/guide-auth-tab)(androidx.browser.auth.AuthTabIntent) when the resolved browser supports it, falling back to Custom Tabs otherwise. Adds a symmetric customizeAuthTabIntent constructor parameter.

Also:
- Declares the CustomTabsService <queries> entry in the `app` sample's manifest so browser resolution (and therefore Auth Tab support detection) actually succeeds on API 30+.
- Adds oauth2's Android host unit tests to CI (unit-test-android-host job only ran okta-direct-auth/auth-foundation).
- Fix hardcoded user agent in web-authentication-ui