### PR TITLE
Add client assertion support to direct auth via ClientAssertionProvider

### DIFF
--- a/okta-direct-auth-java-cli-sample/README.md
+++ b/okta-direct-auth-java-cli-sample/README.md
@@ -57,10 +57,11 @@ desktopSignInRedirectUri=http://localhost:8080/callback
 
 ### Confidential client authentication (local testing only)
 
-Browser Sign-In builds a plain `OAuth2ClientBuilder` — a public client by default, which is the
-correct and only recommended setup for a distributed CLI or desktop app. To try this sample against
-a **confidential** client (for example, to exercise PAR with `private_key_jwt` or `client_secret`
-authentication), `ClientAuthentication` reads one of the following from `local.properties`
+Both the Direct Authentication and Browser Sign-In (OAuth2) builders are public clients by
+default — the correct and only recommended setup for a distributed CLI or desktop app. To try
+either against a **confidential** client (for example, to exercise PAR with `private_key_jwt` or
+`client_secret` authentication, or to run Direct Authentication as a confidential client),
+`ClientAuthentication` reads one of the following from `local.properties`
 **at runtime** — never bake either of these into `AppConfig` or any other compiled constant:
 
 ```properties
@@ -75,12 +76,14 @@ then paste it on one line with newlines escaped as `\n`):
 clientAssertionPrivateKeyPem=-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBg...\n-----END PRIVATE KEY-----\n
 ```
 
-If both are set, the private_key_jwt assertion takes precedence. If neither is set, the client
-stays public and Browser Sign-In behaves exactly as before.
+If both are set, the private_key_jwt assertion takes precedence. If neither is set, both clients
+stay public and Direct Authentication/Browser Sign-In behave exactly as before.
 
 The private_key_jwt path registers a `ClientAssertionProvider` rather than a static assertion
-string: the SDK invokes it fresh for every token/PAR request, so each signed JWT gets a unique
-`jti` and an `aud` scoped to the exact endpoint being called — required by
+string: the SDK invokes it fresh for every client-authenticated request — every token/PAR request
+for the OAuth2 builder, and every token/challenge/oob-authenticate/primary-authenticate request
+(including each iteration of an OOB poll) for the Direct Authentication builder — so each signed
+JWT gets a unique `jti` and an `aud` scoped to the exact endpoint being called — required by
 [Okta's client authentication guide](https://developer.okta.com/docs/api/openapi/okta-oauth/guides/client-auth),
 which only allows a given `jti` to be used once.
 

--- a/okta-direct-auth-java-cli-sample/src/main/java/com/okta/directauth/cli/ClientAuthentication.java
+++ b/okta-direct-auth-java-cli-sample/src/main/java/com/okta/directauth/cli/ClientAuthentication.java
@@ -16,7 +16,9 @@
 package com.okta.directauth.cli;
 
 import com.okta.authfoundation.client.ClientAssertion;
+import com.okta.authfoundation.client.ClientAssertionProvider;
 import com.okta.authfoundation.client.jvm.OAuth2ClientBuilder;
+import com.okta.directauth.jvm.DirectAuthenticationFlowBuilder;
 import io.jsonwebtoken.Jwts;
 import java.io.File;
 import java.io.FileInputStream;
@@ -32,15 +34,20 @@ import java.util.Base64;
 import java.util.Date;
 import java.util.Properties;
 import java.util.UUID;
+import java.util.function.Consumer;
 
 /**
  * Reads confidential-client credentials (a client secret or a private_key_jwt signing key) from
- * {@code local.properties} at runtime and applies them to an {@link OAuth2ClientBuilder}, so this
- * CLI can demonstrate Pushed Authorization Requests (PAR) and other confidential-client features
- * against a confidential OAuth2 client.
+ * {@code local.properties} at runtime and applies them to an {@link OAuth2ClientBuilder} or a
+ * {@link DirectAuthenticationFlowBuilder}, so this CLI can demonstrate Pushed Authorization
+ * Requests (PAR), Direct Authentication, and other confidential-client features against a
+ * confidential OAuth2 client.
  *
- * <p>The private_key_jwt path registers a {@code ClientAssertionProvider}, which the SDK invokes
- * fresh for every token/PAR request. This matters for spec compliance — per <a
+ * <p>The private_key_jwt path registers a {@link ClientAssertionProvider}, which the SDK invokes
+ * fresh for every client-authenticated request — every token/PAR request for {@link
+ * OAuth2ClientBuilder}, and every token/challenge/oob-authenticate/primary-authenticate request
+ * (including each iteration of an OOB poll) for {@link DirectAuthenticationFlowBuilder}. This
+ * matters for spec compliance — per <a
  * href="https://developer.okta.com/docs/api/openapi/okta-oauth/guides/client-auth">Okta's client
  * authentication guide</a>, a `jti` may only be used once and `aud` must be the exact endpoint URL
  * being called, neither of which a single statically-built assertion can satisfy across more than
@@ -103,6 +110,49 @@ final class ClientAuthentication {
    * unit-tested without touching the filesystem.
    */
   static void configure(OAuth2ClientBuilder builder, String clientId, Properties localProperties) {
+    applyLocalClientCredentials(
+        clientId, localProperties, builder::setClientSecret, builder::setClientAssertionProvider);
+  }
+
+  /**
+   * Applies a client secret or private_key_jwt client assertion provider to {@code builder}, if
+   * either is present in {@code local.properties}. Does nothing if neither is configured, leaving
+   * the client a public client (the default for this sample).
+   *
+   * <p>The private_key_jwt provider registered here is invoked fresh for every client-authenticated
+   * request the Direct Authentication flow makes — including each iteration of an OOB poll — not
+   * just once, since a single statically-built assertion could not satisfy the `jti`/`aud`
+   * requirements across more than one request.
+   *
+   * @param builder the builder to configure
+   * @param clientId the OAuth 2.0 client ID, used as the {@code iss}/{@code sub} claims of a
+   *     private_key_jwt assertion
+   */
+  static void configure(DirectAuthenticationFlowBuilder builder, String clientId) {
+    configure(builder, clientId, findLocalProperties());
+  }
+
+  /**
+   * Overload taking an already-loaded {@link Properties}, so the credential-selection logic can be
+   * unit-tested without touching the filesystem.
+   */
+  static void configure(
+      DirectAuthenticationFlowBuilder builder, String clientId, Properties localProperties) {
+    applyLocalClientCredentials(
+        clientId, localProperties, builder::setClientSecret, builder::setClientAssertionProvider);
+  }
+
+  /**
+   * Shared credential-selection logic for both {@link OAuth2ClientBuilder} and {@link
+   * DirectAuthenticationFlowBuilder}: reads {@code clientSecret}/{@code
+   * clientAssertionPrivateKeyPem} from {@code localProperties} and applies whichever is present via
+   * {@code setClientSecret}/{@code setClientAssertionProvider}.
+   */
+  private static void applyLocalClientCredentials(
+      String clientId,
+      Properties localProperties,
+      Consumer<String> setClientSecret,
+      Consumer<ClientAssertionProvider> setClientAssertionProvider) {
     String clientSecret = localProperties.getProperty(CLIENT_SECRET_PROPERTY, "").trim();
     String clientAssertionPem =
         localProperties.getProperty(CLIENT_ASSERTION_PEM_PROPERTY, "").trim();
@@ -115,7 +165,7 @@ final class ClientAuthentication {
                 + "using the private_key_jwt assertion and ignoring clientSecret.");
       }
       PrivateKey privateKey = parsePkcs8PrivateKey(clientAssertionPem);
-      builder.setClientAssertionProvider(
+      setClientAssertionProvider.accept(
           audience ->
               new ClientAssertion(
                   JWT_BEARER_CLIENT_ASSERTION_TYPE,
@@ -125,7 +175,7 @@ final class ClientAuthentication {
           "Using a private_key_jwt client assertion provider from local.properties (testing"
               + " only; a fresh JWT is signed for every request).");
     } else if (!clientSecret.isEmpty()) {
-      builder.setClientSecret(clientSecret);
+      setClientSecret.accept(clientSecret);
       CliLogger.info(TAG, "Using a client_secret from local.properties (testing only).");
     } else {
       CliLogger.debug(

--- a/okta-direct-auth-java-cli-sample/src/main/java/com/okta/directauth/cli/Main.java
+++ b/okta-direct-auth-java-cli-sample/src/main/java/com/okta/directauth/cli/Main.java
@@ -144,18 +144,22 @@ public final class Main implements Callable<Integer> {
     List<String> recoveryScopes = List.of("okta.myAccount.password.manage");
 
     CliLogger.info(TAG, "Building Direct Auth sign-in flow (scopes: " + signInScopes + ")");
-    DirectAuthResult<DirectAuthenticationFlow> signInResult =
+    DirectAuthenticationFlowBuilder signInBuilder =
         new DirectAuthenticationFlowBuilder(issuer, clientId, signInScopes)
             .setAuthorizationServerId(authorizationServerId)
-            .setIntent(DirectAuthenticationIntent.SIGN_IN)
-            .build();
+            .setIntent(DirectAuthenticationIntent.SIGN_IN);
+    // Testing only: reads a client secret or private_key_jwt key from local.properties at
+    // runtime. See ClientAuthentication for why this must not be done in a shipped app.
+    ClientAuthentication.configure(signInBuilder, clientId);
+    DirectAuthResult<DirectAuthenticationFlow> signInResult = signInBuilder.build();
 
     CliLogger.info(TAG, "Building Direct Auth recovery flow (scopes: " + recoveryScopes + ")");
-    DirectAuthResult<DirectAuthenticationFlow> recoveryResult =
+    DirectAuthenticationFlowBuilder recoveryBuilder =
         new DirectAuthenticationFlowBuilder(issuer, clientId, recoveryScopes)
             .setAuthorizationServerId(authorizationServerId)
-            .setIntent(DirectAuthenticationIntent.RECOVERY)
-            .build();
+            .setIntent(DirectAuthenticationIntent.RECOVERY);
+    ClientAuthentication.configure(recoveryBuilder, clientId);
+    DirectAuthResult<DirectAuthenticationFlow> recoveryResult = recoveryBuilder.build();
 
     if (signInResult.isFailure()) {
       Throwable cause = signInResult.exceptionOrNull();

--- a/okta-direct-auth-java-cli-sample/src/test/java/com/okta/directauth/cli/ClientAuthenticationTest.java
+++ b/okta-direct-auth-java-cli-sample/src/test/java/com/okta/directauth/cli/ClientAuthenticationTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import com.okta.authfoundation.client.ClientAssertion;
 import com.okta.authfoundation.client.ClientAssertionProvider;
 import com.okta.authfoundation.client.jvm.OAuth2ClientBuilder;
+import com.okta.directauth.jvm.DirectAuthenticationFlowBuilder;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import java.security.KeyPair;
@@ -148,6 +149,68 @@ public class ClientAuthenticationTest {
   @Test
   public void configure_WithNeitherConfigured_LeavesBuilderUntouched() {
     OAuth2ClientBuilder builder = mock(OAuth2ClientBuilder.class);
+
+    ClientAuthentication.configure(builder, CLIENT_ID, new Properties());
+
+    verifyNoMoreInteractions(builder);
+  }
+
+  @Test
+  public void configure_DirectAuthBuilder_WithClientSecretOnly_SetsClientSecretOnly() {
+    DirectAuthenticationFlowBuilder builder = mock(DirectAuthenticationFlowBuilder.class);
+    Properties properties = new Properties();
+    properties.setProperty("clientSecret", "test-secret");
+
+    ClientAuthentication.configure(builder, CLIENT_ID, properties);
+
+    verify(builder).setClientSecret("test-secret");
+    verify(builder, never()).setClientAssertionProvider(any());
+  }
+
+  @Test
+  public void
+      configure_DirectAuthBuilder_WithClientAssertionPemOnly_RegistersProviderThatSignsFreshJwtPerCall()
+          throws NoSuchAlgorithmException {
+    DirectAuthenticationFlowBuilder builder = mock(DirectAuthenticationFlowBuilder.class);
+    KeyPair keyPair = generateRsaKeyPair();
+    Properties properties = new Properties();
+    properties.setProperty("clientAssertionPrivateKeyPem", toPem(keyPair.getPrivate()));
+
+    ClientAuthentication.configure(builder, CLIENT_ID, properties);
+
+    verify(builder, never()).setClientSecret(any());
+    ArgumentCaptor<ClientAssertionProvider> providerCaptor =
+        ArgumentCaptor.forClass(ClientAssertionProvider.class);
+    verify(builder).setClientAssertionProvider(providerCaptor.capture());
+    ClientAssertionProvider provider = providerCaptor.getValue();
+
+    ClientAssertion first = provider.provide("https://example.okta.com/oauth2/default/v1/token");
+    ClientAssertion second =
+        provider.provide("https://example.okta.com/oauth2/default/v1/challenge");
+
+    // Each call must be freshly signed (unique jti) and scoped to the audience it was asked for.
+    assertThat(first.getAssertion()).isNotEqualTo(second.getAssertion());
+    Claims firstClaims =
+        Jwts.parser()
+            .verifyWith(keyPair.getPublic())
+            .build()
+            .parseSignedClaims(first.getAssertion())
+            .getPayload();
+    assertThat(firstClaims.getAudience())
+        .containsExactly("https://example.okta.com/oauth2/default/v1/token");
+    Claims secondClaims =
+        Jwts.parser()
+            .verifyWith(keyPair.getPublic())
+            .build()
+            .parseSignedClaims(second.getAssertion())
+            .getPayload();
+    assertThat(secondClaims.getAudience())
+        .containsExactly("https://example.okta.com/oauth2/default/v1/challenge");
+  }
+
+  @Test
+  public void configure_DirectAuthBuilder_WithNeitherConfigured_LeavesBuilderUntouched() {
+    DirectAuthenticationFlowBuilder builder = mock(DirectAuthenticationFlowBuilder.class);
 
     ClientAuthentication.configure(builder, CLIENT_ID, new Properties());
 

--- a/okta-direct-auth-shared/README.md
+++ b/okta-direct-auth-shared/README.md
@@ -123,9 +123,10 @@ Ensure your test user is enrolled in the authenticators you intend to use.
 
 ### Confidential client authentication (local testing only)
 
-Browser Sign-In builds a public `OAuth2Client` by default — the correct and only recommended setup
-for a distributed Android or desktop app. To try this sample against a **confidential** client (for
-example, to exercise PAR with `private_key_jwt` or `client_secret` authentication), add one of the
+Browser Sign-In and Direct Authentication both build public clients by default — the correct and
+only recommended setup for a distributed Android or desktop app. To try either against a
+**confidential** client (for example, to exercise PAR with `private_key_jwt` or `client_secret`
+authentication, or to run Direct Authentication as a confidential client), add one of the
 following to `local.properties`:
 
 ```properties
@@ -140,10 +141,12 @@ then paste it on one line with newlines escaped as `\n`):
 clientAssertionPrivateKeyPem=-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBg...\n-----END PRIVATE KEY-----\n
 ```
 
-If both are set, the private_key_jwt assertion takes precedence. If neither is set, the client
-stays public and Browser Sign-In behaves exactly as before. See `configureClientAuthentication`
-(`src/commonMain/.../platform/PlatformClientAuthentication.kt` and its two platform actuals) for
-how each platform applies this — the two platforms get there very differently:
+If both are set, the private_key_jwt assertion takes precedence. If neither is set, both clients
+stay public and Browser Sign-In/Direct Authentication behave exactly as before. See the two
+`configureClientAuthentication` overloads — one for `OAuth2ClientBuilder`, one for
+`DirectAuthenticationFlowBuilder` — in `src/commonMain/.../platform/PlatformClientAuthentication.kt`
+and its two platform actuals for how each platform applies this — the two platforms get there very
+differently:
 
 *   **Desktop** (`src/jvmMain`) reads `local.properties` directly **at runtime**, deliberately not
     via the `AppConfig` pattern used for the rest of this sample's config, so the secret is never
@@ -154,8 +157,11 @@ how each platform applies this — the two platforms get there very differently:
     non-secret values (issuer, client ID, etc.) already are.
 
 On both platforms, the private_key_jwt path registers a `ClientAssertionProvider` rather than a
-static assertion string: the SDK invokes it fresh for every token/PAR request, so each signed JWT
-gets a unique `jti` and an `aud` scoped to the exact endpoint being called — required by
+static assertion string: the SDK invokes it fresh for every client-authenticated request — every
+token/PAR request for `OAuth2ClientBuilder`, and every token/challenge/oob-authenticate/
+primary-authenticate request (including each iteration of an OOB poll) for
+`DirectAuthenticationFlowBuilder` — so each signed JWT gets a unique `jti` and an `aud` scoped to
+the exact endpoint being called — required by
 [Okta's client authentication guide](https://developer.okta.com/docs/api/openapi/okta-oauth/guides/client-auth),
 which only allows a given `jti` to be used once.
 

--- a/okta-direct-auth-shared/src/androidMain/kotlin/com/okta/directauth/app/platform/PlatformClientAuthentication.android.kt
+++ b/okta-direct-auth-shared/src/androidMain/kotlin/com/okta/directauth/app/platform/PlatformClientAuthentication.android.kt
@@ -18,6 +18,7 @@ package com.okta.directauth.app.platform
 import com.okta.authfoundation.client.ClientAssertion
 import com.okta.authfoundation.client.ClientAssertionProvider
 import com.okta.authfoundation.client.OAuth2ClientBuilder
+import com.okta.directauth.DirectAuthenticationFlowBuilder
 import com.okta.directauth.app.AppConfig
 import com.okta.directauth.app.util.AppLogger
 import io.jsonwebtoken.Jwts
@@ -56,6 +57,36 @@ private val CLIENT_ASSERTION_LIFETIME = 5.minutes
  * https://developer.okta.com/docs/api/openapi/okta-oauth/guides/client-auth).
  */
 actual fun OAuth2ClientBuilder.configureClientAuthentication(clientId: String) {
+    applyBakedClientAuthentication(
+        clientId = clientId,
+        setClientSecret = { this.clientSecret = it },
+        setClientAssertionProvider = { this.clientAssertionProvider = it }
+    )
+}
+
+/**
+ * Android implementation for the Direct Authentication demo. Same source ([AppConfig], baked at
+ * build time) and precedence as [OAuth2ClientBuilder.configureClientAuthentication] — see its
+ * KDoc for the full security rationale.
+ */
+actual fun DirectAuthenticationFlowBuilder.configureClientAuthentication(clientId: String) {
+    applyBakedClientAuthentication(
+        clientId = clientId,
+        setClientSecret = { this.clientSecret = it },
+        setClientAssertionProvider = { this.clientAssertionProvider = it }
+    )
+}
+
+/**
+ * Reads a client secret or private_key_jwt signing key from [AppConfig] and applies whichever is
+ * present via [setClientSecret]/[setClientAssertionProvider], shared by both [OAuth2ClientBuilder]
+ * and [DirectAuthenticationFlowBuilder].
+ */
+private fun applyBakedClientAuthentication(
+    clientId: String,
+    setClientSecret: (String) -> Unit,
+    setClientAssertionProvider: (ClientAssertionProvider) -> Unit,
+) {
     val clientSecret = AppConfig.CLIENT_SECRET.trim()
     val clientAssertionPem = AppConfig.CLIENT_ASSERTION_PRIVATE_KEY_PEM.trim()
 
@@ -69,13 +100,14 @@ actual fun OAuth2ClientBuilder.configureClientAuthentication(clientId: String) {
                 )
             }
             val privateKey = parsePkcs8PrivateKey(clientAssertionPem)
-            this.clientAssertionProvider =
+            setClientAssertionProvider(
                 ClientAssertionProvider { audience ->
                     ClientAssertion(
                         type = JWT_BEARER_CLIENT_ASSERTION_TYPE,
                         assertion = buildClientAssertionJwt(clientId, audience, privateKey)
                     )
                 }
+            )
             AppLogger.write(
                 TAG,
                 "Using a private_key_jwt client assertion provider baked from local.properties (testing " +
@@ -84,7 +116,7 @@ actual fun OAuth2ClientBuilder.configureClientAuthentication(clientId: String) {
         }
 
         clientSecret.isNotEmpty() -> {
-            this.clientSecret = clientSecret
+            setClientSecret(clientSecret)
             AppLogger.write(TAG, "Using a client_secret baked from local.properties (testing only).")
         }
 

--- a/okta-direct-auth-shared/src/commonMain/kotlin/com/okta/directauth/app/platform/PlatformClientAuthentication.kt
+++ b/okta-direct-auth-shared/src/commonMain/kotlin/com/okta/directauth/app/platform/PlatformClientAuthentication.kt
@@ -16,6 +16,7 @@
 package com.okta.directauth.app.platform
 
 import com.okta.authfoundation.client.OAuth2ClientBuilder
+import com.okta.directauth.DirectAuthenticationFlowBuilder
 
 /**
  * Applies a client secret or private_key_jwt [ClientAssertionProvider][com.okta.authfoundation.client.ClientAssertionProvider]
@@ -58,3 +59,21 @@ import com.okta.authfoundation.client.OAuth2ClientBuilder
  *   assertion
  */
 expect fun OAuth2ClientBuilder.configureClientAuthentication(clientId: String)
+
+/**
+ * Applies a client secret or private_key_jwt [ClientAssertionProvider][com.okta.authfoundation.client.ClientAssertionProvider]
+ * to [this] builder, so the Direct Authentication demo (username/password, OTP, OOB, WebAuthn)
+ * can be tried against a confidential OAuth2 client.
+ *
+ * Same source, precedence, and security rationale as
+ * [OAuth2ClientBuilder.configureClientAuthentication] — see its KDoc. The private_key_jwt path
+ * is especially relevant here: Direct Authentication issues more than one client-authenticated
+ * request per flow (e.g. an OOB poll makes repeated `/token` calls), and a
+ * [ClientAssertionProvider][com.okta.authfoundation.client.ClientAssertionProvider] is invoked
+ * fresh for each one, unlike a single statically-built assertion which could only ever satisfy
+ * the first request.
+ *
+ * @param clientId the OAuth 2.0 client ID, used as the `iss`/`sub` claims of a private_key_jwt
+ *   assertion
+ */
+expect fun DirectAuthenticationFlowBuilder.configureClientAuthentication(clientId: String)

--- a/okta-direct-auth-shared/src/commonMain/kotlin/com/okta/directauth/app/viewModel/MainViewModel.kt
+++ b/okta-direct-auth-shared/src/commonMain/kotlin/com/okta/directauth/app/viewModel/MainViewModel.kt
@@ -26,6 +26,7 @@ import com.okta.directauth.app.AppConfig
 import com.okta.directauth.app.http.MyAccountReplacePasswordRequest
 import com.okta.directauth.app.model.AuthMethod
 import com.okta.directauth.app.model.OktaErrorResponse
+import com.okta.directauth.app.platform.configureClientAuthentication
 import com.okta.directauth.app.util.AppLogger
 import com.okta.directauth.model.DirectAuthContinuation
 import com.okta.directauth.model.DirectAuthenticationIntent
@@ -123,6 +124,10 @@ class MainViewModel : ViewModel() {
         DirectAuthenticationFlowBuilder
             .create(AppConfig.ISSUER, AppConfig.CLIENT_ID, scopes) {
                 authorizationServerId = AppConfig.AUTHORIZATION_SERVER_ID
+                // Testing only: reads a client secret or private_key_jwt key from
+                // local.properties at runtime. See configureClientAuthentication for
+                // why this must not be done in a shipped app.
+                configureClientAuthentication(clientId = AppConfig.CLIENT_ID)
             }.getOrThrow()
 
     /**
@@ -137,6 +142,7 @@ class MainViewModel : ViewModel() {
         DirectAuthenticationFlowBuilder
             .create(AppConfig.ISSUER, AppConfig.CLIENT_ID, ssprScope) {
                 directAuthenticationIntent = DirectAuthenticationIntent.RECOVERY
+                configureClientAuthentication(clientId = AppConfig.CLIENT_ID)
             }.getOrThrow()
 
     /**

--- a/okta-direct-auth-shared/src/jvmMain/kotlin/com/okta/directauth/app/platform/PlatformClientAuthentication.jvm.kt
+++ b/okta-direct-auth-shared/src/jvmMain/kotlin/com/okta/directauth/app/platform/PlatformClientAuthentication.jvm.kt
@@ -18,6 +18,7 @@ package com.okta.directauth.app.platform
 import com.okta.authfoundation.client.ClientAssertion
 import com.okta.authfoundation.client.ClientAssertionProvider
 import com.okta.authfoundation.client.OAuth2ClientBuilder
+import com.okta.directauth.DirectAuthenticationFlowBuilder
 import com.okta.directauth.app.util.AppLogger
 import io.jsonwebtoken.Jwts
 import java.io.File
@@ -52,6 +53,36 @@ private const val MAX_PARENT_DIRECTORIES_TO_SEARCH = 8
  * https://developer.okta.com/docs/api/openapi/okta-oauth/guides/client-auth).
  */
 actual fun OAuth2ClientBuilder.configureClientAuthentication(clientId: String) {
+    applyLocalClientAuthentication(
+        clientId = clientId,
+        setClientSecret = { this.clientSecret = it },
+        setClientAssertionProvider = { this.clientAssertionProvider = it }
+    )
+}
+
+/**
+ * JVM Desktop implementation for the Direct Authentication demo. Same source
+ * (`local.properties`) and precedence as [OAuth2ClientBuilder.configureClientAuthentication] —
+ * see its KDoc for the full security rationale.
+ */
+actual fun DirectAuthenticationFlowBuilder.configureClientAuthentication(clientId: String) {
+    applyLocalClientAuthentication(
+        clientId = clientId,
+        setClientSecret = { this.clientSecret = it },
+        setClientAssertionProvider = { this.clientAssertionProvider = it }
+    )
+}
+
+/**
+ * Reads a client secret or private_key_jwt signing key from `local.properties` and applies
+ * whichever is present via [setClientSecret]/[setClientAssertionProvider], shared by both
+ * [OAuth2ClientBuilder] and [DirectAuthenticationFlowBuilder].
+ */
+private fun applyLocalClientAuthentication(
+    clientId: String,
+    setClientSecret: (String) -> Unit,
+    setClientAssertionProvider: (ClientAssertionProvider) -> Unit,
+) {
     val localProperties = findLocalProperties()
     val clientSecret = localProperties.getProperty(CLIENT_SECRET_PROPERTY, "").trim()
     val clientAssertionPem = localProperties.getProperty(CLIENT_ASSERTION_PEM_PROPERTY, "").trim()
@@ -66,13 +97,14 @@ actual fun OAuth2ClientBuilder.configureClientAuthentication(clientId: String) {
                 )
             }
             val privateKey = parsePkcs8PrivateKey(clientAssertionPem)
-            this.clientAssertionProvider =
+            setClientAssertionProvider(
                 ClientAssertionProvider { audience ->
                     ClientAssertion(
                         type = JWT_BEARER_CLIENT_ASSERTION_TYPE,
                         assertion = buildClientAssertionJwt(clientId, audience, privateKey)
                     )
                 }
+            )
             AppLogger.write(
                 TAG,
                 "Using a private_key_jwt client assertion provider from local.properties (testing only; " +
@@ -81,7 +113,7 @@ actual fun OAuth2ClientBuilder.configureClientAuthentication(clientId: String) {
         }
 
         clientSecret.isNotEmpty() -> {
-            this.clientSecret = clientSecret
+            setClientSecret(clientSecret)
             AppLogger.write(TAG, "Using a client_secret from local.properties (testing only).")
         }
 

--- a/okta-direct-auth/CHANGELOG.md
+++ b/okta-direct-auth/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [Unreleased]
+
+### Added
+
+- `DirectAuthenticationFlowBuilder.clientAssertionProvider`/`computeDispatcher` (and the
+  corresponding `jvm.DirectAuthenticationFlowBuilder.setClientAssertionProvider`/
+  `setComputeDispatcher`) for `private_key_jwt` client authentication. The provider is invoked
+  fresh for every client-authenticated request the flow makes — including each iteration of an
+  OOB poll — so the returned assertion can carry a unique `jti` and a correctly scoped, non-expired
+  `exp`/`aud`. Mutually exclusive with `clientSecret`.
+
 ## [1.0.0] - 2026-08-05
 
 Graduating from beta (0.0.1) to the first stable release.

--- a/okta-direct-auth/README.md
+++ b/okta-direct-auth/README.md
@@ -74,6 +74,43 @@ val directAuth: DirectAuthenticationFlow =
         }.getOrThrow()
 ```
 
+If your application is registered as a confidential client, authenticate with either a client secret:
+
+```kotlin
+val confidentialFlow: DirectAuthenticationFlow =
+    DirectAuthenticationFlowBuilder
+        .create(
+            issuerUrl = "https://your-org.okta.com",
+            clientId = "your-client-id",
+            scope = listOf("openid", "profile", "email")
+        ) {
+            clientSecret = "your-client-secret"
+        }.getOrThrow()
+```
+
+...or, mutually exclusive with `clientSecret`, a `private_key_jwt` assertion provider. It's invoked fresh for every request the flow makes — including each iteration of an OOB poll — so the returned assertion can carry a unique `jti` and a correctly scoped, non-expired `exp`/`aud`:
+
+```kotlin
+import com.okta.authfoundation.client.ClientAssertion
+import com.okta.authfoundation.client.ClientAssertionProvider
+
+val confidentialFlow: DirectAuthenticationFlow =
+    DirectAuthenticationFlowBuilder
+        .create(
+            issuerUrl = "https://your-org.okta.com",
+            clientId = "your-client-id",
+            scope = listOf("openid", "profile", "email")
+        ) {
+            clientAssertionProvider =
+                ClientAssertionProvider { audience ->
+                    ClientAssertion(
+                        type = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+                        assertion = signJwt(issuer = "your-client-id", subject = "your-client-id", audience = audience)
+                    )
+                }
+        }.getOrThrow()
+```
+
 For self-service password recovery flows, create a separate flow with the recovery intent:
 
 ```kotlin
@@ -464,6 +501,24 @@ DirectAuthResult<DirectAuthenticationFlow> result =
         .build();
 
 DirectAuthenticationFlow flow = result.getOrThrow();
+```
+
+If your application is registered as a confidential client, authenticate with either `setClientSecret` or, mutually exclusive with it, `setClientAssertionProvider` — invoked fresh for every request the flow makes (including each iteration of an OOB poll) so the returned assertion can carry a unique `jti` and a correctly scoped, non-expired `exp`/`aud`:
+
+```java
+import com.okta.authfoundation.client.ClientAssertion;
+
+DirectAuthResult<DirectAuthenticationFlow> result =
+    new DirectAuthenticationFlowBuilder(
+            "https://your-org.okta.com",
+            "your-client-id",
+            List.of("openid", "profile", "email"))
+        .setClientAssertionProvider(
+            audience ->
+                new ClientAssertion(
+                    "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+                    signJwt("your-client-id", "your-client-id", audience)))
+        .build();
 ```
 
 ### Starting Authentication (Java)

--- a/okta-direct-auth/api/jvm/okta-direct-auth.api
+++ b/okta-direct-auth/api/jvm/okta-direct-auth.api
@@ -6,8 +6,10 @@ public final class com/okta/directauth/DirectAuthenticationFlowBuilder {
 	public final fun getAdditionalParameter ()Ljava/util/Map;
 	public final fun getApiExecutor ()Lcom/okta/authfoundation/api/http/ApiExecutor;
 	public final fun getAuthorizationServerId ()Ljava/lang/String;
+	public final fun getClientAssertionProvider ()Lcom/okta/authfoundation/client/ClientAssertionProvider;
 	public final fun getClientSecret ()Ljava/lang/String;
 	public final fun getClock ()Lcom/okta/authfoundation/client/OidcClock;
+	public final fun getComputeDispatcher ()Lkotlin/coroutines/CoroutineContext;
 	public final fun getDirectAuthenticationIntent ()Lcom/okta/directauth/model/DirectAuthenticationIntent;
 	public final fun getLogger ()Lcom/okta/authfoundation/api/log/AuthFoundationLogger;
 	public final fun getSupportedGrantType ()Ljava/util/List;
@@ -15,8 +17,10 @@ public final class com/okta/directauth/DirectAuthenticationFlowBuilder {
 	public final fun setAdditionalParameter (Ljava/util/Map;)V
 	public final fun setApiExecutor (Lcom/okta/authfoundation/api/http/ApiExecutor;)V
 	public final fun setAuthorizationServerId (Ljava/lang/String;)V
+	public final fun setClientAssertionProvider (Lcom/okta/authfoundation/client/ClientAssertionProvider;)V
 	public final fun setClientSecret (Ljava/lang/String;)V
 	public final fun setClock (Lcom/okta/authfoundation/client/OidcClock;)V
+	public final fun setComputeDispatcher (Lkotlin/coroutines/CoroutineContext;)V
 	public final fun setDirectAuthenticationIntent (Lcom/okta/directauth/model/DirectAuthenticationIntent;)V
 	public final fun setLogger (Lcom/okta/authfoundation/api/log/AuthFoundationLogger;)V
 	public final fun setSupportedGrantType (Ljava/util/List;)V
@@ -56,7 +60,7 @@ public final class com/okta/directauth/http/DirectAuthStartRequest$DefaultImpls 
 }
 
 public abstract class com/okta/directauth/http/DirectAuthTokenRequest : com/okta/directauth/http/DirectAuthStartRequest {
-	public synthetic fun <init> (Lcom/okta/directauth/model/DirectAuthenticationContext;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lcom/okta/directauth/model/DirectAuthenticationContext;Lcom/okta/authfoundation/client/ClientAssertion;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun contentType ()Ljava/lang/String;
 	public fun headers ()Ljava/util/Map;
 	public fun method ()Lcom/okta/authfoundation/api/http/ApiRequestMethod;
@@ -169,10 +173,14 @@ public final class com/okta/directauth/jvm/DirectAuthenticationFlowBuilder {
 	public final fun build ()Lcom/okta/directauth/jvm/DirectAuthResult;
 	public final fun setAcrValues (Ljava/util/List;)Lcom/okta/directauth/jvm/DirectAuthenticationFlowBuilder;
 	public final fun setAdditionalParameters (Ljava/util/Map;)Lcom/okta/directauth/jvm/DirectAuthenticationFlowBuilder;
+	public final fun setApiExecutor (Lcom/okta/authfoundation/api/http/ApiExecutor;)Lcom/okta/directauth/jvm/DirectAuthenticationFlowBuilder;
 	public final fun setAuthorizationServerId (Ljava/lang/String;)Lcom/okta/directauth/jvm/DirectAuthenticationFlowBuilder;
+	public final fun setClientAssertionProvider (Lcom/okta/authfoundation/client/ClientAssertionProvider;)Lcom/okta/directauth/jvm/DirectAuthenticationFlowBuilder;
 	public final fun setClientSecret (Ljava/lang/String;)Lcom/okta/directauth/jvm/DirectAuthenticationFlowBuilder;
 	public final fun setClock (Lcom/okta/authfoundation/client/OidcClock;)Lcom/okta/directauth/jvm/DirectAuthenticationFlowBuilder;
+	public final fun setComputeDispatcher (Lkotlin/coroutines/CoroutineContext;)Lcom/okta/directauth/jvm/DirectAuthenticationFlowBuilder;
 	public final fun setIntent (Lcom/okta/directauth/model/DirectAuthenticationIntent;)Lcom/okta/directauth/jvm/DirectAuthenticationFlowBuilder;
+	public final fun setLogger (Lcom/okta/authfoundation/api/log/AuthFoundationLogger;)Lcom/okta/directauth/jvm/DirectAuthenticationFlowBuilder;
 	public final fun setSupportedGrantTypes (Ljava/util/List;)Lcom/okta/directauth/jvm/DirectAuthenticationFlowBuilder;
 }
 

--- a/okta-direct-auth/api/okta-direct-auth.api
+++ b/okta-direct-auth/api/okta-direct-auth.api
@@ -6,8 +6,10 @@ public final class com/okta/directauth/DirectAuthenticationFlowBuilder {
 	public final fun getAdditionalParameter ()Ljava/util/Map;
 	public final fun getApiExecutor ()Lcom/okta/authfoundation/api/http/ApiExecutor;
 	public final fun getAuthorizationServerId ()Ljava/lang/String;
+	public final fun getClientAssertionProvider ()Lcom/okta/authfoundation/client/ClientAssertionProvider;
 	public final fun getClientSecret ()Ljava/lang/String;
 	public final fun getClock ()Lcom/okta/authfoundation/client/OidcClock;
+	public final fun getComputeDispatcher ()Lkotlin/coroutines/CoroutineContext;
 	public final fun getDirectAuthenticationIntent ()Lcom/okta/directauth/model/DirectAuthenticationIntent;
 	public final fun getLogger ()Lcom/okta/authfoundation/api/log/AuthFoundationLogger;
 	public final fun getSupportedGrantType ()Ljava/util/List;
@@ -15,8 +17,10 @@ public final class com/okta/directauth/DirectAuthenticationFlowBuilder {
 	public final fun setAdditionalParameter (Ljava/util/Map;)V
 	public final fun setApiExecutor (Lcom/okta/authfoundation/api/http/ApiExecutor;)V
 	public final fun setAuthorizationServerId (Ljava/lang/String;)V
+	public final fun setClientAssertionProvider (Lcom/okta/authfoundation/client/ClientAssertionProvider;)V
 	public final fun setClientSecret (Ljava/lang/String;)V
 	public final fun setClock (Lcom/okta/authfoundation/client/OidcClock;)V
+	public final fun setComputeDispatcher (Lkotlin/coroutines/CoroutineContext;)V
 	public final fun setDirectAuthenticationIntent (Lcom/okta/directauth/model/DirectAuthenticationIntent;)V
 	public final fun setLogger (Lcom/okta/authfoundation/api/log/AuthFoundationLogger;)V
 	public final fun setSupportedGrantType (Ljava/util/List;)V
@@ -56,11 +60,13 @@ public final class com/okta/directauth/http/DirectAuthStartRequest$DefaultImpls 
 }
 
 public abstract class com/okta/directauth/http/DirectAuthTokenRequest : com/okta/directauth/http/DirectAuthStartRequest {
-	public synthetic fun <init> (Lcom/okta/directauth/model/DirectAuthenticationContext;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lcom/okta/directauth/model/DirectAuthenticationContext;Lcom/okta/authfoundation/client/ClientAssertion;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lcom/okta/directauth/model/DirectAuthenticationContext;Lcom/okta/authfoundation/client/ClientAssertion;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun contentType ()Ljava/lang/String;
 	public fun headers ()Ljava/util/Map;
 	public fun method ()Lcom/okta/authfoundation/api/http/ApiRequestMethod;
 	public fun query ()Ljava/util/Map;
+	protected final fun sharedFormParameters ()Ljava/util/Map;
 	public fun url ()Ljava/lang/String;
 }
 

--- a/okta-direct-auth/build.gradle.kts
+++ b/okta-direct-auth/build.gradle.kts
@@ -155,3 +155,8 @@ binaryCompatValidationExtension {
     javaCompileTaskName.set("")
     ignoredClasses.add("com.okta.directauth.BuildInfo")
 }
+
+java {
+    sourceCompatibility = SOURCE_COMPATIBILITY
+    targetCompatibility = TARGET_COMPATIBILITY
+}

--- a/okta-direct-auth/src/commonMain/kotlin/com/okta/directauth/DirectAuthenticationFlowBuilder.kt
+++ b/okta-direct-auth/src/commonMain/kotlin/com/okta/directauth/DirectAuthenticationFlowBuilder.kt
@@ -21,6 +21,7 @@ import com.okta.authfoundation.api.http.ApiExecutor
 import com.okta.authfoundation.api.http.KtorHttpExecutor
 import com.okta.authfoundation.api.log.AuthFoundationLogger
 import com.okta.authfoundation.api.log.getDefaultAuthFoundationLogger
+import com.okta.authfoundation.client.ClientAssertionProvider
 import com.okta.authfoundation.client.OidcClock
 import com.okta.directauth.DirectAuthenticationFlowBuilder.Companion.create
 import com.okta.directauth.api.DirectAuthenticationFlow
@@ -28,6 +29,8 @@ import com.okta.directauth.model.DirectAuthenticationContext
 import com.okta.directauth.model.DirectAuthenticationIntent
 import io.ktor.http.URLProtocol
 import io.ktor.http.Url
+import kotlinx.coroutines.Dispatchers
+import kotlin.coroutines.CoroutineContext
 import kotlin.time.Clock
 
 /**
@@ -60,6 +63,26 @@ class DirectAuthenticationFlowBuilder private constructor() {
      * Defaults to an empty string.
      */
     var clientSecret: String = ""
+
+    /**
+     * Optional provider for private_key_jwt (or similar JWT-based) client authentication.
+     *
+     * Invoked fresh for every client-authenticated request this flow makes — including each
+     * iteration of an OOB poll — so the returned assertion can carry a unique `jti` and a
+     * correctly scoped, non-expired `exp`/`aud`. Mutually exclusive with [clientSecret].
+     *
+     * @see ClientAssertionProvider
+     */
+    var clientAssertionProvider: ClientAssertionProvider? = null
+
+    /**
+     * The dispatcher used for CPU-bound work, such as invoking [clientAssertionProvider].
+     *
+     * Defaults to [Dispatchers.Default]. If your [clientAssertionProvider] performs blocking I/O
+     * (e.g. a network call to a remote signer), set this to [Dispatchers.IO] or another
+     * IO-appropriate dispatcher.
+     */
+    var computeDispatcher: CoroutineContext = Dispatchers.Default
 
     /**
      * The intended user action for the authentication flow.
@@ -157,6 +180,9 @@ class DirectAuthenticationFlowBuilder private constructor() {
 
                 require(clientId.isNotBlank()) { "clientId must be set and not empty." }
                 require(scope.isNotEmpty()) { "scope must be set and not empty." }
+                require(builder.clientSecret.isBlank() || builder.clientAssertionProvider == null) {
+                    "clientSecret cannot be combined with clientAssertionProvider."
+                }
 
                 Result.success(
                     DirectAuthenticationFlowImpl(
@@ -166,6 +192,8 @@ class DirectAuthenticationFlowBuilder private constructor() {
                             scope,
                             builder.authorizationServerId,
                             builder.clientSecret,
+                            builder.clientAssertionProvider,
+                            builder.computeDispatcher,
                             builder.supportedGrantType,
                             builder.acrValues,
                             builder.directAuthenticationIntent,

--- a/okta-direct-auth/src/commonMain/kotlin/com/okta/directauth/DirectAuthenticationFlowImpl.kt
+++ b/okta-direct-auth/src/commonMain/kotlin/com/okta/directauth/DirectAuthenticationFlowImpl.kt
@@ -28,6 +28,8 @@ import com.okta.directauth.model.DirectAuthenticationContext
 import com.okta.directauth.model.DirectAuthenticationError
 import com.okta.directauth.model.DirectAuthenticationState
 import com.okta.directauth.model.PrimaryFactor
+import com.okta.directauth.model.endpointUrl
+import com.okta.directauth.model.resolveClientAssertion
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlin.coroutines.cancellation.CancellationException
@@ -35,12 +37,27 @@ import kotlin.coroutines.cancellation.CancellationException
 internal class DirectAuthenticationFlowImpl(
     internal val context: DirectAuthenticationContext,
 ) : DirectAuthenticationFlow {
-    private fun PrimaryFactor.startRequest(loginHint: String): StepHandler =
+    private suspend fun PrimaryFactor.startRequest(loginHint: String): StepHandler =
         when (this) {
-            is PrimaryFactor.Password -> TokenStepHandler(DirectAuthTokenRequest.Password(context, loginHint, password), context)
-            is PrimaryFactor.Oob -> OobStepHandler(DirectAuthOobAuthenticateRequest(context, loginHint, channel), context)
-            is PrimaryFactor.Otp -> TokenStepHandler(DirectAuthTokenRequest.Otp(context, loginHint, passCode), context)
-            PrimaryFactor.WebAuthn -> PrimaryAuthenticateStepHandler(DirectAuthPrimaryAuthenticateRequest(context, loginHint), context)
+            is PrimaryFactor.Password -> {
+                val clientAssertion = context.resolveClientAssertion(context.endpointUrl("token"))
+                TokenStepHandler(DirectAuthTokenRequest.Password(context, loginHint, password, clientAssertion), context)
+            }
+
+            is PrimaryFactor.Oob -> {
+                val clientAssertion = context.resolveClientAssertion(context.endpointUrl("oob-authenticate"))
+                OobStepHandler(DirectAuthOobAuthenticateRequest(context, loginHint, channel, clientAssertion), context)
+            }
+
+            is PrimaryFactor.Otp -> {
+                val clientAssertion = context.resolveClientAssertion(context.endpointUrl("token"))
+                TokenStepHandler(DirectAuthTokenRequest.Otp(context, loginHint, passCode, clientAssertion), context)
+            }
+
+            PrimaryFactor.WebAuthn -> {
+                val clientAssertion = context.resolveClientAssertion(context.endpointUrl("primary-authenticate"))
+                PrimaryAuthenticateStepHandler(DirectAuthPrimaryAuthenticateRequest(context, loginHint, clientAssertion), context)
+            }
         }
 
     override val authenticationState: StateFlow<DirectAuthenticationState> = context.authenticationStateFlow.asStateFlow()

--- a/okta-direct-auth/src/commonMain/kotlin/com/okta/directauth/http/DirectAuthChallengeRequest.kt
+++ b/okta-direct-auth/src/commonMain/kotlin/com/okta/directauth/http/DirectAuthChallengeRequest.kt
@@ -17,19 +17,21 @@ package com.okta.directauth.http
 
 import com.okta.authfoundation.ChallengeGrantType
 import com.okta.authfoundation.api.http.ApiRequestMethod
+import com.okta.authfoundation.client.ClientAssertion
 import com.okta.directauth.model.DirectAuthenticationContext
 import com.okta.directauth.model.MfaContext
 import com.okta.directauth.model.OobChannel
+import com.okta.directauth.model.clientAuthenticationFormParameters
+import com.okta.directauth.model.endpointUrl
 
 internal class DirectAuthChallengeRequest(
     internal val context: DirectAuthenticationContext,
     private val mfaContext: MfaContext,
     private val challengeTypesSupported: List<ChallengeGrantType>,
     private val oobChannel: OobChannel?,
+    private val clientAssertion: ClientAssertion? = null,
 ) : DirectAuthRequest {
-    private val path = if (context.authorizationServerId.isBlank()) "/oauth2/v1/challenge" else "/oauth2/${context.authorizationServerId}/v1/challenge"
-
-    override fun url(): String = context.issuerUrl.trimEnd('/') + path
+    override fun url(): String = context.endpointUrl("challenge")
 
     override fun method(): ApiRequestMethod = ApiRequestMethod.POST
 
@@ -39,7 +41,7 @@ internal class DirectAuthChallengeRequest(
 
     override fun formParameters(): Map<String, List<String>> =
         buildMap {
-            if (context.clientSecret.isNotBlank()) put("client_secret", listOf(context.clientSecret))
+            putAll(context.clientAuthenticationFormParameters(clientAssertion))
             put("client_id", listOf(context.clientId))
             put("mfa_token", listOf(mfaContext.mfaToken))
             put("challenge_types_supported", listOf(challengeTypesSupported.joinToString(" ") { it.value }))

--- a/okta-direct-auth/src/commonMain/kotlin/com/okta/directauth/http/DirectAuthOobAuthenticateRequest.kt
+++ b/okta-direct-auth/src/commonMain/kotlin/com/okta/directauth/http/DirectAuthOobAuthenticateRequest.kt
@@ -16,17 +16,19 @@
 package com.okta.directauth.http
 
 import com.okta.authfoundation.api.http.ApiRequestMethod
+import com.okta.authfoundation.client.ClientAssertion
 import com.okta.directauth.model.DirectAuthenticationContext
 import com.okta.directauth.model.OobChannel
+import com.okta.directauth.model.clientAuthenticationFormParameters
+import com.okta.directauth.model.endpointUrl
 
 internal class DirectAuthOobAuthenticateRequest(
     internal val context: DirectAuthenticationContext,
     val loginHint: String,
     val oobChannel: OobChannel,
+    private val clientAssertion: ClientAssertion? = null,
 ) : DirectAuthStartRequest {
-    private val path = if (context.authorizationServerId.isBlank()) "/oauth2/v1/oob-authenticate" else "/oauth2/${context.authorizationServerId}/v1/oob-authenticate"
-
-    override fun url(): String = context.issuerUrl.trimEnd('/') + path
+    override fun url(): String = context.endpointUrl("oob-authenticate")
 
     override fun method(): ApiRequestMethod = ApiRequestMethod.POST
 
@@ -36,7 +38,7 @@ internal class DirectAuthOobAuthenticateRequest(
 
     override fun formParameters(): Map<String, List<String>> =
         buildMap {
-            if (context.clientSecret.isNotBlank()) put("client_secret", listOf(context.clientSecret))
+            putAll(context.clientAuthenticationFormParameters(clientAssertion))
             put("client_id", listOf(context.clientId))
             put("login_hint", listOf(loginHint))
             put("channel_hint", listOf(oobChannel.value))

--- a/okta-direct-auth/src/commonMain/kotlin/com/okta/directauth/http/DirectAuthPrimaryAuthenticateRequest.kt
+++ b/okta-direct-auth/src/commonMain/kotlin/com/okta/directauth/http/DirectAuthPrimaryAuthenticateRequest.kt
@@ -17,7 +17,10 @@ package com.okta.directauth.http
 
 import com.okta.authfoundation.GrantType
 import com.okta.authfoundation.api.http.ApiRequestMethod
+import com.okta.authfoundation.client.ClientAssertion
 import com.okta.directauth.model.DirectAuthenticationContext
+import com.okta.directauth.model.clientAuthenticationFormParameters
+import com.okta.directauth.model.endpointUrl
 
 /**
  * HTTP request to the `/primary-authenticate` endpoint for primary WebAuthn flows.
@@ -28,15 +31,9 @@ import com.okta.directauth.model.DirectAuthenticationContext
 internal class DirectAuthPrimaryAuthenticateRequest(
     internal val context: DirectAuthenticationContext,
     val loginHint: String? = null,
+    private val clientAssertion: ClientAssertion? = null,
 ) : DirectAuthStartRequest {
-    private val path =
-        if (context.authorizationServerId.isBlank()) {
-            "/oauth2/v1/primary-authenticate"
-        } else {
-            "/oauth2/${context.authorizationServerId}/v1/primary-authenticate"
-        }
-
-    override fun url(): String = context.issuerUrl.trimEnd('/') + path
+    override fun url(): String = context.endpointUrl("primary-authenticate")
 
     override fun method(): ApiRequestMethod = ApiRequestMethod.POST
 
@@ -46,7 +43,7 @@ internal class DirectAuthPrimaryAuthenticateRequest(
 
     override fun formParameters(): Map<String, List<String>> =
         buildMap {
-            if (context.clientSecret.isNotBlank()) put("client_secret", listOf(context.clientSecret))
+            putAll(context.clientAuthenticationFormParameters(clientAssertion))
             put("client_id", listOf(context.clientId))
             put("challenge_hint", listOf(GrantType.WebAuthn.value))
             loginHint?.let { put("login_hint", listOf(it)) }

--- a/okta-direct-auth/src/commonMain/kotlin/com/okta/directauth/http/DirectAuthTokenRequest.kt
+++ b/okta-direct-auth/src/commonMain/kotlin/com/okta/directauth/http/DirectAuthTokenRequest.kt
@@ -18,17 +18,19 @@ package com.okta.directauth.http
 import com.okta.authfoundation.ChallengeGrantType
 import com.okta.authfoundation.GrantType
 import com.okta.authfoundation.api.http.ApiRequestMethod
+import com.okta.authfoundation.client.ClientAssertion
 import com.okta.directauth.model.DirectAuthenticationContext
 import com.okta.directauth.model.DirectAuthenticationIntent
 import com.okta.directauth.model.MfaContext
 import com.okta.directauth.model.WebAuthnAssertionResponse
+import com.okta.directauth.model.clientAuthenticationFormParameters
+import com.okta.directauth.model.endpointUrl
 
 sealed class DirectAuthTokenRequest(
     internal val context: DirectAuthenticationContext,
+    private val clientAssertion: ClientAssertion? = null,
 ) : DirectAuthStartRequest {
-    private val path = if (context.authorizationServerId.isBlank()) "/oauth2/v1/token" else "/oauth2/${context.authorizationServerId}/v1/token"
-
-    override fun url(): String = context.issuerUrl.trimEnd('/') + path
+    override fun url(): String = context.endpointUrl("token")
 
     override fun method(): ApiRequestMethod = ApiRequestMethod.POST
 
@@ -36,25 +38,26 @@ sealed class DirectAuthTokenRequest(
 
     override fun query(): Map<String, String>? = context.additionalParameters.takeIf { it.isNotEmpty() }
 
-    internal fun DirectAuthenticationContext.formParameters(): Map<String, List<String>> =
+    protected fun sharedFormParameters(): Map<String, List<String>> =
         buildMap {
-            put("client_id", listOf(clientId))
-            if (directAuthenticationIntent == DirectAuthenticationIntent.RECOVERY) {
+            put("client_id", listOf(context.clientId))
+            putAll(context.clientAuthenticationFormParameters(clientAssertion))
+            if (context.directAuthenticationIntent == DirectAuthenticationIntent.RECOVERY) {
                 put("prompt", listOf("recover_authenticator"))
             }
-            put("scope", listOf(scope.joinToString(" ")))
-            put("grant_types_supported", listOf(grantTypes.joinToString(" ") { it.value }))
+            put("scope", listOf(context.scope.joinToString(" ")))
+            put("grant_types_supported", listOf(context.grantTypes.joinToString(" ") { it.value }))
         }
 
     class Password internal constructor(
         context: DirectAuthenticationContext,
         private val username: String,
         private val password: String,
-    ) : DirectAuthTokenRequest(context) {
+        clientAssertion: ClientAssertion? = null,
+    ) : DirectAuthTokenRequest(context, clientAssertion) {
         override fun formParameters(): Map<String, List<String>> =
             buildMap {
-                putAll(context.formParameters())
-                if (context.clientSecret.isNotBlank()) put("client_secret", listOf(context.clientSecret))
+                putAll(sharedFormParameters())
                 put("grant_type", listOf(GrantType.Password.value))
                 put("username", listOf(username))
                 put("password", listOf(password))
@@ -65,11 +68,11 @@ sealed class DirectAuthTokenRequest(
         context: DirectAuthenticationContext,
         private val loginHint: String,
         private val otp: String,
-    ) : DirectAuthTokenRequest(context) {
+        clientAssertion: ClientAssertion? = null,
+    ) : DirectAuthTokenRequest(context, clientAssertion) {
         override fun formParameters(): Map<String, List<String>> =
             buildMap {
-                putAll(context.formParameters())
-                if (context.clientSecret.isNotBlank()) put("client_secret", listOf(context.clientSecret))
+                putAll(sharedFormParameters())
                 put("grant_type", listOf(GrantType.Otp.value))
                 put("login_hint", listOf(loginHint))
                 put("otp", listOf(otp))
@@ -80,11 +83,11 @@ sealed class DirectAuthTokenRequest(
         context: DirectAuthenticationContext,
         private val otp: String,
         private val mfaContext: MfaContext,
-    ) : DirectAuthTokenRequest(context) {
+        clientAssertion: ClientAssertion? = null,
+    ) : DirectAuthTokenRequest(context, clientAssertion) {
         override fun formParameters(): Map<String, List<String>> =
             buildMap {
-                putAll(context.formParameters())
-                if (context.clientSecret.isNotBlank()) put("client_secret", listOf(context.clientSecret))
+                putAll(sharedFormParameters())
                 put("grant_type", listOf(ChallengeGrantType.OtpMfa.value))
                 put("mfa_token", listOf(mfaContext.mfaToken))
                 put("otp", listOf(otp))
@@ -95,11 +98,11 @@ sealed class DirectAuthTokenRequest(
         context: DirectAuthenticationContext,
         private val oobCode: String,
         private val bindingCode: String? = null,
-    ) : DirectAuthTokenRequest(context) {
+        clientAssertion: ClientAssertion? = null,
+    ) : DirectAuthTokenRequest(context, clientAssertion) {
         override fun formParameters(): Map<String, List<String>> =
             buildMap {
-                putAll(context.formParameters())
-                if (context.clientSecret.isNotBlank()) put("client_secret", listOf(context.clientSecret))
+                putAll(sharedFormParameters())
                 put("grant_type", listOf(GrantType.Oob.value))
                 put("oob_code", listOf(oobCode))
                 bindingCode?.let { put("binding_code", listOf(it)) }
@@ -111,11 +114,11 @@ sealed class DirectAuthTokenRequest(
         private val oobCode: String,
         private val mfaContext: MfaContext,
         private val bindingCode: String? = null,
-    ) : DirectAuthTokenRequest(context) {
+        clientAssertion: ClientAssertion? = null,
+    ) : DirectAuthTokenRequest(context, clientAssertion) {
         override fun formParameters(): Map<String, List<String>> =
             buildMap {
-                putAll(context.formParameters())
-                if (context.clientSecret.isNotBlank()) put("client_secret", listOf(context.clientSecret))
+                putAll(sharedFormParameters())
                 put("grant_type", listOf(ChallengeGrantType.OobMfa.value))
                 put("mfa_token", listOf(mfaContext.mfaToken))
                 put("oob_code", listOf(oobCode))
@@ -126,10 +129,11 @@ sealed class DirectAuthTokenRequest(
     class WebAuthn internal constructor(
         context: DirectAuthenticationContext,
         private val assertionResponse: WebAuthnAssertionResponse,
-    ) : DirectAuthTokenRequest(context) {
+        clientAssertion: ClientAssertion? = null,
+    ) : DirectAuthTokenRequest(context, clientAssertion) {
         override fun formParameters(): Map<String, List<String>> =
             buildMap {
-                putAll(context.formParameters())
+                putAll(sharedFormParameters())
                 put("grant_type", listOf(GrantType.WebAuthn.value))
                 put("authenticatorData", listOf(assertionResponse.authenticatorData))
                 put("clientDataJSON", listOf(assertionResponse.clientDataJSON))
@@ -142,10 +146,11 @@ sealed class DirectAuthTokenRequest(
         context: DirectAuthenticationContext,
         private val mfaContext: MfaContext,
         private val assertionResponse: WebAuthnAssertionResponse,
-    ) : DirectAuthTokenRequest(context) {
+        clientAssertion: ClientAssertion? = null,
+    ) : DirectAuthTokenRequest(context, clientAssertion) {
         override fun formParameters(): Map<String, List<String>> =
             buildMap {
-                putAll(context.formParameters())
+                putAll(sharedFormParameters())
                 put("mfa_token", listOf(mfaContext.mfaToken))
                 put("grant_type", listOf(ChallengeGrantType.WebAuthnMfa.value))
                 put("authenticatorData", listOf(assertionResponse.authenticatorData))

--- a/okta-direct-auth/src/commonMain/kotlin/com/okta/directauth/model/DirectAuthContinuation.kt
+++ b/okta-direct-auth/src/commonMain/kotlin/com/okta/directauth/model/DirectAuthContinuation.kt
@@ -68,10 +68,11 @@ sealed class DirectAuthContinuation(
             runCatching {
                 withTimeout(bindingContext.expiresIn.seconds) {
                     while (isActive) {
+                        val clientAssertion = context.resolveClientAssertion(context.endpointUrl("token"))
                         val request =
                             mfaContext?.let {
-                                DirectAuthTokenRequest.OobMfa(context, bindingContext.oobCode, it)
-                            } ?: DirectAuthTokenRequest.Oob(context, bindingContext.oobCode)
+                                DirectAuthTokenRequest.OobMfa(context, bindingContext.oobCode, it, clientAssertion = clientAssertion)
+                            } ?: DirectAuthTokenRequest.Oob(context, bindingContext.oobCode, clientAssertion = clientAssertion)
 
                         val currentState = TokenStepHandler(request, context).process()
 
@@ -173,10 +174,11 @@ sealed class DirectAuthContinuation(
          * @return The next [DirectAuthenticationState] in the flow.
          */
         suspend fun proceed(assertionResponse: WebAuthnAssertionResponse): DirectAuthenticationState {
+            val clientAssertion = context.resolveClientAssertion(context.endpointUrl("token"))
             val request =
                 mfaContext?.let {
-                    DirectAuthTokenRequest.WebAuthnMfa(context, mfaContext, assertionResponse)
-                } ?: DirectAuthTokenRequest.WebAuthn(context, assertionResponse)
+                    DirectAuthTokenRequest.WebAuthnMfa(context, mfaContext, assertionResponse, clientAssertion)
+                } ?: DirectAuthTokenRequest.WebAuthn(context, assertionResponse, clientAssertion)
 
             val result =
                 runCatching { TokenStepHandler(request, context).process() }.getOrElse {
@@ -216,10 +218,11 @@ sealed class DirectAuthContinuation(
          * @return The next [DirectAuthenticationState] in the flow.
          */
         suspend fun proceed(code: String): DirectAuthenticationState {
+            val clientAssertion = context.resolveClientAssertion(context.endpointUrl("token"))
             val request =
                 mfaContext?.let {
-                    DirectAuthTokenRequest.OobMfa(context, bindingContext.oobCode, it, code)
-                } ?: DirectAuthTokenRequest.Oob(context, bindingContext.oobCode, code)
+                    DirectAuthTokenRequest.OobMfa(context, bindingContext.oobCode, it, code, clientAssertion)
+                } ?: DirectAuthTokenRequest.Oob(context, bindingContext.oobCode, code, clientAssertion)
 
             val result =
                 runCatching { TokenStepHandler(request, context).process() }.getOrElse {

--- a/okta-direct-auth/src/commonMain/kotlin/com/okta/directauth/model/DirectAuthenticationContext.kt
+++ b/okta-direct-auth/src/commonMain/kotlin/com/okta/directauth/model/DirectAuthenticationContext.kt
@@ -18,9 +18,14 @@ package com.okta.directauth.model
 import com.okta.authfoundation.GrantType
 import com.okta.authfoundation.api.http.ApiExecutor
 import com.okta.authfoundation.api.log.AuthFoundationLogger
+import com.okta.authfoundation.client.ClientAssertion
+import com.okta.authfoundation.client.ClientAssertionProvider
 import com.okta.authfoundation.client.OidcClock
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
+import kotlin.coroutines.CoroutineContext
 
 internal data class DirectAuthenticationContext(
     val issuerUrl: String,
@@ -28,6 +33,8 @@ internal data class DirectAuthenticationContext(
     val scope: List<String>,
     val authorizationServerId: String,
     val clientSecret: String,
+    val clientAssertionProvider: ClientAssertionProvider? = null,
+    val computeDispatcher: CoroutineContext = Dispatchers.Default,
     val grantTypes: List<GrantType>,
     val acrValues: List<String>,
     val directAuthenticationIntent: DirectAuthenticationIntent,
@@ -45,4 +52,53 @@ internal data class DirectAuthenticationContext(
         }
 
     val authenticationStateFlow: MutableStateFlow<DirectAuthenticationState> = MutableStateFlow(DirectAuthenticationState.Idle)
+
+    override fun toString(): String =
+        "DirectAuthenticationContext(issuerUrl=$issuerUrl, clientId=$clientId, scope=$scope, " +
+            "authorizationServerId=$authorizationServerId, clientSecret=***, " +
+            "clientAssertionProvider=${clientAssertionProvider?.let { "***" }}, grantTypes=$grantTypes, " +
+            "acrValues=$acrValues, directAuthenticationIntent=$directAuthenticationIntent, " +
+            "additionalParameters=$additionalParameters)"
 }
+
+/**
+ * Resolves a fresh [ClientAssertion] from [DirectAuthenticationContext.clientAssertionProvider] for
+ * the given [audience] (the endpoint URL of the request about to be sent), or `null` if no provider
+ * is configured.
+ *
+ * Invoked anew for every client-authenticated request — including each iteration of an OOB poll —
+ * so the returned assertion can carry a unique `jti` and a correctly scoped, non-expired `exp`/`aud`.
+ * Never cache or reuse the result across requests.
+ */
+internal suspend fun DirectAuthenticationContext.resolveClientAssertion(audience: String): ClientAssertion? =
+    clientAssertionProvider?.let { provider -> withContext(computeDispatcher) { provider.provide(audience) } }
+
+/**
+ * Builds the `client_secret` or `client_assertion_type`/`client_assertion` form parameters for a
+ * request, preferring [clientAssertion] (from [resolveClientAssertion]) over
+ * [DirectAuthenticationContext.clientSecret].
+ */
+internal fun DirectAuthenticationContext.clientAuthenticationFormParameters(clientAssertion: ClientAssertion?): Map<String, List<String>> =
+    when {
+        clientAssertion != null -> {
+            mapOf(
+                "client_assertion_type" to listOf(clientAssertion.type),
+                "client_assertion" to listOf(clientAssertion.assertion)
+            )
+        }
+
+        clientSecret.isNotBlank() -> {
+            mapOf("client_secret" to listOf(clientSecret))
+        }
+
+        else -> {
+            emptyMap()
+        }
+    }
+
+/**
+ * The full URL for a Direct Authentication endpoint, honoring
+ * [DirectAuthenticationContext.authorizationServerId] when set.
+ */
+internal fun DirectAuthenticationContext.endpointUrl(pathSuffix: String): String =
+    issuerUrl.trimEnd('/') + if (authorizationServerId.isBlank()) "/oauth2/v1/$pathSuffix" else "/oauth2/$authorizationServerId/v1/$pathSuffix"

--- a/okta-direct-auth/src/commonMain/kotlin/com/okta/directauth/model/DirectAuthenticationState.kt
+++ b/okta-direct-auth/src/commonMain/kotlin/com/okta/directauth/model/DirectAuthenticationState.kt
@@ -106,7 +106,8 @@ sealed interface DirectAuthenticationState {
             challengeTypesSupported: List<ChallengeGrantType> = listOf(WebAuthnMfa, OobMfa, OtpMfa),
         ): DirectAuthenticationState {
             val channel = if (secondaryFactor is PrimaryFactor.Oob) secondaryFactor.channel else null
-            val request = DirectAuthChallengeRequest(context, mfaContext, challengeTypesSupported, channel)
+            val clientAssertion = context.resolveClientAssertion(context.endpointUrl("challenge"))
+            val request = DirectAuthChallengeRequest(context, mfaContext, challengeTypesSupported, channel, clientAssertion)
 
             val result =
                 runCatching { ChallengeStepHandler(request, context, mfaContext).process() }.getOrElse {
@@ -145,7 +146,8 @@ sealed interface DirectAuthenticationState {
                 runCatching {
                     when (secondaryFactor) {
                         is PrimaryFactor.Otp -> {
-                            val request = DirectAuthTokenRequest.MfaOtp(context.copy(grantTypes = challengeTypesSupported), secondaryFactor.passCode, mfaContext)
+                            val clientAssertion = context.resolveClientAssertion(context.endpointUrl("token"))
+                            val request = DirectAuthTokenRequest.MfaOtp(context.copy(grantTypes = challengeTypesSupported), secondaryFactor.passCode, mfaContext, clientAssertion)
                             TokenStepHandler(request, context).process()
                         }
 

--- a/okta-direct-auth/src/commonTest/kotlin/com/okta/directauth/DirectAuthenticationFlowBuilderTest.kt
+++ b/okta-direct-auth/src/commonTest/kotlin/com/okta/directauth/DirectAuthenticationFlowBuilderTest.kt
@@ -22,11 +22,15 @@ import com.okta.authfoundation.api.http.ApiRequest
 import com.okta.authfoundation.api.http.ApiResponse
 import com.okta.authfoundation.api.log.AuthFoundationLogger
 import com.okta.authfoundation.api.log.LogLevel
+import com.okta.authfoundation.client.ClientAssertion
+import com.okta.authfoundation.client.ClientAssertionProvider
 import com.okta.authfoundation.client.OidcClock
 import com.okta.directauth.model.DirectAuthenticationIntent
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class DirectAuthenticationFlowBuilderTest {
@@ -149,5 +153,47 @@ class DirectAuthenticationFlowBuilderTest {
 
         assertIs<IllegalArgumentException>(exception)
         assertEquals("scope must be set and not empty.", exception.message)
+    }
+
+    @Test
+    fun create_withClientSecretAndAssertionProvider_returnsFailure() {
+        val result =
+            DirectAuthenticationFlowBuilder.create(issuerUrl, clientId, scope) {
+                clientSecret = "custom_secret"
+                clientAssertionProvider = ClientAssertionProvider { ClientAssertion("urn:ietf:params:oauth:client-assertion-type:jwt-bearer", "signed-jwt") }
+            }
+
+        assertTrue(result.isFailure)
+        assertEquals(
+            "clientSecret cannot be combined with clientAssertionProvider.",
+            result.exceptionOrNull()?.message
+        )
+    }
+
+    @Test
+    fun create_withClientAssertionProvider_usesCustomValue() {
+        val customProvider = ClientAssertionProvider { audience -> ClientAssertion("urn:ietf:params:oauth:client-assertion-type:jwt-bearer", "signed-jwt-for-$audience") }
+
+        val result =
+            DirectAuthenticationFlowBuilder.create(issuerUrl, clientId, scope) {
+                clientAssertionProvider = customProvider
+            }
+
+        assertTrue(result.isSuccess)
+
+        val flow = result.getOrThrow() as DirectAuthenticationFlowImpl
+        val context = flow.context
+
+        assertSame(customProvider, context.clientAssertionProvider)
+        assertEquals("", context.clientSecret)
+    }
+
+    @Test
+    fun create_withRequiredParameters_hasNoClientAssertionProviderByDefault() {
+        val result = DirectAuthenticationFlowBuilder.create(issuerUrl, clientId, scope)
+        assertTrue(result.isSuccess)
+
+        val flow = result.getOrThrow() as DirectAuthenticationFlowImpl
+        assertNull(flow.context.clientAssertionProvider)
     }
 }

--- a/okta-direct-auth/src/commonTest/kotlin/com/okta/directauth/http/DirectAuthChallengeRequestTest.kt
+++ b/okta-direct-auth/src/commonTest/kotlin/com/okta/directauth/http/DirectAuthChallengeRequestTest.kt
@@ -21,6 +21,7 @@ import com.okta.authfoundation.api.http.ApiRequestMethod
 import com.okta.authfoundation.api.http.KtorHttpExecutor
 import com.okta.authfoundation.api.log.AuthFoundationLogger
 import com.okta.authfoundation.api.log.LogLevel
+import com.okta.authfoundation.client.ClientAssertion
 import com.okta.directauth.model.DirectAuthenticationContext
 import com.okta.directauth.model.DirectAuthenticationIntent
 import com.okta.directauth.model.MfaContext
@@ -130,5 +131,26 @@ class DirectAuthChallengeRequestTest {
         assertEquals(listOf("test_mfa_token"), formParameters["mfa_token"])
         assertEquals(listOf("${ChallengeGrantType.OobMfa.value} ${ChallengeGrantType.OtpMfa.value} ${ChallengeGrantType.WebAuthnMfa.value}"), formParameters["challenge_types_supported"])
         assertEquals(listOf("push"), formParameters["channel_hint"])
+    }
+
+    @Test
+    fun challengeRequest_WithClientAssertionParameters() {
+        val assertionContext = context.copy(clientSecret = "")
+        val clientAssertion = ClientAssertion("urn:ietf:params:oauth:client-assertion-type:jwt-bearer", "test-signed-jwt")
+
+        val mfaContext = MfaContext(listOf(ChallengeGrantType.OobMfa, ChallengeGrantType.OtpMfa), "test_mfa_token")
+        val request =
+            DirectAuthChallengeRequest(
+                context = assertionContext,
+                mfaContext = mfaContext,
+                challengeTypesSupported = listOf(ChallengeGrantType.OobMfa, ChallengeGrantType.OtpMfa),
+                oobChannel = null,
+                clientAssertion = clientAssertion
+            )
+
+        val formParameters = request.formParameters()
+        assertEquals(listOf("urn:ietf:params:oauth:client-assertion-type:jwt-bearer"), formParameters["client_assertion_type"])
+        assertEquals(listOf("test-signed-jwt"), formParameters["client_assertion"])
+        assertFalse(formParameters.containsKey("client_secret"))
     }
 }

--- a/okta-direct-auth/src/commonTest/kotlin/com/okta/directauth/http/DirectAuthOobAuthenticateRequestTest.kt
+++ b/okta-direct-auth/src/commonTest/kotlin/com/okta/directauth/http/DirectAuthOobAuthenticateRequestTest.kt
@@ -20,6 +20,7 @@ import com.okta.authfoundation.api.http.ApiRequestMethod
 import com.okta.authfoundation.api.http.KtorHttpExecutor
 import com.okta.authfoundation.api.log.AuthFoundationLogger
 import com.okta.authfoundation.api.log.LogLevel
+import com.okta.authfoundation.client.ClientAssertion
 import com.okta.directauth.http.handlers.OobStepHandler
 import com.okta.directauth.model.BindingMethod
 import com.okta.directauth.model.DirectAuthContinuation
@@ -128,6 +129,25 @@ class DirectAuthOobAuthenticateRequestTest {
         assertEquals(listOf("test_user"), formParameters["login_hint"])
         assertEquals(listOf("sms"), formParameters["channel_hint"])
         assertEquals(listOf("test_client_secret"), formParameters["client_secret"])
+    }
+
+    @Test
+    fun oobAuthenticateRequest_WithClientAssertionUsesAssertionParameters() {
+        val customContext = context.copy(clientSecret = "")
+        val clientAssertion = ClientAssertion("urn:ietf:params:oauth:client-assertion-type:jwt-bearer", "test-signed-jwt")
+
+        val request =
+            DirectAuthOobAuthenticateRequest(
+                context = customContext,
+                loginHint = "test_user",
+                oobChannel = OobChannel.SMS,
+                clientAssertion = clientAssertion
+            )
+
+        val formParameters = request.formParameters()
+        assertEquals(listOf("urn:ietf:params:oauth:client-assertion-type:jwt-bearer"), formParameters["client_assertion_type"])
+        assertEquals(listOf("test-signed-jwt"), formParameters["client_assertion"])
+        assertFalse(formParameters.containsKey("client_secret"))
     }
 
     @Test

--- a/okta-direct-auth/src/commonTest/kotlin/com/okta/directauth/http/DirectAuthPrimaryAuthenticateRequestTest.kt
+++ b/okta-direct-auth/src/commonTest/kotlin/com/okta/directauth/http/DirectAuthPrimaryAuthenticateRequestTest.kt
@@ -20,6 +20,7 @@ import com.okta.authfoundation.api.http.ApiRequestMethod
 import com.okta.authfoundation.api.http.KtorHttpExecutor
 import com.okta.authfoundation.api.log.AuthFoundationLogger
 import com.okta.authfoundation.api.log.LogLevel
+import com.okta.authfoundation.client.ClientAssertion
 import com.okta.directauth.http.handlers.PrimaryAuthenticateStepHandler
 import com.okta.directauth.model.DirectAuthContinuation
 import com.okta.directauth.model.DirectAuthenticationContext
@@ -104,6 +105,18 @@ class DirectAuthPrimaryAuthenticateRequestTest {
         assertEquals(listOf("test_secret"), formParameters["client_secret"])
         assertEquals(listOf("test_client_id"), formParameters["client_id"])
         assertEquals(listOf("test_user"), formParameters["login_hint"])
+    }
+
+    @Test
+    fun primaryAuthenticateRequest_withClientAssertionUsesAssertionParameters() {
+        val customContext = context.copy(clientSecret = "")
+        val clientAssertion = ClientAssertion("urn:ietf:params:oauth:client-assertion-type:jwt-bearer", "test-signed-jwt")
+        val request = DirectAuthPrimaryAuthenticateRequest(customContext, "test_user", clientAssertion)
+
+        val formParameters = request.formParameters()
+        assertEquals(listOf("urn:ietf:params:oauth:client-assertion-type:jwt-bearer"), formParameters["client_assertion_type"])
+        assertEquals(listOf("test-signed-jwt"), formParameters["client_assertion"])
+        assertFalse(formParameters.containsKey("client_secret"))
     }
 
     @Test

--- a/okta-direct-auth/src/commonTest/kotlin/com/okta/directauth/http/DirectAuthTokenRequestTest.kt
+++ b/okta-direct-auth/src/commonTest/kotlin/com/okta/directauth/http/DirectAuthTokenRequestTest.kt
@@ -21,6 +21,7 @@ import com.okta.authfoundation.api.http.ApiRequestMethod
 import com.okta.authfoundation.api.http.KtorHttpExecutor
 import com.okta.authfoundation.api.log.AuthFoundationLogger
 import com.okta.authfoundation.api.log.LogLevel
+import com.okta.authfoundation.client.ClientAssertion
 import com.okta.directauth.apiErrorClientMockEngine
 import com.okta.directauth.authorizationPendingMockEngine
 import com.okta.directauth.emptyResponseMockEngine
@@ -142,6 +143,24 @@ class DirectAuthTokenRequestTest {
         assertEquals(listOf(GrantType.Password.value), formParameters["grant_type"])
         assertEquals(listOf("test_user"), formParameters["username"])
         assertEquals(listOf("test_password"), formParameters["password"])
+    }
+
+    @Test
+    fun passwordRequest_usesClientAssertionInsteadOfClientSecret() {
+        val assertionContext = context.copy(clientSecret = "")
+        val clientAssertion = ClientAssertion("urn:ietf:params:oauth:client-assertion-type:jwt-bearer", "test-signed-jwt")
+        val request =
+            DirectAuthTokenRequest.Password(
+                context = assertionContext,
+                username = "test_user",
+                password = "test_password",
+                clientAssertion = clientAssertion
+            )
+
+        val formParameters = request.formParameters()
+        assertEquals(listOf("urn:ietf:params:oauth:client-assertion-type:jwt-bearer"), formParameters["client_assertion_type"])
+        assertEquals(listOf("test-signed-jwt"), formParameters["client_assertion"])
+        assertFalse(formParameters.containsKey("client_secret"))
     }
 
     @Test

--- a/okta-direct-auth/src/commonTest/kotlin/com/okta/directauth/model/DirectAuthContinuationOobPendingStateTest.kt
+++ b/okta-direct-auth/src/commonTest/kotlin/com/okta/directauth/model/DirectAuthContinuationOobPendingStateTest.kt
@@ -34,6 +34,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -128,6 +129,7 @@ class DirectAuthContinuationOobPendingStateTest {
     fun `poll returns Authenticated after one pending response`() {
         val mockEngine = MockEngine.Queue()
         val collectedValues = mutableListOf<DirectAuthenticationState>()
+        val flowFinished = CompletableDeferred<Unit>()
 
         mockEngine.enqueue { respond(AUTHORIZATION_PENDING_JSON, HttpStatusCode.BadRequest, contentType) }
         mockEngine.enqueue { respond(TOKEN_RESPONSE_JSON, HttpStatusCode.OK, contentType) }
@@ -138,10 +140,16 @@ class DirectAuthContinuationOobPendingStateTest {
             CoroutineScope(Dispatchers.Default).launch {
                 context.authenticationStateFlow.collect { value ->
                     if (value !is DirectAuthenticationState.Idle) collectedValues.add(value)
+                    if (value is Authenticated) flowFinished.complete(Unit)
                 }
             }
 
-        val result = runBlocking { oobState.proceed() }
+        val result =
+            runBlocking {
+                val proceedResult = oobState.proceed()
+                flowFinished.await()
+                proceedResult
+            }
 
         assertIs<Authenticated>(result)
         assertEquals(result, context.authenticationStateFlow.value)

--- a/okta-direct-auth/src/commonTest/kotlin/com/okta/directauth/model/DirectAuthContinuationTransferStateTest.kt
+++ b/okta-direct-auth/src/commonTest/kotlin/com/okta/directauth/model/DirectAuthContinuationTransferStateTest.kt
@@ -20,6 +20,8 @@ import com.okta.authfoundation.GrantType
 import com.okta.authfoundation.api.http.KtorHttpExecutor
 import com.okta.authfoundation.api.log.AuthFoundationLogger
 import com.okta.authfoundation.api.log.LogLevel
+import com.okta.authfoundation.client.ClientAssertion
+import com.okta.authfoundation.client.ClientAssertionProvider
 import com.okta.directauth.AUTHORIZATION_PENDING_JSON
 import com.okta.directauth.TOKEN_RESPONSE_JSON
 import com.okta.directauth.contentType
@@ -158,6 +160,30 @@ class DirectAuthContinuationTransferStateTest {
         assertIs<Authenticated>(collectedValues.last())
 
         job.cancel()
+    }
+
+    @Test
+    fun `proceed resolves a fresh clientAssertion for each poll request`() {
+        val mockEngine = MockEngine.Queue()
+        mockEngine.enqueue { respond(AUTHORIZATION_PENDING_JSON, HttpStatusCode.BadRequest, contentType) }
+        mockEngine.enqueue { respond(TOKEN_RESPONSE_JSON, HttpStatusCode.OK, contentType) }
+
+        val providedAudiences = mutableListOf<String>()
+        val clientAssertionProvider =
+            ClientAssertionProvider { audience ->
+                providedAudiences.add(audience)
+                ClientAssertion("urn:ietf:params:oauth:client-assertion-type:jwt-bearer", "jwt-${providedAudiences.size}")
+            }
+
+        val context =
+            createDirectAuthenticationContext(apiExecutor = KtorHttpExecutor(HttpClient(mockEngine)))
+                .copy(clientSecret = "", clientAssertionProvider = clientAssertionProvider)
+        val transferState = DirectAuthContinuation.Transfer(bindingContext.copy(interval = 0), context)
+
+        val result = runBlocking { transferState.proceed() }
+
+        assertIs<Authenticated>(result)
+        assertEquals(listOf("https://example.okta.com/oauth2/v1/token", "https://example.okta.com/oauth2/v1/token"), providedAudiences)
     }
 
     @Test

--- a/okta-direct-auth/src/jvmMain/kotlin/com/okta/directauth/jvm/DirectAuthenticationFlowBuilder.kt
+++ b/okta-direct-auth/src/jvmMain/kotlin/com/okta/directauth/jvm/DirectAuthenticationFlowBuilder.kt
@@ -17,8 +17,12 @@ package com.okta.directauth.jvm
 
 import com.okta.authfoundation.ChallengeGrantType
 import com.okta.authfoundation.GrantType
+import com.okta.authfoundation.api.http.ApiExecutor
+import com.okta.authfoundation.api.log.AuthFoundationLogger
+import com.okta.authfoundation.client.ClientAssertionProvider
 import com.okta.authfoundation.client.OidcClock
 import com.okta.directauth.model.DirectAuthenticationIntent
+import kotlin.coroutines.CoroutineContext
 import com.okta.directauth.DirectAuthenticationFlowBuilder as KotlinBuilder
 
 /**
@@ -40,6 +44,8 @@ class DirectAuthenticationFlowBuilder(
 ) {
     private var authorizationServerId: String = ""
     private var clientSecret: String = ""
+    private var clientAssertionProvider: ClientAssertionProvider? = null
+    private var computeDispatcher: CoroutineContext? = null
     private var intent: DirectAuthenticationIntent = DirectAuthenticationIntent.SIGN_IN
     private var supportedGrantTypes: List<GrantType> =
         listOf(
@@ -52,6 +58,8 @@ class DirectAuthenticationFlowBuilder(
             ChallengeGrantType.WebAuthnMfa
         )
     private var acrValues: List<String> = emptyList()
+    private var apiExecutor: ApiExecutor? = null
+    private var logger: AuthFoundationLogger? = null
     private var clock: OidcClock? = null
     private var additionalParameters: Map<String, String> = emptyMap()
 
@@ -75,6 +83,33 @@ class DirectAuthenticationFlowBuilder(
     fun setClientSecret(clientSecret: String): DirectAuthenticationFlowBuilder =
         apply {
             this.clientSecret = clientSecret
+        }
+
+    /**
+     * Sets the provider for private_key_jwt (or similar JWT-based) client authentication.
+     *
+     * Invoked fresh for every client-authenticated request this flow makes — including each
+     * iteration of an OOB poll — so the returned assertion can carry a unique `jti` and a
+     * correctly scoped `aud`/`exp`. Cannot be combined with [setClientSecret].
+     *
+     * @param clientAssertionProvider The [ClientAssertionProvider] to use.
+     * @return This builder for chaining.
+     */
+    fun setClientAssertionProvider(clientAssertionProvider: ClientAssertionProvider): DirectAuthenticationFlowBuilder =
+        apply {
+            this.clientAssertionProvider = clientAssertionProvider
+        }
+
+    /**
+     * Sets the dispatcher used for CPU-bound work, such as invoking the [ClientAssertionProvider]
+     * set via [setClientAssertionProvider].
+     *
+     * @param dispatcher The [CoroutineContext] for computation.
+     * @return This builder for chaining.
+     */
+    fun setComputeDispatcher(dispatcher: CoroutineContext): DirectAuthenticationFlowBuilder =
+        apply {
+            this.computeDispatcher = dispatcher
         }
 
     /**
@@ -111,6 +146,28 @@ class DirectAuthenticationFlowBuilder(
         }
 
     /**
+     * Sets the HTTP client executor used to make network requests.
+     *
+     * @param apiExecutor The [ApiExecutor] to use.
+     * @return This builder for chaining.
+     */
+    fun setApiExecutor(apiExecutor: ApiExecutor): DirectAuthenticationFlowBuilder =
+        apply {
+            this.apiExecutor = apiExecutor
+        }
+
+    /**
+     * Sets the logger used by the SDK to output diagnostic information.
+     *
+     * @param logger The [AuthFoundationLogger] to use.
+     * @return This builder for chaining.
+     */
+    fun setLogger(logger: AuthFoundationLogger): DirectAuthenticationFlowBuilder =
+        apply {
+            this.logger = logger
+        }
+
+    /**
      * Sets the clock used for time-sensitive operations.
      *
      * @param clock The [OidcClock] to use.
@@ -142,9 +199,13 @@ class DirectAuthenticationFlowBuilder(
             KotlinBuilder.create(issuerUrl, clientId, scope) {
                 authorizationServerId = this@DirectAuthenticationFlowBuilder.authorizationServerId
                 clientSecret = this@DirectAuthenticationFlowBuilder.clientSecret
+                this@DirectAuthenticationFlowBuilder.clientAssertionProvider?.let { clientAssertionProvider = it }
+                this@DirectAuthenticationFlowBuilder.computeDispatcher?.let { computeDispatcher = it }
                 directAuthenticationIntent = this@DirectAuthenticationFlowBuilder.intent
                 supportedGrantType = this@DirectAuthenticationFlowBuilder.supportedGrantTypes
                 acrValues = this@DirectAuthenticationFlowBuilder.acrValues
+                this@DirectAuthenticationFlowBuilder.apiExecutor?.let { apiExecutor = it }
+                this@DirectAuthenticationFlowBuilder.logger?.let { logger = it }
                 this@DirectAuthenticationFlowBuilder.clock?.let { clock = it }
                 additionalParameter = this@DirectAuthenticationFlowBuilder.additionalParameters
             }

--- a/okta-direct-auth/src/jvmTest/java/com/okta/directauth/jvm/BuilderApiTest.java
+++ b/okta-direct-auth/src/jvmTest/java/com/okta/directauth/jvm/BuilderApiTest.java
@@ -18,6 +18,8 @@ package com.okta.directauth.jvm;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import com.okta.authfoundation.api.log.JvmAuthFoundationLogger;
+import com.okta.authfoundation.client.ClientAssertion;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -60,6 +62,34 @@ public class BuilderApiTest {
             .getOrThrow();
 
     assertNotNull("Flow should not be null after chaining", flow);
+    flow.close();
+  }
+
+  @Test
+  public void build_WithClientAssertionProviderSetter_Succeeds() {
+    DirectAuthenticationFlow flow =
+        new DirectAuthenticationFlowBuilder(ISSUER_URL, CLIENT_ID, SCOPE)
+            .setClientAssertionProvider(
+                audience ->
+                    new ClientAssertion(
+                        "urn:ietf:params:oauth:client-assertion-type:jwt-bearer", "signed-jwt"))
+            .build()
+            .getOrThrow();
+
+    assertNotNull("Flow should not be null after setting client assertion provider", flow);
+    flow.close();
+  }
+
+  @Test
+  public void build_WithApiExecutorAndLogger_Succeeds() {
+    DirectAuthenticationFlow flow =
+        new DirectAuthenticationFlowBuilder(ISSUER_URL, CLIENT_ID, SCOPE)
+            .setApiExecutor(TestHelpers.createMockApiExecutor())
+            .setLogger(new JvmAuthFoundationLogger("BuilderApiTest"))
+            .build()
+            .getOrThrow();
+
+    assertNotNull("Flow should not be null after setting apiExecutor and logger", flow);
     flow.close();
   }
 

--- a/okta-direct-auth/src/jvmTest/java/com/okta/directauth/jvm/TestStateFactory.java
+++ b/okta-direct-auth/src/jvmTest/java/com/okta/directauth/jvm/TestStateFactory.java
@@ -36,6 +36,7 @@ import com.okta.directauth.model.OobChannel;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import kotlinx.coroutines.Dispatchers;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -60,6 +61,8 @@ final class TestStateFactory {
         /* scope= */ List.of("openid", "email", "profile", "offline_access"),
         /* authorizationServerId= */ "",
         /* clientSecret= */ "test_client_secret",
+        /* clientAssertionProvider= */ null,
+        /* computeDispatcher= */ Dispatchers.getDefault(),
         /* grantTypes= */ List.of(GrantType.Password.INSTANCE, GrantType.WebAuthn.INSTANCE),
         /* acrValues= */ Collections.emptyList(),
         /* directAuthenticationIntent= */ DirectAuthenticationIntent.SIGN_IN,


### PR DESCRIPTION
Resolve the client assertion fresh for each client-authenticated request (token, challenge, oob-authenticate, primary-authenticate — including each OOB poll iteration) using auth-foundation's ClientAssertionProvider, scoped to that request's own endpoint URL as audience. A single assertion minted once at builder time would be replayed across requests, which breaks jti one-time-use, exp expiry, and per-endpoint aud scoping on MFA, OOB polling, and WebAuthn paths — this matches OAuth2ClientConfiguration's existing pattern instead.

Update sample README: confidential-client auth now covers Direct Auth too

Add client assertion samples to direct-auth desktop/Android/CLI apps