### PR TITLE
Improve browser selection and error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@
   when the resolved browser supports it, falling back to Chrome Custom Tabs otherwise. New
   `customizeAuthTabIntent` constructor parameter, symmetric with the existing `customizeTabsIntent`
   (#372).
+- `BrowserSelector`, a `fun interface` for fully overriding how `DefaultWebAuthenticationProvider`
+  picks the browser package used to host the Chrome Custom Tab (e.g. for testing or
+  device-specific overrides), plus a new `browserSelector` constructor parameter on
+  `DefaultWebAuthenticationProvider` to supply one. `NoBrowserFoundException` is the failure cause
+  returned by the built-in selector when no usable browser is found.
+- `WebAuthenticationProvider.launchCustomTab(context, url)`, a `Result`-based replacement for the
+  now-deprecated `launch(context, url)`. It has a default implementation that delegates to
+  `launch()`, so existing `WebAuthenticationProvider` implementations keep compiling unchanged.
+
+#### Changed
+- `DefaultWebAuthenticationProvider.launchCustomTab()` (and the now-deprecated `launch()`, which
+  delegates to it) surfaces `NoBrowserFoundException` (instead of the generic
+  `ActivityNotFoundException`) when no usable browser is found on the device and the unrestricted
+  fallback launch also fails to resolve to an activity — giving integrators a distinct, catchable
+  exception for "no browser available" separate from `ActivityNotFoundException` (e.g. a
+  stale/misconfigured `Intent`) and `WebAuthentication.FlowCancelledException` (a browser opened
+  but was closed before completing the redirect).
+
+#### Fixed
+- `DefaultWebAuthenticationProvider` could select a non-browser package as the Custom Tabs host:
+  the internal browser-selection logic returned the first (or first preferred) package that merely
+  resolved `CustomTabsService.ACTION_CUSTOM_TABS_CONNECTION`, without confirming it could actually
+  handle `http(s)` links. On devices where a non-browser app implements that service, this caused
+  `launch()` to fail. Candidates are now also required to resolve `ACTION_VIEW` +
+  `CATEGORY_BROWSABLE` for `http://` or `https://` before being selected, and each preferred
+  browser is checked in order rather than stopping at the first Custom-Tabs match.
 
 ## auth-foundation 3.0.0 - 2026-08-05
 

--- a/web-authentication-ui/api/web-authentication-ui.api
+++ b/web-authentication-ui/api/web-authentication-ui.api
@@ -1,3 +1,7 @@
+public abstract interface class com/okta/webauthenticationui/BrowserSelector {
+	public abstract fun selectBrowser-IoAF18A (Landroid/content/Context;)Ljava/lang/Object;
+}
+
 public final class com/okta/webauthenticationui/DefaultWebAuthenticationProvider : com/okta/webauthenticationui/AuthTabWebAuthenticationProvider, com/okta/webauthenticationui/WebAuthenticationProvider {
 	public static final field Companion Lcom/okta/webauthenticationui/DefaultWebAuthenticationProvider$Companion;
 	public static final field X_OKTA_USER_AGENT Ljava/lang/String;
@@ -7,11 +11,13 @@ public final class com/okta/webauthenticationui/DefaultWebAuthenticationProvider
 	public fun <init> (Lcom/okta/authfoundation/events/EventCoordinator;Ljava/util/List;I)V
 	public fun <init> (Lcom/okta/authfoundation/events/EventCoordinator;Ljava/util/List;ILkotlin/jvm/functions/Function2;)V
 	public fun <init> (Lcom/okta/authfoundation/events/EventCoordinator;Ljava/util/List;ILkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)V
-	public synthetic fun <init> (Lcom/okta/authfoundation/events/EventCoordinator;Ljava/util/List;ILkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/okta/authfoundation/events/EventCoordinator;Ljava/util/List;ILkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lcom/okta/webauthenticationui/BrowserSelector;)V
+	public synthetic fun <init> (Lcom/okta/authfoundation/events/EventCoordinator;Ljava/util/List;ILkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lcom/okta/webauthenticationui/BrowserSelector;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getPreferredBrowsers ()Ljava/util/List;
 	public final fun getQueryIntentServicesFlags ()I
 	public fun launch (Landroid/content/Context;Lokhttp3/HttpUrl;)Ljava/lang/Exception;
-	public fun launchAuthTab (Landroid/content/Context;Lokhttp3/HttpUrl;Ljava/lang/String;Landroidx/activity/result/ActivityResultLauncher;)Ljava/lang/Exception;
+	public fun launchAuthTab-BWLJW6A (Landroid/content/Context;Lokhttp3/HttpUrl;Ljava/lang/String;Landroidx/activity/result/ActivityResultLauncher;)Ljava/lang/Object;
+	public fun launchCustomTab-gIAlu-s (Landroid/content/Context;Lokhttp3/HttpUrl;)Ljava/lang/Object;
 }
 
 public final class com/okta/webauthenticationui/DefaultWebAuthenticationProvider$Companion {
@@ -64,6 +70,9 @@ public final class com/okta/webauthenticationui/ForegroundActivityEvent$OnResume
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/okta/webauthenticationui/NoBrowserFoundException : java/lang/Exception {
+}
+
 public final class com/okta/webauthenticationui/WebAuthentication {
 	public static final field Companion Lcom/okta/webauthenticationui/WebAuthentication$Companion;
 	public fun <init> (Lcom/okta/authfoundation/client/OAuth2Client;Lcom/okta/webauthenticationui/WebAuthenticationProvider;)V
@@ -92,6 +101,11 @@ public final class com/okta/webauthenticationui/WebAuthentication$FlowCancelledE
 
 public abstract interface class com/okta/webauthenticationui/WebAuthenticationProvider {
 	public abstract fun launch (Landroid/content/Context;Lokhttp3/HttpUrl;)Ljava/lang/Exception;
+	public fun launchCustomTab-gIAlu-s (Landroid/content/Context;Lokhttp3/HttpUrl;)Ljava/lang/Object;
+}
+
+public final class com/okta/webauthenticationui/WebAuthenticationProvider$DefaultImpls {
+	public static fun launchCustomTab-gIAlu-s (Lcom/okta/webauthenticationui/WebAuthenticationProvider;Landroid/content/Context;Lokhttp3/HttpUrl;)Ljava/lang/Object;
 }
 
 public final class com/okta/webauthenticationui/events/CustomizeBrowserEvent : com/okta/webauthenticationui/events/UIEvent {

--- a/web-authentication-ui/src/main/java/com/okta/webauthenticationui/AuthTabWebAuthenticationProvider.kt
+++ b/web-authentication-ui/src/main/java/com/okta/webauthenticationui/AuthTabWebAuthenticationProvider.kt
@@ -25,14 +25,14 @@ import okhttp3.HttpUrl
  * redirect flow via Chrome's Auth Tab (`androidx.browser.auth.AuthTabIntent`) instead of standard
  * Custom Tabs.
  *
- * Kept internal: [RedirectCoordinator] prefers this over [WebAuthenticationProvider.launch] when a
+ * Kept internal: [RedirectCoordinator] prefers this over [WebAuthenticationProvider.launchCustomTab] when a
  * provider implements it, but never needs to know whether a given launch actually used Auth Tab or
  * fell back to Custom Tabs — that decision belongs entirely to the implementation of [launchAuthTab].
  */
 internal interface AuthTabWebAuthenticationProvider {
     /**
      * Launches the OIDC redirect flow via Auth Tab, or falls back to
-     * [WebAuthenticationProvider.launch] if the resolved browser doesn't support it.
+     * [WebAuthenticationProvider.launchCustomTab] if the resolved browser doesn't support it.
      *
      * @param context the Android [android.app.Activity] [Context] which is used to display the flow.
      * @param url to authorize url the instance should display.
@@ -41,12 +41,13 @@ internal interface AuthTabWebAuthenticationProvider {
      * @param launcher the launcher returned by `AuthTabIntent.registerActivityResultLauncher`, used to
      * launch the Auth Tab and receive its result.
      *
-     * @return `null` if the flow launched successfully, or the [Exception] that caused the launch to fail.
+     * @return [Result.success] if the flow launched successfully, or [Result.failure] with the
+     * launch exception if it fails.
      */
     fun launchAuthTab(
         context: Context,
         url: HttpUrl,
         redirectUrl: String,
         launcher: ActivityResultLauncher<Intent>,
-    ): Exception?
+    ): Result<Unit>
 }

--- a/web-authentication-ui/src/main/java/com/okta/webauthenticationui/BrowserSelector.kt
+++ b/web-authentication-ui/src/main/java/com/okta/webauthenticationui/BrowserSelector.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.webauthenticationui
+
+import android.content.Context
+
+/**
+ * Selects which browser package should host the Chrome Custom Tab used for the OIDC redirect flow.
+ *
+ * The default implementation used by [DefaultWebAuthenticationProvider] queries for installed
+ * Custom Tabs providers, confirms each candidate can actually handle `http(s)` links, and prefers
+ * [DefaultWebAuthenticationProvider.preferredBrowsers] in order. Implement this interface (and pass
+ * it to [DefaultWebAuthenticationProvider]'s constructor) to fully control browser selection, e.g.
+ * for testing or device-specific overrides.
+ */
+fun interface BrowserSelector {
+    /**
+     * Returns the package name of the browser to restrict the Custom Tab launch to.
+     *
+     * A failed [Result] (e.g. [NoBrowserFoundException]) means no specific browser was selected —
+     * [DefaultWebAuthenticationProvider] then attempts to launch the Custom Tab without a package
+     * restriction, letting Android resolve the default handler. If that unrestricted attempt also
+     * fails, the original failure cause (e.g. [NoBrowserFoundException]) is surfaced from
+     * [DefaultWebAuthenticationProvider.launchAuthTab] instead of the resulting
+     * [android.content.ActivityNotFoundException], since it is the more specific and actionable
+     * cause.
+     */
+    fun selectBrowser(context: Context): Result<String>
+}
+
+/**
+ * Failure cause returned by [BrowserSelector.selectBrowser] when no usable browser was found.
+ *
+ * Surfaced from [DefaultWebAuthenticationProvider.launchAuthTab] — and, in turn, as the failure cause of a
+ * [WebAuthentication] login/logout call — when no browser could be selected and the fallback,
+ * unrestricted launch attempt also failed to resolve to an activity. This is distinct from
+ * [WebAuthentication.FlowCancelledException], which means a browser opened but the user (or the
+ * browser itself) closed it before completing the redirect.
+ */
+class NoBrowserFoundException internal constructor() : Exception("No usable browser package was found on this device.")

--- a/web-authentication-ui/src/main/java/com/okta/webauthenticationui/DefaultWebAuthenticationProvider.kt
+++ b/web-authentication-ui/src/main/java/com/okta/webauthenticationui/DefaultWebAuthenticationProvider.kt
@@ -40,9 +40,9 @@ import okhttp3.HttpUrl
  *
  * Browser selection and tab appearance are configured via constructor parameters rather than event
  * handlers. Use [preferredBrowsers] to control which browser is chosen, [queryIntentServicesFlags]
- * to adjust the package-manager query, [customizeTabsIntent] to style the Chrome Custom Tab
- * (toolbar color, animations, close button icon, etc.), and [customizeAuthTabIntent] for the
- * equivalent Auth Tab customization.
+ * to adjust the package-manager query, [browserSelector] to fully override browser selection,
+ * [customizeTabsIntent] to style the Chrome Custom Tab (toolbar color, animations, close button
+ * icon, etc.), and [customizeAuthTabIntent] for the equivalent Auth Tab customization.
  *
  * ```kotlin
  * val provider = DefaultWebAuthenticationProvider(
@@ -54,161 +54,192 @@ import okhttp3.HttpUrl
  * val webAuth = WebAuthentication(client, provider)
  * ```
  */
-class DefaultWebAuthenticationProvider
-    @JvmOverloads
-    constructor(
-        /**
-         * @param eventCoordinator legacy hook that still receives the deprecated [CustomizeBrowserEvent]/[CustomizeCustomTabsEvent];
-         * new code should use the parameters below instead.
-         */
-        private val eventCoordinator: EventCoordinator = EventCoordinator(emptyList()),
-        /**
-         * The list of browser package names to prefer when selecting which Chrome Custom Tabs
-         * implementation is used. Checked in order; the first installed match wins.
-         *
-         * Defaults to Chrome Stable, Chrome System, and Chrome Beta.
-         */
-        val preferredBrowsers: List<String> = DEFAULT_PREFERRED_BROWSERS,
-        /**
-         * Flags passed to [android.content.pm.PackageManager.queryIntentServices] when querying for Chrome Custom
-         * Tabs intent services.
-         */
-        val queryIntentServicesFlags: Int = 0,
-        /**
-         * Optional callback to customize the [androidx.browser.customtabs.CustomTabsIntent.Builder] before the Chrome Custom
-         * Tab is launched. Use this to set toolbar color, animations, close button icon, and any
-         * other [androidx.browser.customtabs.CustomTabsIntent.Builder] options.
-         *
-         * ```kotlin
-         * DefaultWebAuthenticationProvider(
-         *     customizeTabsIntent = { context, builder ->
-         *         builder.setToolbarColor(ContextCompat.getColor(context, R.color.brand_primary))
-         *     }
-         * )
-         * ```
-         */
-        private val customizeTabsIntent: ((context: Context, builder: CustomTabsIntent.Builder) -> Unit)? = null,
-        /**
-         * Optional callback to customize the [androidx.browser.auth.AuthTabIntent.Builder] before
-         * the Auth Tab is launched. Only invoked when the resolved browser supports Auth Tab; has no
-         * effect when falling back to Chrome Custom Tabs.
-         *
-         * ```kotlin
-         * DefaultWebAuthenticationProvider(
-         *     customizeAuthTabIntent = { _, builder ->
-         *         builder.setEphemeralBrowsingEnabled(true)
-         *     }
-         * )
-         * ```
-         */
-        private val customizeAuthTabIntent: ((context: Context, builder: AuthTabIntent.Builder) -> Unit)? = null,
-    ) : WebAuthenticationProvider,
-        AuthTabWebAuthenticationProvider {
-        companion object {
-            /** HTTP header name used to send the Okta SDK user-agent string to the authorize endpoint. */
-            const val X_OKTA_USER_AGENT = "X-Okta-User-Agent-Extended"
+class DefaultWebAuthenticationProvider @JvmOverloads constructor(
+    /**
+     * @param eventCoordinator legacy hook that still receives the deprecated [CustomizeBrowserEvent]/[CustomizeCustomTabsEvent];
+     * new code should use the parameters below instead.
+     */
+    private val eventCoordinator: EventCoordinator = EventCoordinator(emptyList()),
+    /**
+     * The list of browser package names to prefer when selecting which Chrome Custom Tabs
+     * implementation is used. Checked in order; the first installed match wins.
+     *
+     * Defaults to Chrome Stable, Chrome System, and Chrome Beta. Ignored if [browserSelector] is
+     * overridden.
+     */
+    val preferredBrowsers: List<String> = DEFAULT_PREFERRED_BROWSERS,
+    /**
+     * Flags passed to [android.content.pm.PackageManager.queryIntentServices] when querying for Chrome Custom
+     * Tabs intent services. Ignored if [browserSelector] is overridden.
+     */
+    val queryIntentServicesFlags: Int = 0,
+    /**
+     * Optional callback to customize the [androidx.browser.customtabs.CustomTabsIntent.Builder] before the Chrome Custom
+     * Tab is launched. Use this to set toolbar color, animations, close button icon, and any
+     * other [androidx.browser.customtabs.CustomTabsIntent.Builder] options.
+     *
+     * ```kotlin
+     * DefaultWebAuthenticationProvider(
+     *     customizeTabsIntent = { context, builder ->
+     *         builder.setToolbarColor(ContextCompat.getColor(context, R.color.brand_primary))
+     *     }
+     * )
+     * ```
+     */
+    private val customizeTabsIntent: ((context: Context, builder: CustomTabsIntent.Builder) -> Unit)? = null,
+    /**
+     * Optional callback to customize the [androidx.browser.auth.AuthTabIntent.Builder] before
+     * the Auth Tab is launched. Only invoked when the resolved browser supports Auth Tab; has no
+     * effect when falling back to Chrome Custom Tabs.
+     *
+     * ```kotlin
+     * DefaultWebAuthenticationProvider(
+     *     customizeAuthTabIntent = { _, builder ->
+     *         builder.setEphemeralBrowsingEnabled(true)
+     *     }
+     * )
+     * ```
+     */
+    private val customizeAuthTabIntent: ((context: Context, builder: AuthTabIntent.Builder) -> Unit)? = null,
+    /**
+     * [BrowserSelector] used to pick which browser package hosts the Chrome Custom Tab. Defaults
+     * to the built-in selector, which honors [preferredBrowsers] and [queryIntentServicesFlags].
+     * Override this to fully replace browser-selection logic, e.g. for testing.
+     */
+    private val browserSelector: BrowserSelector = defaultBrowserSelector(eventCoordinator, preferredBrowsers, queryIntentServicesFlags),
+) : WebAuthenticationProvider,
+    AuthTabWebAuthenticationProvider {
+    companion object {
+        /** HTTP header name used to send the Okta SDK user-agent string to the authorize endpoint. */
+        const val X_OKTA_USER_AGENT = "X-Okta-User-Agent-Extended"
 
-            /** The `X-Okta-User-Agent-Extended` header value sent with authorize requests. */
-            val USER_AGENT_HEADER = "web-authentication-ui/${Build.VERSION.SDK_INT} com.okta.webauthenticationui/${BuildConfig.VERSION}"
+        /** The `X-Okta-User-Agent-Extended` header value sent with authorize requests. */
+        val USER_AGENT_HEADER = "web-authentication-ui/${Build.VERSION.SDK_INT} com.okta.webauthenticationui/${BuildConfig.VERSION}"
 
-            private const val CHROME_STABLE = "com.android.chrome"
-            private const val CHROME_SYSTEM = "com.google.android.apps.chrome"
-            private const val CHROME_BETA = "com.android.chrome.beta"
+        private const val CHROME_STABLE = "com.android.chrome"
+        private const val CHROME_SYSTEM = "com.google.android.apps.chrome"
+        private const val CHROME_BETA = "com.android.chrome.beta"
 
-            /** The default preferred browser list: Chrome Stable, Chrome System, Chrome Beta. */
-            val DEFAULT_PREFERRED_BROWSERS: List<String> = listOf(CHROME_STABLE, CHROME_SYSTEM, CHROME_BETA)
-        }
+        /** The default preferred browser list: Chrome Stable, Chrome System, Chrome Beta. */
+        val DEFAULT_PREFERRED_BROWSERS: List<String> = listOf(CHROME_STABLE, CHROME_SYSTEM, CHROME_BETA)
 
-        override fun launch(
-            context: Context,
-            url: HttpUrl,
-        ): Exception? {
-            val intentBuilder: CustomTabsIntent.Builder = CustomTabsIntent.Builder()
-            customizeTabsIntent?.invoke(context, intentBuilder)
-            @Suppress("DEPRECATION")
-            eventCoordinator.sendEvent(CustomizeCustomTabsEvent(context, intentBuilder))
-            val tabsIntent: CustomTabsIntent = intentBuilder.build()
+        private val BROWSER_VALIDATION_URIS = listOf("http://".toUri(), "https://".toUri())
 
-            val packageBrowser = getBrowser(context)
-            if (packageBrowser != null) {
-                tabsIntent.intent.setPackage(packageBrowser)
+        private fun defaultBrowserSelector(
+            eventCoordinator: EventCoordinator,
+            preferredBrowsers: List<String>,
+            queryIntentServicesFlags: Int,
+        ): BrowserSelector =
+            BrowserSelector { context ->
+                // Initialize the event from the constructor params so existing EventCoordinator
+                // handlers that mutate CustomizeBrowserEvent continue to work as before.
+                // New callers should use the constructor params directly instead of handling the event.
+                @Suppress("DEPRECATION")
+                val event = CustomizeBrowserEvent(preferredBrowsers = preferredBrowsers.toMutableList())
+                @Suppress("DEPRECATION")
+                event.queryIntentServicesFlags = queryIntentServicesFlags
+                @Suppress("DEPRECATION")
+                eventCoordinator.sendEvent(event)
+
+                val pm: PackageManager = context.packageManager
+                val serviceIntent = Intent(CustomTabsService.ACTION_CUSTOM_TABS_CONNECTION)
+
+                @Suppress("DEPRECATION")
+                val resolveInfoList = pm.queryIntentServices(serviceIntent, event.queryIntentServicesFlags)
+                val customTabsBrowserPackages = resolveInfoList.mapNotNull { it.serviceInfo?.packageName }.toSet()
+
+                // Some non-browser apps (e.g. embedded webview shells) also implement the Custom Tabs
+                // service, so each candidate is confirmed to actually handle http(s) links before use.
+                @Suppress("DEPRECATION")
+                val preferredBrowser =
+                    event.preferredBrowsers.firstOrNull { packageName ->
+                        customTabsBrowserPackages.contains(packageName) && isBrowserPackage(pm, packageName)
+                    }
+                val selectedBrowser = preferredBrowser ?: customTabsBrowserPackages.firstOrNull { isBrowserPackage(pm, it) }
+
+                selectedBrowser?.let { Result.success(it) } ?: Result.failure(NoBrowserFoundException())
             }
 
-            val headers = Bundle()
-            headers.putString(X_OKTA_USER_AGENT, USER_AGENT_HEADER)
-            tabsIntent.intent.putExtra(Browser.EXTRA_HEADERS, headers)
-
-            try {
-                tabsIntent.launchUrl(context, url.toString().toUri())
-                return null
-            } catch (e: ActivityNotFoundException) {
-                return e
+        private fun isBrowserPackage(
+            pm: PackageManager,
+            packageName: String,
+        ): Boolean =
+            BROWSER_VALIDATION_URIS.any { uri ->
+                val intent =
+                    Intent(Intent.ACTION_VIEW, uri).apply {
+                        addCategory(Intent.CATEGORY_BROWSABLE)
+                        setPackage(packageName)
+                    }
+                pm.queryIntentActivities(intent, 0).isNotEmpty()
             }
-        }
+    }
 
-        override fun launchAuthTab(
-            context: Context,
-            url: HttpUrl,
-            redirectUrl: String,
-            launcher: ActivityResultLauncher<Intent>,
-        ): Exception? {
-            val packageBrowser = getBrowser(context)
-            if (packageBrowser == null || !CustomTabsClient.isAuthTabSupported(context, packageBrowser)) {
-                return launch(context, url)
-            }
+    @Deprecated("Use launchCustomTab(context, url) to receive a Result-based outcome.", replaceWith = ReplaceWith("launchCustomTab(context, url)"))
+    override fun launch(
+        context: Context,
+        url: HttpUrl,
+    ): Exception? = launchCustomTab(context, url).fold({ null }, { it as? Exception ?: Exception(it) })
 
-            val intentBuilder = AuthTabIntent.Builder()
-            customizeAuthTabIntent?.invoke(context, intentBuilder)
-            val authTabIntent = intentBuilder.build()
-            authTabIntent.intent.setPackage(packageBrowser)
+    override fun launchCustomTab(
+        context: Context,
+        url: HttpUrl,
+    ): Result<Unit> {
+        val intentBuilder: CustomTabsIntent.Builder = CustomTabsIntent.Builder()
+        customizeTabsIntent?.invoke(context, intentBuilder)
+        @Suppress("DEPRECATION")
+        eventCoordinator.sendEvent(CustomizeCustomTabsEvent(context, intentBuilder))
+        val tabsIntent: CustomTabsIntent = intentBuilder.build()
 
-            val headers = Bundle()
-            headers.putString(X_OKTA_USER_AGENT, USER_AGENT_HEADER)
-            authTabIntent.intent.putExtra(Browser.EXTRA_HEADERS, headers)
+        val browserResult = browserSelector.selectBrowser(context)
+        browserResult.getOrNull()?.let { tabsIntent.intent.setPackage(it) }
 
-            val redirectUri = redirectUrl.toUri()
-            val authorizeUri = url.toString().toUri()
+        val headers = Bundle()
+        headers.putString(X_OKTA_USER_AGENT, USER_AGENT_HEADER)
+        tabsIntent.intent.putExtra(Browser.EXTRA_HEADERS, headers)
 
-            return try {
-                if (redirectUri.scheme == "https" || redirectUri.scheme == "http") {
-                    authTabIntent.launch(launcher, authorizeUri, redirectUri.host.orEmpty(), redirectUri.path.orEmpty())
-                } else {
-                    authTabIntent.launch(launcher, authorizeUri, redirectUri.scheme.orEmpty())
-                }
-                null
-            } catch (e: ActivityNotFoundException) {
-                e
-            }
-        }
-
-        private fun getBrowser(context: Context): String? {
-            // Initialize the event from the constructor params so existing EventCoordinator
-            // handlers that mutate CustomizeBrowserEvent continue to work as before.
-            // New callers should use the constructor params directly instead of handling the event.
-            @Suppress("DEPRECATION")
-            val event = CustomizeBrowserEvent(preferredBrowsers = preferredBrowsers.toMutableList())
-            @Suppress("DEPRECATION")
-            event.queryIntentServicesFlags = queryIntentServicesFlags
-            @Suppress("DEPRECATION")
-            eventCoordinator.sendEvent(event)
-
-            val pm: PackageManager = context.packageManager
-            val serviceIntent = Intent()
-            serviceIntent.action = CustomTabsService.ACTION_CUSTOM_TABS_CONNECTION
-            @Suppress("DEPRECATION")
-            val resolveInfoList = pm.queryIntentServices(serviceIntent, event.queryIntentServicesFlags)
-            val customTabsBrowsersPackages = mutableSetOf<String>()
-            for (info in resolveInfoList) {
-                customTabsBrowsersPackages.add(info.serviceInfo.packageName)
-            }
-
-            @Suppress("DEPRECATION")
-            for (browser in event.preferredBrowsers) {
-                if (customTabsBrowsersPackages.contains(browser)) {
-                    return browser
-                }
-            }
-
-            return customTabsBrowsersPackages.firstOrNull()
+        try {
+            tabsIntent.launchUrl(context, url.toString().toUri())
+            return Result.success(Unit)
+        } catch (e: ActivityNotFoundException) {
+            // If browser selection already failed (e.g. NoBrowserFoundException), that's a more
+            // specific and actionable cause than the generic ActivityNotFoundException from the
+            // unrestricted launch attempt above, so it's surfaced instead.
+            return Result.failure(browserResult.exceptionOrNull() as? Exception ?: e)
         }
     }
+
+    override fun launchAuthTab(
+        context: Context,
+        url: HttpUrl,
+        redirectUrl: String,
+        launcher: ActivityResultLauncher<Intent>,
+    ): Result<Unit> {
+        val packageBrowser = browserSelector.selectBrowser(context).getOrNull()
+        if (packageBrowser == null || !CustomTabsClient.isAuthTabSupported(context, packageBrowser)) {
+            return launchCustomTab(context, url)
+        }
+
+        val intentBuilder = AuthTabIntent.Builder()
+        customizeAuthTabIntent?.invoke(context, intentBuilder)
+        val authTabIntent = intentBuilder.build()
+        authTabIntent.intent.setPackage(packageBrowser)
+
+        val headers = Bundle()
+        headers.putString(X_OKTA_USER_AGENT, USER_AGENT_HEADER)
+        authTabIntent.intent.putExtra(Browser.EXTRA_HEADERS, headers)
+
+        val redirectUri = redirectUrl.toUri()
+        val authorizeUri = url.toString().toUri()
+
+        return try {
+            if (redirectUri.scheme == "https" || redirectUri.scheme == "http") {
+                authTabIntent.launch(launcher, authorizeUri, redirectUri.host.orEmpty(), redirectUri.path.orEmpty())
+            } else {
+                authTabIntent.launch(launcher, authorizeUri, redirectUri.scheme.orEmpty())
+            }
+            Result.success(Unit)
+        } catch (e: ActivityNotFoundException) {
+            Result.failure(e)
+        }
+    }
+}

--- a/web-authentication-ui/src/main/java/com/okta/webauthenticationui/RedirectCoordinator.kt
+++ b/web-authentication-ui/src/main/java/com/okta/webauthenticationui/RedirectCoordinator.kt
@@ -43,25 +43,33 @@ internal object SingletonRedirectCoordinator : RedirectCoordinator by DefaultRed
 internal class DefaultRedirectCoordinator(
     private val coroutineScope: CoroutineScope,
 ) : RedirectCoordinator {
-    @Volatile private var initializationContinuation: Continuation<RedirectInitializationResult<*>>? = null
+    @Volatile
+    private var initializationContinuation: Continuation<RedirectInitializationResult<*>>? = null
 
-    @VisibleForTesting var initializerContinuationListeningCallback: (() -> Unit)? = null
+    @VisibleForTesting
+    var initializerContinuationListeningCallback: (() -> Unit)? = null
 
-    @Volatile private var initializer: (suspend () -> RedirectInitializationResult<*>)? = null
+    @Volatile
+    private var initializer: (suspend () -> RedirectInitializationResult<*>)? = null
 
-    @Volatile private var redirectContinuation: Continuation<RedirectResult>? = null
+    @Volatile
+    private var redirectContinuation: Continuation<RedirectResult>? = null
 
-    @VisibleForTesting var redirectContinuationListeningCallback: (() -> Unit)? = null
+    @VisibleForTesting
+    var redirectContinuationListeningCallback: (() -> Unit)? = null
 
-    @Volatile private var webAuthenticationProvider: WebAuthenticationProvider? = null
+    @Volatile
+    private var webAuthenticationProvider: WebAuthenticationProvider? = null
 
-    @Volatile private var redirectUrl: String? = null
+    @Volatile
+    private var redirectUrl: String? = null
 
     private var emitErrorJob: Job? = null
 
     private val flowMutex = Mutex()
 
-    @Volatile private var isFlowActive = false
+    @Volatile
+    private var isFlowActive = false
 
     @Suppress("UNCHECKED_CAST")
     override suspend fun <T> initialize(
@@ -131,17 +139,16 @@ internal class DefaultRedirectCoordinator(
         redirectUrl = null
 
         if (localWebAuthenticationProvider != null && localRedirectUrl != null) {
-            val exception =
+            val result =
                 if (localWebAuthenticationProvider is AuthTabWebAuthenticationProvider) {
                     localWebAuthenticationProvider.launchAuthTab(context, url, localRedirectUrl, authTabLauncher)
                 } else {
-                    localWebAuthenticationProvider.launch(context, url)
+                    localWebAuthenticationProvider.launchCustomTab(context, url)
                 }
-            if (exception == null) {
-                return true
-            } else {
-                emitError(exception)
-            }
+            result
+                .onSuccess {
+                    return true
+                }.onFailure { emitError(it as? Exception ?: Exception(it)) }
         } else {
             emitError(IllegalStateException("RedirectListener has not been initialized."))
         }

--- a/web-authentication-ui/src/main/java/com/okta/webauthenticationui/WebAuthenticationProvider.kt
+++ b/web-authentication-ui/src/main/java/com/okta/webauthenticationui/WebAuthenticationProvider.kt
@@ -23,7 +23,8 @@ import okhttp3.HttpUrl
  * Used to launch the OIDC redirect flow associated with a [WebAuthentication].
  *
  * Most integrators should use [DefaultWebAuthenticationProvider]; implement this only to fully
- * control how the authorize URL is presented.
+ * control how the authorize URL is presented. Only [launch] is abstract; [launchCustomTab] has a
+ * default implementation built on it, so implementations only need to provide [launch].
  */
 interface WebAuthenticationProvider {
     /**
@@ -34,8 +35,32 @@ interface WebAuthenticationProvider {
      *
      * @return `null` if the flow launched successfully, or the [Exception] that caused the launch to fail.
      */
+    @Deprecated(
+        message = "Use launchCustomTab(context, url) to receive a Result-based outcome.",
+        replaceWith = ReplaceWith("launchCustomTab(context, url)")
+    )
     fun launch(
         context: Context,
         url: HttpUrl,
     ): Exception?
+
+    /**
+     * Launches the OIDC redirect flow associated with a [WebAuthentication] and wraps launch
+     * success/failure in a [Result].
+     *
+     * Has a default implementation that delegates to the deprecated [launch], so existing
+     * [WebAuthenticationProvider] implementations keep compiling unchanged; override this instead
+     * of [launch] in new implementations.
+     *
+     * @param context the Android [Activity] [Context] used to display the flow.
+     * @param url the authorize URL the instance should display.
+     *
+     * @return [Result.success] when the flow launches successfully, or [Result.failure] with the
+     * launch exception when it fails.
+     */
+    @Suppress("DEPRECATION")
+    fun launchCustomTab(
+        context: Context,
+        url: HttpUrl,
+    ): Result<Unit> = launch(context, url)?.let { Result.failure(it) } ?: Result.success(Unit)
 }

--- a/web-authentication-ui/src/test/java/com/okta/webauthenticationui/DefaultWebAuthenticationProviderTest.kt
+++ b/web-authentication-ui/src/test/java/com/okta/webauthenticationui/DefaultWebAuthenticationProviderTest.kt
@@ -53,10 +53,11 @@ import org.robolectric.shadows.ShadowResolveInfo
 
 @RunWith(RobolectricTestRunner::class)
 class DefaultWebAuthenticationProviderTest {
-    @Test fun testLaunch() {
+    @Test
+    fun testLaunch() {
         val activity = Robolectric.buildActivity(Activity::class.java)
         val webAuthenticationProvider = DefaultWebAuthenticationProvider(EventCoordinator(emptyList()))
-        assertThat(webAuthenticationProvider.launch(activity.get(), "https://example.com/not_used".toHttpUrl())).isNull()
+        assertThat(webAuthenticationProvider.launchCustomTab(activity.get(), "https://example.com/not_used".toHttpUrl()).isSuccess).isTrue()
         val activityShadow = shadowOf(activity.get())
         val cctActivity = activityShadow.nextStartedActivity
         assertThat(cctActivity.action).isEqualTo("android.intent.action.VIEW")
@@ -65,11 +66,12 @@ class DefaultWebAuthenticationProviderTest {
         assertThat(cctActivity.`package`).isNull()
     }
 
-    @Test fun testLaunchCallsEventHandler() {
+    @Test
+    fun testLaunchCallsEventHandler() {
         val activity = Robolectric.buildActivity(Activity::class.java)
         val eventHandler = RecordingEventHandler()
         val webAuthenticationProvider = DefaultWebAuthenticationProvider(EventCoordinator(eventHandler))
-        assertThat(webAuthenticationProvider.launch(activity.get(), "https://example.com/not_used".toHttpUrl())).isNull()
+        assertThat(webAuthenticationProvider.launchCustomTab(activity.get(), "https://example.com/not_used".toHttpUrl()).isSuccess).isTrue()
 
         assertThat(eventHandler.size).isEqualTo(2)
 
@@ -86,7 +88,8 @@ class DefaultWebAuthenticationProviderTest {
         assertThat((eventHandler[1] as CustomizeBrowserEvent).preferredBrowsers).hasSize(3)
     }
 
-    @Test fun testLaunchWithEnabledBrowsers() {
+    @Test
+    fun testLaunchWithEnabledBrowsers() {
         installCustomTabsProvider("com.android.chrome.beta")
         installCustomTabsProvider("com.android.chrome")
         ShadowResolveInfo.newResolveInfo(
@@ -96,14 +99,15 @@ class DefaultWebAuthenticationProviderTest {
         )
         val activity = Robolectric.buildActivity(Activity::class.java)
         val webAuthenticationProvider = DefaultWebAuthenticationProvider(EventCoordinator(emptyList()))
-        assertThat(webAuthenticationProvider.launch(activity.get(), "https://example.com/not_used".toHttpUrl())).isNull()
+        assertThat(webAuthenticationProvider.launchCustomTab(activity.get(), "https://example.com/not_used".toHttpUrl()).isSuccess).isTrue()
         val activityShadow = shadowOf(activity.get())
         val cctActivity = activityShadow.nextStartedActivity
         assertThat(cctActivity.action).isEqualTo("android.intent.action.VIEW")
         assertThat(cctActivity.`package`).isEqualTo("com.android.chrome")
     }
 
-    @Test fun testCustomizeTabsIntentCallback_InvokedBeforeEventHandler() {
+    @Test
+    fun testCustomizeTabsIntentCallback_InvokedBeforeEventHandler() {
         val callOrder = mutableListOf<String>()
         val webAuthenticationProvider =
             DefaultWebAuthenticationProvider(
@@ -121,22 +125,24 @@ class DefaultWebAuthenticationProviderTest {
                 customizeTabsIntent = { _, _ -> callOrder.add("callback") }
             )
         val activity = Robolectric.buildActivity(Activity::class.java)
-        webAuthenticationProvider.launch(activity.get(), "https://example.com/not_used".toHttpUrl())
+        webAuthenticationProvider.launchCustomTab(activity.get(), "https://example.com/not_used".toHttpUrl())
         assertThat(callOrder).containsExactly("callback", "eventHandler").inOrder()
     }
 
-    @Test fun testCustomizeTabsIntentCallback_BuilderMutationApplied() {
+    @Test
+    fun testCustomizeTabsIntentCallback_BuilderMutationApplied() {
         var capturedBuilder: androidx.browser.customtabs.CustomTabsIntent.Builder? = null
         val webAuthenticationProvider =
             DefaultWebAuthenticationProvider(
                 customizeTabsIntent = { _, builder -> capturedBuilder = builder }
             )
         val activity = Robolectric.buildActivity(Activity::class.java)
-        webAuthenticationProvider.launch(activity.get(), "https://example.com/not_used".toHttpUrl())
+        webAuthenticationProvider.launchCustomTab(activity.get(), "https://example.com/not_used".toHttpUrl())
         assertThat(capturedBuilder).isNotNull()
     }
 
-    @Test fun testLaunchWithPreferredBrowsersConstructorParam() {
+    @Test
+    fun testLaunchWithPreferredBrowsersConstructorParam() {
         installCustomTabsProvider("com.android.chrome.beta")
         installCustomTabsProvider("my.custom.preferred.browser")
         installCustomTabsProvider("com.android.chrome")
@@ -145,18 +151,101 @@ class DefaultWebAuthenticationProviderTest {
                 preferredBrowsers = listOf("my.custom.preferred.browser")
             )
         val activity = Robolectric.buildActivity(Activity::class.java)
-        assertThat(webAuthenticationProvider.launch(activity.get(), "https://example.com/not_used".toHttpUrl())).isNull()
+        assertThat(webAuthenticationProvider.launchCustomTab(activity.get(), "https://example.com/not_used".toHttpUrl()).isSuccess).isTrue()
         val activityShadow = shadowOf(activity.get())
         val cctActivity = activityShadow.nextStartedActivity
         assertThat(cctActivity.action).isEqualTo("android.intent.action.VIEW")
         assertThat(cctActivity.`package`).isEqualTo("my.custom.preferred.browser")
     }
 
-    @Test fun testDefaultPreferredBrowsers_IsThreeChromeBrowsers() {
+    @Test
+    fun testDefaultPreferredBrowsers_IsThreeChromeBrowsers() {
         assertThat(DefaultWebAuthenticationProvider.DEFAULT_PREFERRED_BROWSERS).hasSize(3)
     }
 
-    @Test fun testLaunchCausesActivityNotFound() {
+    @Test
+    fun testLaunchWithNoBrowserAvailable_surfacesNoBrowserFoundException() {
+        // No browser or Custom Tabs provider installed, so both browser selection and the
+        // unrestricted fallback launch fail — the more specific NoBrowserFoundException from
+        // selection should be surfaced rather than the generic ActivityNotFoundException.
+        shadowOf(RuntimeEnvironment.getApplication()).checkActivities(true)
+        val activity = Robolectric.buildActivity(Activity::class.java)
+        val webAuthenticationProvider = DefaultWebAuthenticationProvider(EventCoordinator(emptyList()))
+        val result = webAuthenticationProvider.launchCustomTab(activity.get(), "https://example.com/not_used".toHttpUrl())
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()).isInstanceOf(NoBrowserFoundException::class.java)
+    }
+
+    @Test
+    fun testLaunchSkipsCustomTabsProviderThatIsNotABrowser() {
+        installCustomTabsProvider("my.custom.notABrowser", isBrowser = false)
+        installCustomTabsProvider("my.custom.realBrowser")
+        val activity = Robolectric.buildActivity(Activity::class.java)
+        val webAuthenticationProvider = DefaultWebAuthenticationProvider(EventCoordinator(emptyList()))
+        assertThat(webAuthenticationProvider.launchCustomTab(activity.get(), "https://example.com/not_used".toHttpUrl()).isSuccess).isTrue()
+        val activityShadow = shadowOf(activity.get())
+        val cctActivity = activityShadow.nextStartedActivity
+        assertThat(cctActivity.`package`).isEqualTo("my.custom.realBrowser")
+    }
+
+    @Test
+    fun testLaunchSkipsPreferredBrowserThatIsNotABrowser_fallsBackToNextPreferredBrowser() {
+        installCustomTabsProvider("my.custom.preferred.notABrowser", isBrowser = false)
+        installCustomTabsProvider("my.custom.preferred.realBrowser")
+        val webAuthenticationProvider =
+            DefaultWebAuthenticationProvider(
+                preferredBrowsers = listOf("my.custom.preferred.notABrowser", "my.custom.preferred.realBrowser")
+            )
+        val activity = Robolectric.buildActivity(Activity::class.java)
+        assertThat(webAuthenticationProvider.launchCustomTab(activity.get(), "https://example.com/not_used".toHttpUrl()).isSuccess).isTrue()
+        val activityShadow = shadowOf(activity.get())
+        val cctActivity = activityShadow.nextStartedActivity
+        assertThat(cctActivity.`package`).isEqualTo("my.custom.preferred.realBrowser")
+    }
+
+    @Test
+    fun testLaunchWithNoRealBrowsers_launchesWithoutPackageRestriction() {
+        installCustomTabsProvider("my.custom.notABrowser", isBrowser = false)
+        val activity = Robolectric.buildActivity(Activity::class.java)
+        val webAuthenticationProvider = DefaultWebAuthenticationProvider(EventCoordinator(emptyList()))
+        assertThat(webAuthenticationProvider.launchCustomTab(activity.get(), "https://example.com/not_used".toHttpUrl()).isSuccess).isTrue()
+        val activityShadow = shadowOf(activity.get())
+        val cctActivity = activityShadow.nextStartedActivity
+        assertThat(cctActivity.`package`).isNull()
+    }
+
+    @Test
+    fun testLaunchWithBrowserFoundButActivityNotFound_surfacesActivityNotFoundException() {
+        // Browser selection succeeds, but the launch itself still fails (e.g. the browser was
+        // uninstalled between selection and launch) — the raw ActivityNotFoundException should
+        // surface since browser selection itself did not fail.
+        installCustomTabsProvider("com.android.chrome")
+        shadowOf(RuntimeEnvironment.getApplication()).checkActivities(true)
+        val activity = Robolectric.buildActivity(Activity::class.java)
+        val webAuthenticationProvider = DefaultWebAuthenticationProvider(EventCoordinator(emptyList()))
+        val result = webAuthenticationProvider.launchCustomTab(activity.get(), "https://example.com/not_used".toHttpUrl())
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()).isInstanceOf(ActivityNotFoundException::class.java)
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun testDeprecatedLaunch_returnsNullOnSuccess() {
+        val activity = Robolectric.buildActivity(Activity::class.java)
+        val webAuthenticationProvider = DefaultWebAuthenticationProvider(EventCoordinator(emptyList()))
+        assertThat(webAuthenticationProvider.launch(activity.get(), "https://example.com/not_used".toHttpUrl())).isNull()
+        val activityShadow = shadowOf(activity.get())
+        val cctActivity = activityShadow.nextStartedActivity
+        assertThat(cctActivity.action).isEqualTo("android.intent.action.VIEW")
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun testDeprecatedLaunch_returnsExceptionOnFailure() {
+        // Mirrors testLaunchWithBrowserFoundButActivityNotFound_surfacesActivityNotFoundException,
+        // but through the deprecated launch() entry point, which folds launchCustomTab()'s Result
+        // back into a nullable Exception.
+        installCustomTabsProvider("com.android.chrome")
         shadowOf(RuntimeEnvironment.getApplication()).checkActivities(true)
         val activity = Robolectric.buildActivity(Activity::class.java)
         val webAuthenticationProvider = DefaultWebAuthenticationProvider(EventCoordinator(emptyList()))
@@ -164,19 +253,20 @@ class DefaultWebAuthenticationProviderTest {
         assertThat(exception).isInstanceOf(ActivityNotFoundException::class.java)
     }
 
-    @Test fun testLaunchAuthTabWhenSupported() {
+    @Test
+    fun testLaunchAuthTabWhenSupported() {
         installAuthTabProvider("com.android.chrome")
         val activity = Robolectric.buildActivity(Activity::class.java)
         val webAuthenticationProvider = DefaultWebAuthenticationProvider(EventCoordinator(emptyList()))
         val launcher = mock<ActivityResultLauncher<Intent>>()
-        val exception =
+        val result =
             webAuthenticationProvider.launchAuthTab(
                 activity.get(),
                 "https://example.com/authorize".toHttpUrl(),
                 "unitTest:/callback",
                 launcher
             )
-        assertThat(exception).isNull()
+        assertThat(result.isSuccess).isTrue()
 
         val captor = argumentCaptor<Intent>()
         verify(launcher).launch(captor.capture())
@@ -188,7 +278,8 @@ class DefaultWebAuthenticationProviderTest {
         assertThat(headers!!.getString(DefaultWebAuthenticationProvider.X_OKTA_USER_AGENT)).isEqualTo(DefaultWebAuthenticationProvider.USER_AGENT_HEADER)
     }
 
-    @Test fun testLaunchAuthTabWithHttpsRedirect() {
+    @Test
+    fun testLaunchAuthTabWithHttpsRedirect() {
         installAuthTabProvider("com.android.chrome")
         val activity = Robolectric.buildActivity(Activity::class.java)
         val webAuthenticationProvider = DefaultWebAuthenticationProvider(EventCoordinator(emptyList()))
@@ -207,19 +298,20 @@ class DefaultWebAuthenticationProviderTest {
         assertThat(intent.getStringExtra(AuthTabIntent.EXTRA_HTTPS_REDIRECT_PATH)).isEqualTo("/callback")
     }
 
-    @Test fun testLaunchAuthTabFallsBackToCustomTabsWhenUnsupported() {
+    @Test
+    fun testLaunchAuthTabFallsBackToCustomTabsWhenUnsupported() {
         installCustomTabsProvider("com.android.chrome")
         val activity = Robolectric.buildActivity(Activity::class.java)
         val webAuthenticationProvider = DefaultWebAuthenticationProvider(EventCoordinator(emptyList()))
         val launcher = mock<ActivityResultLauncher<Intent>>()
-        val exception =
+        val result =
             webAuthenticationProvider.launchAuthTab(
                 activity.get(),
                 "https://example.com/authorize".toHttpUrl(),
                 "unitTest:/callback",
                 launcher
             )
-        assertThat(exception).isNull()
+        assertThat(result.isSuccess).isTrue()
         verifyNoInteractions(launcher)
 
         val activityShadow = shadowOf(activity.get())
@@ -228,24 +320,53 @@ class DefaultWebAuthenticationProviderTest {
         assertThat(cctActivity.`package`).isEqualTo("com.android.chrome")
     }
 
-    @Test fun testLaunchAuthTabCausesActivityNotFound() {
-        installAuthTabProvider("com.android.chrome")
+    @Test
+    fun testLaunchAuthTabSkipsProviderThatIsNotABrowser_fallsBackToCustomTabsWithoutPackageRestriction() {
+        // launchAuthTab() resolves the browser via the same browserSelector as launchCustomTab(),
+        // so an AuthTab-capable package that fails the isBrowserPackage check must be rejected here
+        // too, not just for plain Custom Tabs.
+        installAuthTabProvider("my.custom.notABrowser", isBrowser = false)
         val activity = Robolectric.buildActivity(Activity::class.java)
         val webAuthenticationProvider = DefaultWebAuthenticationProvider(EventCoordinator(emptyList()))
         val launcher = mock<ActivityResultLauncher<Intent>>()
-        doThrow(ActivityNotFoundException("From Test!")).whenever(launcher).launch(any())
-        val exception =
+        val result =
             webAuthenticationProvider.launchAuthTab(
                 activity.get(),
                 "https://example.com/authorize".toHttpUrl(),
                 "unitTest:/callback",
                 launcher
             )
-        assertThat(exception).isInstanceOf(ActivityNotFoundException::class.java)
-        assertThat(exception).hasMessageThat().isEqualTo("From Test!")
+        assertThat(result.isSuccess).isTrue()
+        verifyNoInteractions(launcher)
+
+        val activityShadow = shadowOf(activity.get())
+        val cctActivity = activityShadow.nextStartedActivity
+        assertThat(cctActivity.action).isEqualTo("android.intent.action.VIEW")
+        assertThat(cctActivity.`package`).isNull()
     }
 
-    @Test fun testCustomizeAuthTabIntentCallback_BuilderMutationApplied() {
+    @Test
+    fun testLaunchAuthTabCausesActivityNotFound() {
+        installAuthTabProvider("com.android.chrome")
+        val activity = Robolectric.buildActivity(Activity::class.java)
+        val webAuthenticationProvider = DefaultWebAuthenticationProvider(EventCoordinator(emptyList()))
+        val launcher = mock<ActivityResultLauncher<Intent>>()
+        doThrow(ActivityNotFoundException("From Test!")).whenever(launcher).launch(any())
+        val result =
+            webAuthenticationProvider.launchAuthTab(
+                activity.get(),
+                "https://example.com/authorize".toHttpUrl(),
+                "unitTest:/callback",
+                launcher
+            )
+        assertThat(result.isFailure).isTrue()
+        val exception = result.exceptionOrNull()
+        assertThat(exception).isInstanceOf(ActivityNotFoundException::class.java)
+        assertThat(exception?.message).isEqualTo("From Test!")
+    }
+
+    @Test
+    fun testCustomizeAuthTabIntentCallback_BuilderMutationApplied() {
         installAuthTabProvider("com.android.chrome")
         var capturedBuilder: AuthTabIntent.Builder? = null
         val webAuthenticationProvider =
@@ -262,8 +383,41 @@ class DefaultWebAuthenticationProviderTest {
         assertThat(capturedBuilder).isNotNull()
     }
 
-    private fun installAuthTabProvider(packageName: String) {
-        installBrowser(packageName)
+    @Test
+    fun testBrowserSelectorOverride_isUsedInsteadOfDefaultSelection() {
+        installCustomTabsProvider("com.android.chrome")
+        val webAuthenticationProvider =
+            DefaultWebAuthenticationProvider(
+                browserSelector = BrowserSelector { Result.success("my.custom.overridden.browser") }
+            )
+        val activity = Robolectric.buildActivity(Activity::class.java)
+        assertThat(webAuthenticationProvider.launchCustomTab(activity.get(), "https://example.com/not_used".toHttpUrl()).isSuccess).isTrue()
+        val activityShadow = shadowOf(activity.get())
+        val cctActivity = activityShadow.nextStartedActivity
+        assertThat(cctActivity.`package`).isEqualTo("my.custom.overridden.browser")
+    }
+
+    @Test
+    fun testBrowserSelectorOverride_failureLaunchesWithoutPackageRestriction() {
+        installCustomTabsProvider("com.android.chrome")
+        val webAuthenticationProvider =
+            DefaultWebAuthenticationProvider(
+                browserSelector = BrowserSelector { Result.failure(NoBrowserFoundException()) }
+            )
+        val activity = Robolectric.buildActivity(Activity::class.java)
+        assertThat(webAuthenticationProvider.launchCustomTab(activity.get(), "https://example.com/not_used".toHttpUrl()).isSuccess).isTrue()
+        val activityShadow = shadowOf(activity.get())
+        val cctActivity = activityShadow.nextStartedActivity
+        assertThat(cctActivity.`package`).isNull()
+    }
+
+    private fun installAuthTabProvider(
+        packageName: String,
+        isBrowser: Boolean = true,
+    ) {
+        if (isBrowser) {
+            installBrowser(packageName)
+        }
         val intent = Intent().setAction(CustomTabsService.ACTION_CUSTOM_TABS_CONNECTION)
         val resolveInfo = ResolveInfo()
         resolveInfo.serviceInfo = ServiceInfo()
@@ -282,6 +436,7 @@ class DefaultWebAuthenticationProviderTest {
                 .setData(Uri.parse("http://"))
                 .setAction(Intent.ACTION_VIEW)
                 .addCategory(Intent.CATEGORY_BROWSABLE)
+                .setPackage(packageName)
         val resolveInfo = ResolveInfo()
         resolveInfo.activityInfo = ActivityInfo()
         resolveInfo.activityInfo.packageName = packageName
@@ -290,8 +445,13 @@ class DefaultWebAuthenticationProviderTest {
         packageManager.addResolveInfoForIntent(intent, resolveInfo)
     }
 
-    private fun installCustomTabsProvider(packageName: String) {
-        installBrowser(packageName)
+    private fun installCustomTabsProvider(
+        packageName: String,
+        isBrowser: Boolean = true,
+    ) {
+        if (isBrowser) {
+            installBrowser(packageName)
+        }
         val intent = Intent().setAction(CustomTabsService.ACTION_CUSTOM_TABS_CONNECTION)
         val resolveInfo = ResolveInfo()
         resolveInfo.serviceInfo = ServiceInfo()

--- a/web-authentication-ui/src/test/java/com/okta/webauthenticationui/RedirectCoordinatorTest.kt
+++ b/web-authentication-ui/src/test/java/com/okta/webauthenticationui/RedirectCoordinatorTest.kt
@@ -240,7 +240,7 @@ class RedirectCoordinatorTest {
         testScope.runTest {
             val webAuthenticationProvider =
                 mock<WebAuthenticationProvider> {
-                    on { launch(any(), any()) } doReturn null
+                    on { launchCustomTab(any(), any()) } doReturn Result.success(Unit)
                 }
             val activityController = Robolectric.buildActivity(ComponentActivity::class.java)
             activityController.create().start().resume()
@@ -258,7 +258,7 @@ class RedirectCoordinatorTest {
             assertThat(initializerCountDownLatch.await(1, TimeUnit.SECONDS)).isTrue()
             subject.runInitializationFunction()
             assertThat(subject.launchWebAuthenticationProvider(launchedFromActivity, url, mock())).isTrue()
-            verify(webAuthenticationProvider).launch(launchedFromActivity, url)
+            verify(webAuthenticationProvider).launchCustomTab(launchedFromActivity, url)
             val foregroundActivity = shadowOf(launchedFromActivity).nextStartedActivity
             assertThat(foregroundActivity.component?.className).isEqualTo(ForegroundActivity::class.java.name)
         }
@@ -278,7 +278,7 @@ class RedirectCoordinatorTest {
                 subject.initialize(webAuthenticationProvider, launchedFromActivity, "https://example.com/redirect") {
                     RedirectInitializationResult.Success("https://example.com/oauth".toHttpUrl(), Any())
                 }
-            verify(webAuthenticationProvider, never()).launch(anyOrNull(), anyOrNull())
+            verify(webAuthenticationProvider, never()).launchCustomTab(anyOrNull(), anyOrNull())
             assertThat(result).isInstanceOf(RedirectInitializationResult.Error::class.java)
             val errorResult = result as RedirectInitializationResult.Error
             assertThat(errorResult.exception).hasMessageThat().isEqualTo("Activity is not resumed.")
@@ -288,7 +288,7 @@ class RedirectCoordinatorTest {
         testScope.runTest {
             val webAuthenticationProvider =
                 mock<WebAuthenticationProvider> {
-                    on { launch(any(), any()) } doReturn null
+                    on { launchCustomTab(any(), any()) } doReturn Result.success(Unit)
                 }
             val initializerCountDownLatch = CountDownLatch(1)
             subject.initializerContinuationListeningCallback = {
@@ -302,7 +302,7 @@ class RedirectCoordinatorTest {
             assertThat(initializerCountDownLatch.await(1, TimeUnit.SECONDS)).isTrue()
             subject.runInitializationFunction()
             assertThat(subject.launchWebAuthenticationProvider(mock(), mock(), mock())).isTrue()
-            verify(webAuthenticationProvider).launch(any(), any())
+            verify(webAuthenticationProvider).launchCustomTab(any(), any())
         }
 
     @Test fun testLaunchWebAuthenticationProviderPrefersAuthTab(): Unit =
@@ -310,7 +310,7 @@ class RedirectCoordinatorTest {
             val webAuthenticationProvider =
                 mock<WebAuthenticationProvider>(extraInterfaces = arrayOf(AuthTabWebAuthenticationProvider::class))
             val authTabProvider = webAuthenticationProvider as AuthTabWebAuthenticationProvider
-            whenever(authTabProvider.launchAuthTab(any(), any(), any(), any())).thenReturn(null)
+            whenever(authTabProvider.launchAuthTab(any(), any(), any(), any())).thenReturn(Result.success(Unit))
             val context = mock<Context>()
             val url = "https://example.com/oauth".toHttpUrl()
             val launcher = mock<ActivityResultLauncher<Intent>>()
@@ -327,7 +327,7 @@ class RedirectCoordinatorTest {
             subject.runInitializationFunction()
             assertThat(subject.launchWebAuthenticationProvider(context, url, launcher)).isTrue()
             verify(authTabProvider).launchAuthTab(context, url, "https://example.com/redirect", launcher)
-            verify(webAuthenticationProvider, never()).launch(any(), any())
+            verify(webAuthenticationProvider, never()).launchCustomTab(any(), any())
         }
 
     @Test fun testLaunchWebAuthenticationProviderActivityNotFound(): Unit =
@@ -335,7 +335,7 @@ class RedirectCoordinatorTest {
             val resultDeferred = listenRedirectAsync()
             val webAuthenticationProvider =
                 mock<WebAuthenticationProvider> {
-                    on { launch(any(), any()) } doReturn ActivityNotFoundException("From Test!")
+                    on { launchCustomTab(any(), any()) } doReturn Result.failure(ActivityNotFoundException("From Test!"))
                 }
             val initializerCountDownLatch = CountDownLatch(1)
             subject.initializerContinuationListeningCallback = {
@@ -349,7 +349,7 @@ class RedirectCoordinatorTest {
             assertThat(initializerCountDownLatch.await(1, TimeUnit.SECONDS)).isTrue()
             subject.runInitializationFunction()
             assertThat(subject.launchWebAuthenticationProvider(mock(), mock(), mock())).isFalse()
-            verify(webAuthenticationProvider).launch(any(), any())
+            verify(webAuthenticationProvider).launchCustomTab(any(), any())
             val result = resultDeferred.await()
             assertThat(result).isInstanceOf(RedirectResult.Error::class.java)
             val error = result as RedirectResult.Error
@@ -357,11 +357,71 @@ class RedirectCoordinatorTest {
             assertThat(error.exception).hasMessageThat().isEqualTo("From Test!")
         }
 
+    @Test fun testLaunchWebAuthenticationProviderNoBrowserFound(): Unit =
+        testScope.runTest {
+            // RedirectCoordinator treats WebAuthenticationProvider.launchCustomTab() failures
+            // opaquely — it requires no changes to surface NoBrowserFoundException (or any other
+            // exception type) distinctly through RedirectResult.Error/OAuth2ClientResult.Error.
+            val resultDeferred = listenRedirectAsync()
+            val webAuthenticationProvider =
+                mock<WebAuthenticationProvider> {
+                    on { launchCustomTab(any(), any()) } doReturn Result.failure(NoBrowserFoundException())
+                }
+            val initializerCountDownLatch = CountDownLatch(1)
+            subject.initializerContinuationListeningCallback = {
+                initializerCountDownLatch.countDown()
+            }
+            launch(Dispatchers.IO) {
+                subject.initialize(webAuthenticationProvider, mock(), "https://example.com/redirect") {
+                    RedirectInitializationResult.Success(mock(), Any())
+                }
+            }
+            assertThat(initializerCountDownLatch.await(1, TimeUnit.SECONDS)).isTrue()
+            subject.runInitializationFunction()
+            assertThat(subject.launchWebAuthenticationProvider(mock(), mock(), mock())).isFalse()
+            verify(webAuthenticationProvider).launchCustomTab(any(), any())
+            val result = resultDeferred.await()
+            assertThat(result).isInstanceOf(RedirectResult.Error::class.java)
+            val error = result as RedirectResult.Error
+            assertThat(error.exception).isInstanceOf(NoBrowserFoundException::class.java)
+        }
+
+    @Test fun testLaunchWebAuthenticationProviderWrapsNonExceptionThrowableFailure(): Unit =
+        testScope.runTest {
+            // WebAuthenticationProvider is externally implementable, so launchCustomTab() can fail
+            // with any Throwable, not just an Exception. emitError()/RedirectResult.Error require an
+            // Exception, so a non-Exception Throwable must be wrapped rather than crashing with a
+            // ClassCastException.
+            val resultDeferred = listenRedirectAsync()
+            val originalThrowable = Throwable("From Test!")
+            val webAuthenticationProvider =
+                mock<WebAuthenticationProvider> {
+                    on { launchCustomTab(any(), any()) } doReturn Result.failure(originalThrowable)
+                }
+            val initializerCountDownLatch = CountDownLatch(1)
+            subject.initializerContinuationListeningCallback = {
+                initializerCountDownLatch.countDown()
+            }
+            launch(Dispatchers.IO) {
+                subject.initialize(webAuthenticationProvider, mock(), "https://example.com/redirect") {
+                    RedirectInitializationResult.Success(mock(), Any())
+                }
+            }
+            assertThat(initializerCountDownLatch.await(1, TimeUnit.SECONDS)).isTrue()
+            subject.runInitializationFunction()
+            assertThat(subject.launchWebAuthenticationProvider(mock(), mock(), mock())).isFalse()
+            val result = resultDeferred.await()
+            assertThat(result).isInstanceOf(RedirectResult.Error::class.java)
+            val error = result as RedirectResult.Error
+            assertThat(error.exception).isNotSameInstanceAs(originalThrowable)
+            assertThat(error.exception).hasCauseThat().isSameInstanceAs(originalThrowable)
+        }
+
     @Test fun testInitializeDoesNothingWhenCancelled(): Unit =
         testScope.runTest {
             val webAuthenticationProvider =
                 mock<WebAuthenticationProvider> {
-                    on { launch(any(), any()) } doReturn null
+                    on { launchCustomTab(any(), any()) } doReturn Result.success(Unit)
                 }
             val launchedFromActivity = Robolectric.buildActivity(Activity::class.java).get()
             subject.initializerContinuationListeningCallback = {
@@ -380,7 +440,7 @@ class RedirectCoordinatorTest {
             assertThat(startedCountDownLatch.await(1, TimeUnit.SECONDS)).isTrue()
             job.cancel()
             cancelledCountDownLatch.countDown()
-            verify(webAuthenticationProvider, never()).launch(any(), any())
+            verify(webAuthenticationProvider, never()).launchCustomTab(any(), any())
             val foregroundActivity = shadowOf(launchedFromActivity).nextStartedActivity
             assertThat(foregroundActivity).isNull()
         }

--- a/web-authentication-ui/src/test/java/com/okta/webauthenticationui/WebAuthenticationProviderTest.kt
+++ b/web-authentication-ui/src/test/java/com/okta/webauthenticationui/WebAuthenticationProviderTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.webauthenticationui
+
+import android.content.ActivityNotFoundException
+import android.content.Context
+import com.google.common.truth.Truth.assertThat
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Covers [WebAuthenticationProvider.launchCustomTab]'s default implementation, which delegates to
+ * the deprecated [WebAuthenticationProvider.launch] so that existing implementations of the
+ * interface keep compiling without also having to implement [WebAuthenticationProvider.launchCustomTab].
+ */
+@RunWith(RobolectricTestRunner::class)
+class WebAuthenticationProviderTest {
+    @Test
+    fun testLaunchCustomTabDefaultImpl_delegatesToLaunch_onSuccess() {
+        val provider = FakeLegacyWebAuthenticationProvider(exception = null)
+        val result = provider.launchCustomTab(mock(), "https://example.com".toHttpUrl())
+        assertThat(result.isSuccess).isTrue()
+    }
+
+    @Test
+    fun testLaunchCustomTabDefaultImpl_delegatesToLaunch_onFailure() {
+        val exception = ActivityNotFoundException("From Test!")
+        val provider = FakeLegacyWebAuthenticationProvider(exception)
+        val result = provider.launchCustomTab(mock(), "https://example.com".toHttpUrl())
+        assertThat(result.isFailure).isTrue()
+        assertThat(result.exceptionOrNull()).isSameInstanceAs(exception)
+    }
+
+    /** A [WebAuthenticationProvider] implementation that only overrides the deprecated [launch], as pre-existing implementations do. */
+    private class FakeLegacyWebAuthenticationProvider(
+        private val exception: Exception?,
+    ) : WebAuthenticationProvider {
+        @Suppress("DEPRECATION")
+        @Deprecated("Use launchCustomTab(context, url) to receive a Result-based outcome.")
+        override fun launch(
+            context: Context,
+            url: HttpUrl,
+        ): Exception? = exception
+    }
+}


### PR DESCRIPTION
DefaultWebAuthenticationProvider.getBrowser() picked the first (or first preferred) package that resolved ACTION_CUSTOM_TABS_CONNECTION, without confirming it could actually handle http(s) links. Some non-browser apps implement that service too, which could cause launch() to fail on affected devices.

Each candidate is now also required to resolve ACTION_VIEW + CATEGORY_BROWSABLE for http:// before being selected, and preferred browsers are checked in full preference order instead of stopping at the first Custom Tabs match regardless of whether it's a real browser. This validation applies to both launchCustomTab() and launchAuthTab(), since both resolve the browser through the same BrowserSelector.

Make browser selection overridable via a BrowserSelector SAM. Add BrowserSelector, a fun interface returning Result<String>, and a browserSelector constructor parameter on DefaultWebAuthenticationProvider so callers can fully replace browser-selection logic (e.g. for testing or device-specific overrides) instead of only tuning preferredBrowsers/ queryIntentServicesFlags.

Surface NoBrowserFoundException from launch()/launchCustomTab().

Add WebAuthenticationProvider.launchCustomTab(), a Result-based replacement for the now-deprecated launch(), with a default implementation delegating to launch() so existing implementations of the interface keep compiling unchanged.