### PR TITLE
Restore auth-foundation JVM wrapper parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## auth-foundation Unreleased
+
+#### Added
+- `OAuth2ClientBuilder` (jvm wrapper) gained `setJson`, `setIdTokenValidator`,
+  `setAccessTokenValidator`, `setDeviceSecretValidator`, and `setRateLimitRetryCallback`, restoring
+  parity with the commonMain `OAuth2ClientBuilder`/`OAuth2ClientConfiguration`.
+- `TokenCredentialManager` (jvm wrapper) gained `setMetadata(TokenMetadata)`,
+  `find(Predicate<TokenMetadata>)`, and `findByCredential(Predicate<Credential>)`, restoring parity
+  with the commonMain `TokenCredentialManager`.
+
+#### Fixed
+- `OAuth2ClientBuilder` (jvm wrapper)'s `clientSecret` was tracked internally as a nullable
+  `String?` and only forwarded to the underlying KMP builder when set, diverging from
+  `OAuth2ClientConfiguration.clientSecret`'s actual non-null `String` type (default `""`). It's now
+  tracked as `String = ""` and always forwarded.
+
 ## web-authentication-ui Unreleased
 
 #### Added

--- a/auth-foundation/api/jvm/auth-foundation.api
+++ b/auth-foundation/api/jvm/auth-foundation.api
@@ -478,6 +478,7 @@ public final class com/okta/authfoundation/client/jvm/AuthFoundationResult$Compa
 public final class com/okta/authfoundation/client/jvm/OAuth2ClientBuilder {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
 	public final fun build ()Lcom/okta/authfoundation/client/jvm/AuthFoundationResult;
+	public final fun setAccessTokenValidator (Lcom/okta/authfoundation/client/kmp/AccessTokenValidator;)Lcom/okta/authfoundation/client/jvm/OAuth2ClientBuilder;
 	public final fun setAcrValues (Ljava/lang/String;)Lcom/okta/authfoundation/client/jvm/OAuth2ClientBuilder;
 	public final fun setApiExecutor (Lcom/okta/authfoundation/api/http/ApiExecutor;)Lcom/okta/authfoundation/client/jvm/OAuth2ClientBuilder;
 	public final fun setAuthorizationServerId (Ljava/lang/String;)Lcom/okta/authfoundation/client/jvm/OAuth2ClientBuilder;
@@ -485,8 +486,12 @@ public final class com/okta/authfoundation/client/jvm/OAuth2ClientBuilder {
 	public final fun setClientSecret (Ljava/lang/String;)Lcom/okta/authfoundation/client/jvm/OAuth2ClientBuilder;
 	public final fun setClock (Lcom/okta/authfoundation/client/OidcClock;)Lcom/okta/authfoundation/client/jvm/OAuth2ClientBuilder;
 	public final fun setComputeDispatcher (Lkotlin/coroutines/CoroutineContext;)Lcom/okta/authfoundation/client/jvm/OAuth2ClientBuilder;
+	public final fun setDeviceSecretValidator (Lcom/okta/authfoundation/client/kmp/DeviceSecretValidator;)Lcom/okta/authfoundation/client/jvm/OAuth2ClientBuilder;
 	public final fun setEndpointOverrides (Lcom/okta/authfoundation/client/OAuth2EndpointOverrides;)Lcom/okta/authfoundation/client/jvm/OAuth2ClientBuilder;
+	public final fun setIdTokenValidator (Lcom/okta/authfoundation/client/kmp/IdTokenValidator;)Lcom/okta/authfoundation/client/jvm/OAuth2ClientBuilder;
 	public final fun setIoDispatcher (Lkotlin/coroutines/CoroutineContext;)Lcom/okta/authfoundation/client/jvm/OAuth2ClientBuilder;
+	public final fun setJson (Lkotlinx/serialization/json/Json;)Lcom/okta/authfoundation/client/jvm/OAuth2ClientBuilder;
+	public final fun setRateLimitRetryCallback (Lkotlin/jvm/functions/Function1;)Lcom/okta/authfoundation/client/jvm/OAuth2ClientBuilder;
 }
 
 public abstract interface class com/okta/authfoundation/client/kmp/AccessTokenValidator {
@@ -734,10 +739,13 @@ public final class com/okta/authfoundation/credential/jvm/TokenCredentialManager
 	public final fun createTokenData (Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/okta/authfoundation/credential/kmp/TokenData;
 	public static synthetic fun createTokenData$default (Lcom/okta/authfoundation/credential/jvm/TokenCredentialManager;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/okta/authfoundation/credential/kmp/TokenData;
 	public final fun delete (Ljava/lang/String;)Lcom/okta/authfoundation/client/jvm/AuthFoundationResult;
+	public final fun find (Ljava/util/function/Predicate;)Lcom/okta/authfoundation/client/jvm/AuthFoundationResult;
+	public final fun findByCredential (Ljava/util/function/Predicate;)Lcom/okta/authfoundation/client/jvm/AuthFoundationResult;
 	public final fun get (Ljava/lang/String;)Lcom/okta/authfoundation/client/jvm/AuthFoundationResult;
 	public final fun getDefault ()Lcom/okta/authfoundation/client/jvm/AuthFoundationResult;
 	public final fun metadata (Ljava/lang/String;)Lcom/okta/authfoundation/client/jvm/AuthFoundationResult;
 	public final fun setDefault (Lcom/okta/authfoundation/credential/kmp/Credential;)Lcom/okta/authfoundation/client/jvm/AuthFoundationResult;
+	public final fun setMetadata (Lcom/okta/authfoundation/credential/TokenMetadata;)Lcom/okta/authfoundation/client/jvm/AuthFoundationResult;
 	public final fun store (Lcom/okta/authfoundation/credential/kmp/TokenData;)Lcom/okta/authfoundation/client/jvm/AuthFoundationResult;
 	public final fun store (Lcom/okta/authfoundation/credential/kmp/TokenData;Ljava/util/Map;)Lcom/okta/authfoundation/client/jvm/AuthFoundationResult;
 	public static synthetic fun store$default (Lcom/okta/authfoundation/credential/jvm/TokenCredentialManager;Lcom/okta/authfoundation/credential/kmp/TokenData;Ljava/util/Map;ILjava/lang/Object;)Lcom/okta/authfoundation/client/jvm/AuthFoundationResult;

--- a/auth-foundation/src/jvmMain/kotlin/com/okta/authfoundation/client/jvm/OAuth2ClientBuilder.kt
+++ b/auth-foundation/src/jvmMain/kotlin/com/okta/authfoundation/client/jvm/OAuth2ClientBuilder.kt
@@ -19,7 +19,12 @@ import com.okta.authfoundation.api.http.ApiExecutor
 import com.okta.authfoundation.client.Cache
 import com.okta.authfoundation.client.OAuth2ClientBuilder
 import com.okta.authfoundation.client.OidcClock
+import com.okta.authfoundation.client.kmp.AccessTokenValidator
+import com.okta.authfoundation.client.kmp.DeviceSecretValidator
+import com.okta.authfoundation.client.kmp.IdTokenValidator
 import com.okta.authfoundation.client.kmp.OAuth2Client
+import com.okta.authfoundation.client.kmp.RateLimitRetryConfig
+import kotlinx.serialization.json.Json
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -46,11 +51,16 @@ class OAuth2ClientBuilder(
     private var clock: OidcClock? = null
     private var ioDispatcher: CoroutineContext? = null
     private var computeDispatcher: CoroutineContext? = null
+    private var json: Json? = null
     private var cache: Cache? = null
     private var authorizationServerId: String? = null
-    private var clientSecret: String? = null
+    private var clientSecret: String = ""
     private var acrValues: String? = null
+    private var idTokenValidator: IdTokenValidator? = null
+    private var accessTokenValidator: AccessTokenValidator? = null
+    private var deviceSecretValidator: DeviceSecretValidator? = null
     private var endpointOverrides: com.okta.authfoundation.client.OAuth2EndpointOverrides? = null
+    private var rateLimitRetryCallback: ((retryCount: Int) -> RateLimitRetryConfig?)? = null
 
     /**
      * Sets the HTTP executor used for all network requests.
@@ -94,6 +104,17 @@ class OAuth2ClientBuilder(
     fun setComputeDispatcher(dispatcher: CoroutineContext): com.okta.authfoundation.client.jvm.OAuth2ClientBuilder =
         apply {
             this.computeDispatcher = dispatcher
+        }
+
+    /**
+     * Sets the JSON serializer used for encoding/decoding responses.
+     *
+     * @param json The [Json] instance to use.
+     * @return This builder for chaining.
+     */
+    fun setJson(json: Json): com.okta.authfoundation.client.jvm.OAuth2ClientBuilder =
+        apply {
+            this.json = json
         }
 
     /**
@@ -145,6 +166,39 @@ class OAuth2ClientBuilder(
         }
 
     /**
+     * Sets the ID token validator. When set, ID tokens are validated after token refresh.
+     *
+     * @param idTokenValidator The [IdTokenValidator] to use.
+     * @return This builder for chaining.
+     */
+    fun setIdTokenValidator(idTokenValidator: IdTokenValidator): com.okta.authfoundation.client.jvm.OAuth2ClientBuilder =
+        apply {
+            this.idTokenValidator = idTokenValidator
+        }
+
+    /**
+     * Sets the access token validator. When set, access tokens are validated via `at_hash` claim.
+     *
+     * @param accessTokenValidator The [AccessTokenValidator] to use.
+     * @return This builder for chaining.
+     */
+    fun setAccessTokenValidator(accessTokenValidator: AccessTokenValidator): com.okta.authfoundation.client.jvm.OAuth2ClientBuilder =
+        apply {
+            this.accessTokenValidator = accessTokenValidator
+        }
+
+    /**
+     * Sets the device secret validator. When set, device secrets are validated via `ds_hash` claim.
+     *
+     * @param deviceSecretValidator The [DeviceSecretValidator] to use.
+     * @return This builder for chaining.
+     */
+    fun setDeviceSecretValidator(deviceSecretValidator: DeviceSecretValidator): com.okta.authfoundation.client.jvm.OAuth2ClientBuilder =
+        apply {
+            this.deviceSecretValidator = deviceSecretValidator
+        }
+
+    /**
      * Sets optional per-endpoint URL overrides.
      *
      * When provided, each non-null field in [overrides] replaces the corresponding URL from
@@ -160,6 +214,21 @@ class OAuth2ClientBuilder(
         }
 
     /**
+     * Sets the callback invoked when an HTTP 429 rate-limit response is received.
+     *
+     * Return a [RateLimitRetryConfig] from [rateLimitRetryCallback] to retry the request, or `null`
+     * to surface the failure immediately. The `retryCount` parameter is 0-based: 0 on the first
+     * retry opportunity.
+     *
+     * @param rateLimitRetryCallback The callback to invoke on a 429 response.
+     * @return This builder for chaining.
+     */
+    fun setRateLimitRetryCallback(rateLimitRetryCallback: (retryCount: Int) -> RateLimitRetryConfig?): com.okta.authfoundation.client.jvm.OAuth2ClientBuilder =
+        apply {
+            this.rateLimitRetryCallback = rateLimitRetryCallback
+        }
+
+    /**
      * Creates an [OAuth2Client] instance with the configured parameters.
      *
      * @return A [AuthFoundationResult] containing the [OAuth2Client] on success, or an exception on failure.
@@ -171,11 +240,16 @@ class OAuth2ClientBuilder(
                 this@OAuth2ClientBuilder.clock?.let { clock = it }
                 this@OAuth2ClientBuilder.ioDispatcher?.let { ioDispatcher = it }
                 this@OAuth2ClientBuilder.computeDispatcher?.let { computeDispatcher = it }
+                this@OAuth2ClientBuilder.json?.let { json = it }
                 this@OAuth2ClientBuilder.cache?.let { cache = it }
                 this@OAuth2ClientBuilder.authorizationServerId?.let { authorizationServerId = it }
-                this@OAuth2ClientBuilder.clientSecret?.let { clientSecret = it }
+                clientSecret = this@OAuth2ClientBuilder.clientSecret
                 this@OAuth2ClientBuilder.acrValues?.let { acrValues = it }
+                this@OAuth2ClientBuilder.idTokenValidator?.let { idTokenValidator = it }
+                this@OAuth2ClientBuilder.accessTokenValidator?.let { accessTokenValidator = it }
+                this@OAuth2ClientBuilder.deviceSecretValidator?.let { deviceSecretValidator = it }
                 this@OAuth2ClientBuilder.endpointOverrides?.let { endpointOverrides = it }
+                this@OAuth2ClientBuilder.rateLimitRetryCallback?.let { rateLimitRetryCallback = it }
             }
         return AuthFoundationResult.fromKotlinResult(kotlinResult)
     }

--- a/auth-foundation/src/jvmMain/kotlin/com/okta/authfoundation/credential/jvm/TokenCredentialManager.kt
+++ b/auth-foundation/src/jvmMain/kotlin/com/okta/authfoundation/credential/jvm/TokenCredentialManager.kt
@@ -138,6 +138,35 @@ class TokenCredentialManager
                 .let { AuthFoundationResult.fromKotlinResult(it) }
 
         /**
+         * Updates metadata for an existing credential.
+         */
+        fun setMetadata(metadata: TokenMetadata): AuthFoundationResult<Unit> =
+            runCatching { runBlocking { delegate.setMetadata(metadata).getOrThrow() } }
+                .let { AuthFoundationResult.fromKotlinResult(it) }
+
+        /**
+         * Returns all credentials whose [TokenMetadata] matches the given [predicate].
+         *
+         * @param predicate A [Predicate] that receives [TokenMetadata] and returns `true` for
+         *   credentials to include.
+         */
+        fun find(predicate: Predicate<TokenMetadata>): AuthFoundationResult<List<Credential>> =
+            runCatching {
+                runBlocking { delegate.find { metadata: TokenMetadata -> predicate.test(metadata) }.getOrThrow() }
+            }.let { AuthFoundationResult.fromKotlinResult(it) }
+
+        /**
+         * Returns all credentials matching the given [predicate].
+         *
+         * @param predicate A [Predicate] that receives [Credential] and returns `true` for
+         *   credentials to include.
+         */
+        fun findByCredential(predicate: Predicate<Credential>): AuthFoundationResult<List<Credential>> =
+            runCatching {
+                runBlocking { delegate.find { credential: Credential -> predicate.test(credential) }.getOrThrow() }
+            }.let { AuthFoundationResult.fromKotlinResult(it) }
+
+        /**
          * Deletes a credential by ID.
          */
         fun delete(id: String): AuthFoundationResult<Unit> =

--- a/auth-foundation/src/jvmTest/java/com/okta/authfoundation/client/jvm/OAuth2ClientBuilderJavaTest.java
+++ b/auth-foundation/src/jvmTest/java/com/okta/authfoundation/client/jvm/OAuth2ClientBuilderJavaTest.java
@@ -19,9 +19,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import com.okta.authfoundation.client.kmp.DefaultAccessTokenValidator;
+import com.okta.authfoundation.client.kmp.DefaultDeviceSecretValidator;
+import com.okta.authfoundation.client.kmp.DefaultIdTokenValidator;
 import com.okta.authfoundation.client.kmp.OAuth2Client;
 import java.util.Arrays;
 import java.util.Collections;
+import kotlinx.serialization.json.Json;
 import org.junit.Test;
 
 /** Pure Java tests verifying that the JvmOAuth2ClientBuilder API is usable from Java. */
@@ -71,6 +75,21 @@ public class OAuth2ClientBuilderJavaTest {
             .getOrThrow();
 
     assertNotNull("Client should not be null after chaining", client);
+  }
+
+  @Test
+  public void build_WithAllOptionalSetters_Succeeds() {
+    OAuth2Client client =
+        new OAuth2ClientBuilder(BASE_URL, CLIENT_ID, Arrays.asList(SCOPE.split(" ")))
+            .setJson(Json.Default)
+            .setIdTokenValidator(new DefaultIdTokenValidator(600))
+            .setAccessTokenValidator(new DefaultAccessTokenValidator())
+            .setDeviceSecretValidator(new DefaultDeviceSecretValidator())
+            .setRateLimitRetryCallback(retryCount -> null)
+            .build()
+            .getOrThrow();
+
+    assertNotNull("Client should not be null after chaining all optional setters", client);
   }
 
   @Test

--- a/auth-foundation/src/jvmTest/java/com/okta/authfoundation/credential/jvm/TokenCredentialManagerJavaTest.java
+++ b/auth-foundation/src/jvmTest/java/com/okta/authfoundation/credential/jvm/TokenCredentialManagerJavaTest.java
@@ -211,6 +211,60 @@ public class TokenCredentialManagerJavaTest {
   }
 
   @Test
+  public void setMetadata_UpdatesExistingCredentialTags() {
+    TokenData token = manager.createTokenData("set-metadata-at");
+    Credential credential = manager.store(token).getOrThrow();
+    TokenMetadata original = manager.metadata(credential.getId()).getOrThrow();
+
+    TokenMetadata updated =
+        new TokenMetadata(
+            original.getId(),
+            Collections.singletonMap("env", "updated"),
+            original.getPayloadData(),
+            original.getJson());
+
+    assertTrue("setMetadata should succeed", manager.setMetadata(updated).isSuccess());
+    assertEquals("updated", manager.metadata(credential.getId()).getOrThrow().getTags().get("env"));
+  }
+
+  @Test
+  public void find_ByMetadataPredicate_ReturnsMatchingCredentials() {
+    Credential matching =
+        manager.store(manager.createTokenData("find-metadata-match")).getOrThrow();
+    manager.store(manager.createTokenData("find-metadata-nomatch")).getOrThrow();
+    TokenMetadata original = manager.metadata(matching.getId()).getOrThrow();
+    manager
+        .setMetadata(
+            new TokenMetadata(
+                original.getId(),
+                Collections.singletonMap("env", "prod"),
+                original.getPayloadData(),
+                original.getJson()))
+        .getOrThrow();
+
+    List<Credential> results =
+        manager
+            .find((Predicate<TokenMetadata>) m -> "prod".equals(m.getTags().get("env")))
+            .getOrThrow();
+
+    assertEquals(1, results.size());
+    assertEquals(matching.getId(), results.get(0).getId());
+  }
+
+  @Test
+  public void findByCredential_ReturnsMatchingCredentials() {
+    Credential matching =
+        manager.store(manager.createTokenData("find-credential-match")).getOrThrow();
+    manager.store(manager.createTokenData("find-credential-nomatch")).getOrThrow();
+
+    List<Credential> results =
+        manager.findByCredential(c -> matching.getId().equals(c.getId())).getOrThrow();
+
+    assertEquals(1, results.size());
+    assertEquals(matching.getId(), results.get(0).getId());
+  }
+
+  @Test
   public void delete_RemovesCredential() {
     TokenData token = manager.createTokenData("delete-at");
     Credential credential = manager.store(token).getOrThrow();

--- a/auth-foundation/src/jvmTest/kotlin/com/okta/authfoundation/credential/TestOAuth2ClientConfiguration.kt
+++ b/auth-foundation/src/jvmTest/kotlin/com/okta/authfoundation/credential/TestOAuth2ClientConfiguration.kt
@@ -36,7 +36,7 @@ object TestOAuth2ClientConfiguration {
             json = kotlinx.serialization.json.Json { ignoreUnknownKeys = true },
             cache = NoOpCache,
             authorizationServerId = null,
-            clientSecret = null,
+            clientSecret = "",
             acrValues = null
         )
 


### PR DESCRIPTION
JVM wrappers has drifted a bit. This change restores parity for all the jvm wrapper classes.