### PR TITLE
Declare Cross App Access API surface and two-server test harness

### DIFF
--- a/oauth2/api/jvm/oauth2.api
+++ b/oauth2/api/jvm/oauth2.api
@@ -65,6 +65,119 @@ public abstract interface class com/okta/oauth2/kmp/BrowserRedirectHandler {
 	public abstract fun handleRedirect (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public final class com/okta/oauth2/kmp/CrossAppAccessCredentialExtensionsKt {
+	public static final fun crossAppAccessSubject (Lcom/okta/authfoundation/credential/kmp/Credential;Lcom/okta/oauth2/kmp/SubjectAssertion$Type;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun crossAppAccessSubject$default (Lcom/okta/authfoundation/credential/kmp/Credential;Lcom/okta/oauth2/kmp/SubjectAssertion$Type;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun crossAppAccessToken (Lcom/okta/authfoundation/credential/kmp/Credential;Lcom/okta/authfoundation/client/kmp/OAuth2Client;Lcom/okta/oauth2/kmp/CrossAppAccessTarget;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun crossAppAccessToken$default (Lcom/okta/authfoundation/credential/kmp/Credential;Lcom/okta/authfoundation/client/kmp/OAuth2Client;Lcom/okta/oauth2/kmp/CrossAppAccessTarget;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract class com/okta/oauth2/kmp/CrossAppAccessException : java/lang/Exception {
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class com/okta/oauth2/kmp/CrossAppAccessException$IdpExchangeFailed : com/okta/oauth2/kmp/CrossAppAccessException {
+}
+
+public final class com/okta/oauth2/kmp/CrossAppAccessException$TargetRedemptionFailed : com/okta/oauth2/kmp/CrossAppAccessException {
+}
+
+public abstract interface class com/okta/oauth2/kmp/CrossAppAccessFlow {
+	public static final field Companion Lcom/okta/oauth2/kmp/CrossAppAccessFlow$Companion;
+	public static fun create-gIAlu-s (Lcom/okta/authfoundation/client/kmp/OAuth2Client;Lcom/okta/oauth2/kmp/CrossAppAccessTarget;)Ljava/lang/Object;
+	public abstract fun exchange-0E7RQCE (Lcom/okta/oauth2/kmp/SubjectAssertion;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun exchange-0E7RQCE$default (Lcom/okta/oauth2/kmp/CrossAppAccessFlow;Lcom/okta/oauth2/kmp/SubjectAssertion;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun getIdpClient ()Lcom/okta/authfoundation/client/kmp/OAuth2Client;
+	public abstract fun getTargetClient ()Lcom/okta/authfoundation/client/kmp/OAuth2Client;
+	public abstract fun redeem-gIAlu-s (Lcom/okta/oauth2/kmp/IdJagAssertion;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun start-0E7RQCE (Lcom/okta/oauth2/kmp/SubjectAssertion;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun start-0E7RQCE$default (Lcom/okta/oauth2/kmp/CrossAppAccessFlow;Lcom/okta/oauth2/kmp/SubjectAssertion;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun toString ()Ljava/lang/String;
+}
+
+public final class com/okta/oauth2/kmp/CrossAppAccessFlow$Companion {
+	public final fun create-gIAlu-s (Lcom/okta/authfoundation/client/kmp/OAuth2Client;Lcom/okta/oauth2/kmp/CrossAppAccessTarget;)Ljava/lang/Object;
+}
+
+public final class com/okta/oauth2/kmp/CrossAppAccessFlow$DefaultImpls {
+	public static synthetic fun exchange-0E7RQCE$default (Lcom/okta/oauth2/kmp/CrossAppAccessFlow;Lcom/okta/oauth2/kmp/SubjectAssertion;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun start-0E7RQCE$default (Lcom/okta/oauth2/kmp/CrossAppAccessFlow;Lcom/okta/oauth2/kmp/SubjectAssertion;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract class com/okta/oauth2/kmp/CrossAppAccessTarget {
+	public static final field Companion Lcom/okta/oauth2/kmp/CrossAppAccessTarget$Companion;
+	public static final fun forAuthorizationServerId (Ljava/lang/String;)Lcom/okta/oauth2/kmp/CrossAppAccessTarget$AuthorizationServerId;
+	public static final fun forAuthorizationServerId (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/okta/oauth2/kmp/CrossAppAccessTarget$AuthorizationServerId;
+	public static final fun forIssuer (Ljava/lang/String;)Lcom/okta/oauth2/kmp/CrossAppAccessTarget$Issuer;
+	public static final fun forIssuer (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/okta/oauth2/kmp/CrossAppAccessTarget$Issuer;
+	public abstract fun getResource ()Ljava/lang/String;
+	public abstract fun getScope ()Ljava/util/List;
+	public abstract fun toString ()Ljava/lang/String;
+	public static final fun wrapping (Lcom/okta/authfoundation/client/kmp/OAuth2Client;)Lcom/okta/oauth2/kmp/CrossAppAccessTarget$Prebuilt;
+	public static final fun wrapping (Lcom/okta/authfoundation/client/kmp/OAuth2Client;Ljava/lang/String;)Lcom/okta/oauth2/kmp/CrossAppAccessTarget$Prebuilt;
+	public static final fun wrapping (Lcom/okta/authfoundation/client/kmp/OAuth2Client;Ljava/lang/String;Ljava/util/List;)Lcom/okta/oauth2/kmp/CrossAppAccessTarget$Prebuilt;
+}
+
+public final class com/okta/oauth2/kmp/CrossAppAccessTarget$AuthorizationServerId : com/okta/oauth2/kmp/CrossAppAccessTarget {
+	public final fun getAuthorizationServerId ()Ljava/lang/String;
+	public final fun getClientAssertionProvider ()Lcom/okta/authfoundation/client/ClientAssertionProvider;
+	public final fun getClientBuildAction ()Lkotlin/jvm/functions/Function1;
+	public final fun getClientId ()Ljava/lang/String;
+	public final fun getClientSecret ()Ljava/lang/String;
+	public final fun getEndpointOverrides ()Lcom/okta/authfoundation/client/OAuth2EndpointOverrides;
+	public fun getResource ()Ljava/lang/String;
+	public fun getScope ()Ljava/util/List;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/okta/oauth2/kmp/CrossAppAccessTarget$Companion {
+	public final fun forAuthorizationServerId (Ljava/lang/String;)Lcom/okta/oauth2/kmp/CrossAppAccessTarget$AuthorizationServerId;
+	public final fun forAuthorizationServerId (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/okta/oauth2/kmp/CrossAppAccessTarget$AuthorizationServerId;
+	public static synthetic fun forAuthorizationServerId$default (Lcom/okta/oauth2/kmp/CrossAppAccessTarget$Companion;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/okta/oauth2/kmp/CrossAppAccessTarget$AuthorizationServerId;
+	public final fun forIssuer (Ljava/lang/String;)Lcom/okta/oauth2/kmp/CrossAppAccessTarget$Issuer;
+	public final fun forIssuer (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/okta/oauth2/kmp/CrossAppAccessTarget$Issuer;
+	public static synthetic fun forIssuer$default (Lcom/okta/oauth2/kmp/CrossAppAccessTarget$Companion;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/okta/oauth2/kmp/CrossAppAccessTarget$Issuer;
+	public final fun wrapping (Lcom/okta/authfoundation/client/kmp/OAuth2Client;)Lcom/okta/oauth2/kmp/CrossAppAccessTarget$Prebuilt;
+	public final fun wrapping (Lcom/okta/authfoundation/client/kmp/OAuth2Client;Ljava/lang/String;)Lcom/okta/oauth2/kmp/CrossAppAccessTarget$Prebuilt;
+	public final fun wrapping (Lcom/okta/authfoundation/client/kmp/OAuth2Client;Ljava/lang/String;Ljava/util/List;)Lcom/okta/oauth2/kmp/CrossAppAccessTarget$Prebuilt;
+	public static synthetic fun wrapping$default (Lcom/okta/oauth2/kmp/CrossAppAccessTarget$Companion;Lcom/okta/authfoundation/client/kmp/OAuth2Client;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lcom/okta/oauth2/kmp/CrossAppAccessTarget$Prebuilt;
+}
+
+public final class com/okta/oauth2/kmp/CrossAppAccessTarget$Issuer : com/okta/oauth2/kmp/CrossAppAccessTarget {
+	public final fun getClientAssertionProvider ()Lcom/okta/authfoundation/client/ClientAssertionProvider;
+	public final fun getClientBuildAction ()Lkotlin/jvm/functions/Function1;
+	public final fun getClientId ()Ljava/lang/String;
+	public final fun getClientSecret ()Ljava/lang/String;
+	public final fun getEndpointOverrides ()Lcom/okta/authfoundation/client/OAuth2EndpointOverrides;
+	public final fun getIssuer ()Ljava/lang/String;
+	public fun getResource ()Ljava/lang/String;
+	public fun getScope ()Ljava/util/List;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/okta/oauth2/kmp/CrossAppAccessTarget$Prebuilt : com/okta/oauth2/kmp/CrossAppAccessTarget {
+	public fun getResource ()Ljava/lang/String;
+	public fun getScope ()Ljava/util/List;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/okta/oauth2/kmp/CrossAppAccessTargetBuilder {
+	public final fun getClientAssertionProvider ()Lcom/okta/authfoundation/client/ClientAssertionProvider;
+	public final fun getClientBuildAction ()Lkotlin/jvm/functions/Function1;
+	public final fun getClientId ()Ljava/lang/String;
+	public final fun getClientSecret ()Ljava/lang/String;
+	public final fun getEndpointOverrides ()Lcom/okta/authfoundation/client/OAuth2EndpointOverrides;
+	public final fun getResource ()Ljava/lang/String;
+	public final fun getScope ()Ljava/util/List;
+	public final fun setClientAssertionProvider (Lcom/okta/authfoundation/client/ClientAssertionProvider;)V
+	public final fun setClientBuildAction (Lkotlin/jvm/functions/Function1;)V
+	public final fun setClientId (Ljava/lang/String;)V
+	public final fun setClientSecret (Ljava/lang/String;)V
+	public final fun setEndpointOverrides (Lcom/okta/authfoundation/client/OAuth2EndpointOverrides;)V
+	public final fun setResource (Ljava/lang/String;)V
+	public final fun setScope (Ljava/util/List;)V
+}
+
 public abstract interface class com/okta/oauth2/kmp/DeviceAuthorizationFlow {
 	public static final field Companion Lcom/okta/oauth2/kmp/DeviceAuthorizationFlow$Companion;
 	public abstract fun getClient ()Lcom/okta/authfoundation/client/kmp/OAuth2Client;
@@ -100,6 +213,28 @@ public final class com/okta/oauth2/kmp/DeviceAuthorizationFlowContext {
 	public final fun getVerificationUriComplete ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/okta/oauth2/kmp/IdJagAssertion {
+	public static final field Companion Lcom/okta/oauth2/kmp/IdJagAssertion$Companion;
+	public final fun getAudience ()Ljava/lang/String;
+	public final fun getExpiresIn ()I
+	public final fun getIssuedAt ()J
+	public final fun getIssuedTokenType ()Ljava/lang/String;
+	public final fun getScope ()Ljava/lang/String;
+	public final fun getValue ()Ljava/lang/String;
+	public final fun isExpired (Lcom/okta/authfoundation/client/OidcClock;)Z
+	public static final fun restore (Ljava/lang/String;Ljava/lang/String;IJ)Lcom/okta/oauth2/kmp/IdJagAssertion;
+	public static final fun restore (Ljava/lang/String;Ljava/lang/String;IJLjava/lang/String;)Lcom/okta/oauth2/kmp/IdJagAssertion;
+	public static final fun restore (Ljava/lang/String;Ljava/lang/String;IJLjava/lang/String;Ljava/lang/String;)Lcom/okta/oauth2/kmp/IdJagAssertion;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/okta/oauth2/kmp/IdJagAssertion$Companion {
+	public final fun restore (Ljava/lang/String;Ljava/lang/String;IJ)Lcom/okta/oauth2/kmp/IdJagAssertion;
+	public final fun restore (Ljava/lang/String;Ljava/lang/String;IJLjava/lang/String;)Lcom/okta/oauth2/kmp/IdJagAssertion;
+	public final fun restore (Ljava/lang/String;Ljava/lang/String;IJLjava/lang/String;Ljava/lang/String;)Lcom/okta/oauth2/kmp/IdJagAssertion;
+	public static synthetic fun restore$default (Lcom/okta/oauth2/kmp/IdJagAssertion$Companion;Ljava/lang/String;Ljava/lang/String;IJLjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/okta/oauth2/kmp/IdJagAssertion;
 }
 
 public final class com/okta/oauth2/kmp/LocalhostBrowserRedirectHandler : com/okta/oauth2/kmp/BrowserRedirectHandler {
@@ -180,6 +315,31 @@ public final class com/okta/oauth2/kmp/SessionTokenFlow$Companion {
 
 public final class com/okta/oauth2/kmp/SessionTokenFlow$DefaultImpls {
 	public static synthetic fun start-yxL6bBk$default (Lcom/okta/oauth2/kmp/SessionTokenFlow;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/okta/oauth2/kmp/SubjectAssertion {
+	public static final field Companion Lcom/okta/oauth2/kmp/SubjectAssertion$Companion;
+	public static final fun accessToken (Ljava/lang/String;)Lcom/okta/oauth2/kmp/SubjectAssertion;
+	public final fun getType ()Lcom/okta/oauth2/kmp/SubjectAssertion$Type;
+	public final fun getValue ()Ljava/lang/String;
+	public static final fun idToken (Ljava/lang/String;)Lcom/okta/oauth2/kmp/SubjectAssertion;
+	public static final fun refreshToken (Ljava/lang/String;)Lcom/okta/oauth2/kmp/SubjectAssertion;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/okta/oauth2/kmp/SubjectAssertion$Companion {
+	public final fun accessToken (Ljava/lang/String;)Lcom/okta/oauth2/kmp/SubjectAssertion;
+	public final fun idToken (Ljava/lang/String;)Lcom/okta/oauth2/kmp/SubjectAssertion;
+	public final fun refreshToken (Ljava/lang/String;)Lcom/okta/oauth2/kmp/SubjectAssertion;
+}
+
+public final class com/okta/oauth2/kmp/SubjectAssertion$Type : java/lang/Enum {
+	public static final field ACCESS_TOKEN Lcom/okta/oauth2/kmp/SubjectAssertion$Type;
+	public static final field ID_TOKEN Lcom/okta/oauth2/kmp/SubjectAssertion$Type;
+	public static final field REFRESH_TOKEN Lcom/okta/oauth2/kmp/SubjectAssertion$Type;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/okta/oauth2/kmp/SubjectAssertion$Type;
+	public static fun values ()[Lcom/okta/oauth2/kmp/SubjectAssertion$Type;
 }
 
 public abstract interface class com/okta/oauth2/kmp/TokenExchangeFlow {

--- a/oauth2/api/oauth2.api
+++ b/oauth2/api/oauth2.api
@@ -191,6 +191,119 @@ public abstract interface class com/okta/oauth2/kmp/BrowserRedirectHandler {
 	public abstract fun handleRedirect (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public final class com/okta/oauth2/kmp/CrossAppAccessCredentialExtensionsKt {
+	public static final fun crossAppAccessSubject (Lcom/okta/authfoundation/credential/kmp/Credential;Lcom/okta/oauth2/kmp/SubjectAssertion$Type;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun crossAppAccessSubject$default (Lcom/okta/authfoundation/credential/kmp/Credential;Lcom/okta/oauth2/kmp/SubjectAssertion$Type;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun crossAppAccessToken (Lcom/okta/authfoundation/credential/kmp/Credential;Lcom/okta/authfoundation/client/kmp/OAuth2Client;Lcom/okta/oauth2/kmp/CrossAppAccessTarget;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun crossAppAccessToken$default (Lcom/okta/authfoundation/credential/kmp/Credential;Lcom/okta/authfoundation/client/kmp/OAuth2Client;Lcom/okta/oauth2/kmp/CrossAppAccessTarget;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract class com/okta/oauth2/kmp/CrossAppAccessException : java/lang/Exception {
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class com/okta/oauth2/kmp/CrossAppAccessException$IdpExchangeFailed : com/okta/oauth2/kmp/CrossAppAccessException {
+}
+
+public final class com/okta/oauth2/kmp/CrossAppAccessException$TargetRedemptionFailed : com/okta/oauth2/kmp/CrossAppAccessException {
+}
+
+public abstract interface class com/okta/oauth2/kmp/CrossAppAccessFlow {
+	public static final field Companion Lcom/okta/oauth2/kmp/CrossAppAccessFlow$Companion;
+	public static fun create-gIAlu-s (Lcom/okta/authfoundation/client/kmp/OAuth2Client;Lcom/okta/oauth2/kmp/CrossAppAccessTarget;)Ljava/lang/Object;
+	public abstract fun exchange-0E7RQCE (Lcom/okta/oauth2/kmp/SubjectAssertion;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun exchange-0E7RQCE$default (Lcom/okta/oauth2/kmp/CrossAppAccessFlow;Lcom/okta/oauth2/kmp/SubjectAssertion;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun getIdpClient ()Lcom/okta/authfoundation/client/kmp/OAuth2Client;
+	public abstract fun getTargetClient ()Lcom/okta/authfoundation/client/kmp/OAuth2Client;
+	public abstract fun redeem-gIAlu-s (Lcom/okta/oauth2/kmp/IdJagAssertion;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun start-0E7RQCE (Lcom/okta/oauth2/kmp/SubjectAssertion;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun start-0E7RQCE$default (Lcom/okta/oauth2/kmp/CrossAppAccessFlow;Lcom/okta/oauth2/kmp/SubjectAssertion;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun toString ()Ljava/lang/String;
+}
+
+public final class com/okta/oauth2/kmp/CrossAppAccessFlow$Companion {
+	public final fun create-gIAlu-s (Lcom/okta/authfoundation/client/kmp/OAuth2Client;Lcom/okta/oauth2/kmp/CrossAppAccessTarget;)Ljava/lang/Object;
+}
+
+public final class com/okta/oauth2/kmp/CrossAppAccessFlow$DefaultImpls {
+	public static synthetic fun exchange-0E7RQCE$default (Lcom/okta/oauth2/kmp/CrossAppAccessFlow;Lcom/okta/oauth2/kmp/SubjectAssertion;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun start-0E7RQCE$default (Lcom/okta/oauth2/kmp/CrossAppAccessFlow;Lcom/okta/oauth2/kmp/SubjectAssertion;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract class com/okta/oauth2/kmp/CrossAppAccessTarget {
+	public static final field Companion Lcom/okta/oauth2/kmp/CrossAppAccessTarget$Companion;
+	public static final fun forAuthorizationServerId (Ljava/lang/String;)Lcom/okta/oauth2/kmp/CrossAppAccessTarget$AuthorizationServerId;
+	public static final fun forAuthorizationServerId (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/okta/oauth2/kmp/CrossAppAccessTarget$AuthorizationServerId;
+	public static final fun forIssuer (Ljava/lang/String;)Lcom/okta/oauth2/kmp/CrossAppAccessTarget$Issuer;
+	public static final fun forIssuer (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/okta/oauth2/kmp/CrossAppAccessTarget$Issuer;
+	public abstract fun getResource ()Ljava/lang/String;
+	public abstract fun getScope ()Ljava/util/List;
+	public abstract fun toString ()Ljava/lang/String;
+	public static final fun wrapping (Lcom/okta/authfoundation/client/kmp/OAuth2Client;)Lcom/okta/oauth2/kmp/CrossAppAccessTarget$Prebuilt;
+	public static final fun wrapping (Lcom/okta/authfoundation/client/kmp/OAuth2Client;Ljava/lang/String;)Lcom/okta/oauth2/kmp/CrossAppAccessTarget$Prebuilt;
+	public static final fun wrapping (Lcom/okta/authfoundation/client/kmp/OAuth2Client;Ljava/lang/String;Ljava/util/List;)Lcom/okta/oauth2/kmp/CrossAppAccessTarget$Prebuilt;
+}
+
+public final class com/okta/oauth2/kmp/CrossAppAccessTarget$AuthorizationServerId : com/okta/oauth2/kmp/CrossAppAccessTarget {
+	public final fun getAuthorizationServerId ()Ljava/lang/String;
+	public final fun getClientAssertionProvider ()Lcom/okta/authfoundation/client/ClientAssertionProvider;
+	public final fun getClientBuildAction ()Lkotlin/jvm/functions/Function1;
+	public final fun getClientId ()Ljava/lang/String;
+	public final fun getClientSecret ()Ljava/lang/String;
+	public final fun getEndpointOverrides ()Lcom/okta/authfoundation/client/OAuth2EndpointOverrides;
+	public fun getResource ()Ljava/lang/String;
+	public fun getScope ()Ljava/util/List;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/okta/oauth2/kmp/CrossAppAccessTarget$Companion {
+	public final fun forAuthorizationServerId (Ljava/lang/String;)Lcom/okta/oauth2/kmp/CrossAppAccessTarget$AuthorizationServerId;
+	public final fun forAuthorizationServerId (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/okta/oauth2/kmp/CrossAppAccessTarget$AuthorizationServerId;
+	public static synthetic fun forAuthorizationServerId$default (Lcom/okta/oauth2/kmp/CrossAppAccessTarget$Companion;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/okta/oauth2/kmp/CrossAppAccessTarget$AuthorizationServerId;
+	public final fun forIssuer (Ljava/lang/String;)Lcom/okta/oauth2/kmp/CrossAppAccessTarget$Issuer;
+	public final fun forIssuer (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/okta/oauth2/kmp/CrossAppAccessTarget$Issuer;
+	public static synthetic fun forIssuer$default (Lcom/okta/oauth2/kmp/CrossAppAccessTarget$Companion;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/okta/oauth2/kmp/CrossAppAccessTarget$Issuer;
+	public final fun wrapping (Lcom/okta/authfoundation/client/kmp/OAuth2Client;)Lcom/okta/oauth2/kmp/CrossAppAccessTarget$Prebuilt;
+	public final fun wrapping (Lcom/okta/authfoundation/client/kmp/OAuth2Client;Ljava/lang/String;)Lcom/okta/oauth2/kmp/CrossAppAccessTarget$Prebuilt;
+	public final fun wrapping (Lcom/okta/authfoundation/client/kmp/OAuth2Client;Ljava/lang/String;Ljava/util/List;)Lcom/okta/oauth2/kmp/CrossAppAccessTarget$Prebuilt;
+	public static synthetic fun wrapping$default (Lcom/okta/oauth2/kmp/CrossAppAccessTarget$Companion;Lcom/okta/authfoundation/client/kmp/OAuth2Client;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lcom/okta/oauth2/kmp/CrossAppAccessTarget$Prebuilt;
+}
+
+public final class com/okta/oauth2/kmp/CrossAppAccessTarget$Issuer : com/okta/oauth2/kmp/CrossAppAccessTarget {
+	public final fun getClientAssertionProvider ()Lcom/okta/authfoundation/client/ClientAssertionProvider;
+	public final fun getClientBuildAction ()Lkotlin/jvm/functions/Function1;
+	public final fun getClientId ()Ljava/lang/String;
+	public final fun getClientSecret ()Ljava/lang/String;
+	public final fun getEndpointOverrides ()Lcom/okta/authfoundation/client/OAuth2EndpointOverrides;
+	public final fun getIssuer ()Ljava/lang/String;
+	public fun getResource ()Ljava/lang/String;
+	public fun getScope ()Ljava/util/List;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/okta/oauth2/kmp/CrossAppAccessTarget$Prebuilt : com/okta/oauth2/kmp/CrossAppAccessTarget {
+	public fun getResource ()Ljava/lang/String;
+	public fun getScope ()Ljava/util/List;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/okta/oauth2/kmp/CrossAppAccessTargetBuilder {
+	public final fun getClientAssertionProvider ()Lcom/okta/authfoundation/client/ClientAssertionProvider;
+	public final fun getClientBuildAction ()Lkotlin/jvm/functions/Function1;
+	public final fun getClientId ()Ljava/lang/String;
+	public final fun getClientSecret ()Ljava/lang/String;
+	public final fun getEndpointOverrides ()Lcom/okta/authfoundation/client/OAuth2EndpointOverrides;
+	public final fun getResource ()Ljava/lang/String;
+	public final fun getScope ()Ljava/util/List;
+	public final fun setClientAssertionProvider (Lcom/okta/authfoundation/client/ClientAssertionProvider;)V
+	public final fun setClientBuildAction (Lkotlin/jvm/functions/Function1;)V
+	public final fun setClientId (Ljava/lang/String;)V
+	public final fun setClientSecret (Ljava/lang/String;)V
+	public final fun setEndpointOverrides (Lcom/okta/authfoundation/client/OAuth2EndpointOverrides;)V
+	public final fun setResource (Ljava/lang/String;)V
+	public final fun setScope (Ljava/util/List;)V
+}
+
 public abstract interface class com/okta/oauth2/kmp/DeviceAuthorizationFlow {
 	public static final field Companion Lcom/okta/oauth2/kmp/DeviceAuthorizationFlow$Companion;
 	public abstract fun getClient ()Lcom/okta/authfoundation/client/kmp/OAuth2Client;
@@ -226,6 +339,28 @@ public final class com/okta/oauth2/kmp/DeviceAuthorizationFlowContext {
 	public final fun getVerificationUriComplete ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/okta/oauth2/kmp/IdJagAssertion {
+	public static final field Companion Lcom/okta/oauth2/kmp/IdJagAssertion$Companion;
+	public final fun getAudience ()Ljava/lang/String;
+	public final fun getExpiresIn ()I
+	public final fun getIssuedAt ()J
+	public final fun getIssuedTokenType ()Ljava/lang/String;
+	public final fun getScope ()Ljava/lang/String;
+	public final fun getValue ()Ljava/lang/String;
+	public final fun isExpired (Lcom/okta/authfoundation/client/OidcClock;)Z
+	public static final fun restore (Ljava/lang/String;Ljava/lang/String;IJ)Lcom/okta/oauth2/kmp/IdJagAssertion;
+	public static final fun restore (Ljava/lang/String;Ljava/lang/String;IJLjava/lang/String;)Lcom/okta/oauth2/kmp/IdJagAssertion;
+	public static final fun restore (Ljava/lang/String;Ljava/lang/String;IJLjava/lang/String;Ljava/lang/String;)Lcom/okta/oauth2/kmp/IdJagAssertion;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/okta/oauth2/kmp/IdJagAssertion$Companion {
+	public final fun restore (Ljava/lang/String;Ljava/lang/String;IJ)Lcom/okta/oauth2/kmp/IdJagAssertion;
+	public final fun restore (Ljava/lang/String;Ljava/lang/String;IJLjava/lang/String;)Lcom/okta/oauth2/kmp/IdJagAssertion;
+	public final fun restore (Ljava/lang/String;Ljava/lang/String;IJLjava/lang/String;Ljava/lang/String;)Lcom/okta/oauth2/kmp/IdJagAssertion;
+	public static synthetic fun restore$default (Lcom/okta/oauth2/kmp/IdJagAssertion$Companion;Ljava/lang/String;Ljava/lang/String;IJLjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/okta/oauth2/kmp/IdJagAssertion;
 }
 
 public abstract interface class com/okta/oauth2/kmp/RedirectEndSessionFlow {
@@ -288,6 +423,32 @@ public final class com/okta/oauth2/kmp/SessionTokenFlow$Companion {
 
 public final class com/okta/oauth2/kmp/SessionTokenFlow$DefaultImpls {
 	public static synthetic fun start-yxL6bBk$default (Lcom/okta/oauth2/kmp/SessionTokenFlow;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/okta/oauth2/kmp/SubjectAssertion {
+	public static final field Companion Lcom/okta/oauth2/kmp/SubjectAssertion$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lcom/okta/oauth2/kmp/SubjectAssertion$Type;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun accessToken (Ljava/lang/String;)Lcom/okta/oauth2/kmp/SubjectAssertion;
+	public final fun getType ()Lcom/okta/oauth2/kmp/SubjectAssertion$Type;
+	public final fun getValue ()Ljava/lang/String;
+	public static final fun idToken (Ljava/lang/String;)Lcom/okta/oauth2/kmp/SubjectAssertion;
+	public static final fun refreshToken (Ljava/lang/String;)Lcom/okta/oauth2/kmp/SubjectAssertion;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/okta/oauth2/kmp/SubjectAssertion$Companion {
+	public final fun accessToken (Ljava/lang/String;)Lcom/okta/oauth2/kmp/SubjectAssertion;
+	public final fun idToken (Ljava/lang/String;)Lcom/okta/oauth2/kmp/SubjectAssertion;
+	public final fun refreshToken (Ljava/lang/String;)Lcom/okta/oauth2/kmp/SubjectAssertion;
+}
+
+public final class com/okta/oauth2/kmp/SubjectAssertion$Type : java/lang/Enum {
+	public static final field ACCESS_TOKEN Lcom/okta/oauth2/kmp/SubjectAssertion$Type;
+	public static final field ID_TOKEN Lcom/okta/oauth2/kmp/SubjectAssertion$Type;
+	public static final field REFRESH_TOKEN Lcom/okta/oauth2/kmp/SubjectAssertion$Type;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/okta/oauth2/kmp/SubjectAssertion$Type;
+	public static fun values ()[Lcom/okta/oauth2/kmp/SubjectAssertion$Type;
 }
 
 public abstract interface class com/okta/oauth2/kmp/TokenExchangeFlow {

--- a/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/CrossAppAccessCredentialExtensions.kt
+++ b/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/CrossAppAccessCredentialExtensions.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp
+
+import com.okta.authfoundation.client.TokenInfo
+import com.okta.authfoundation.client.kmp.OAuth2Client
+import com.okta.authfoundation.credential.kmp.Credential
+
+/**
+ * Derives a [SubjectAssertion] from this credential's stored token, so a caller does not have to
+ * pull the raw token string out by hand.
+ *
+ * This is the commonMain `Credential` interface, not the deprecated Android-only `Credential`
+ * class — a multiplatform capability cannot extend the latter. Existing sample code using the
+ * deprecated type must migrate to this interface first.
+ *
+ * @param type which of the credential's stored tokens to use. Defaults to the ID token.
+ * @return [Result.success] with the [SubjectAssertion], or [Result.failure] with an
+ *   [IllegalStateException] naming the missing token, produced before any network request, if
+ *   [type]'s corresponding token is absent from this credential.
+ */
+suspend fun Credential.crossAppAccessSubject(type: SubjectAssertion.Type = SubjectAssertion.Type.ID_TOKEN): Result<SubjectAssertion> =
+    TODO("implemented in the https://oktainc.atlassian.net/browse/OKTA-1258537")
+
+/**
+ * One-call convenience that derives a subject assertion from this credential and runs the
+ * complete Cross App Access exchange against [target], without mutating, replacing, or
+ * invalidating this credential.
+ *
+ * @param idpClient the primary client, already configured against the IdP authorization server.
+ * @param target the resource authorization server to redeem an ID-JAG at.
+ * @param scope requested scopes at the target; see [CrossAppAccessFlow.start].
+ * @return [Result.success] with the resource access [TokenInfo], or [Result.failure] from
+ *   deriving the subject assertion, from [CrossAppAccessFlow.create], or from the exchange itself.
+ */
+suspend fun Credential.crossAppAccessToken(
+    idpClient: OAuth2Client,
+    target: CrossAppAccessTarget,
+    scope: List<String>? = null,
+): Result<TokenInfo> = TODO("implemented in the https://oktainc.atlassian.net/browse/OKTA-1258537")

--- a/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/CrossAppAccessException.kt
+++ b/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/CrossAppAccessException.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp
+
+/**
+ * Names which authorization server rejected a Cross App Access exchange.
+ *
+ * Both steps of the exchange ultimately call the same underlying token-request machinery, which
+ * fails with the same generic transport error regardless of which server answered. Without this
+ * type, a caller can only tell an IdP-side denial apart from a target-side rejection by parsing
+ * the failure's message text. The original transport failure is always attached as [Throwable.cause],
+ * so the server-provided error code and description remain reachable there.
+ */
+sealed class CrossAppAccessException(
+    message: String,
+    cause: Throwable?,
+) : Exception(message, cause) {
+    /**
+     * The first step failed at the **IdP authorization server** while exchanging the subject
+     * assertion for an ID-JAG — for example, no trusted connection is configured between the
+     * requesting app and the resource app, or the request was otherwise rejected before an
+     * ID-JAG could be issued.
+     */
+    class IdpExchangeFailed internal constructor(
+        message: String,
+        cause: Throwable?,
+    ) : CrossAppAccessException(message, cause)
+
+    /**
+     * The second step failed at the **resource authorization server** while redeeming an ID-JAG
+     * for a resource access token — for example, the ID-JAG expired or was rejected, or the
+     * target's discovery metadata could not be retrieved.
+     */
+    class TargetRedemptionFailed internal constructor(
+        message: String,
+        cause: Throwable?,
+    ) : CrossAppAccessException(message, cause)
+}

--- a/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/CrossAppAccessFlow.kt
+++ b/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/CrossAppAccessFlow.kt
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp
+
+import com.okta.authfoundation.client.TokenInfo
+import com.okta.authfoundation.client.kmp.OAuth2Client
+
+/**
+ * Implements [Cross App Access](https://developer.okta.com/docs/concepts/xaa/) (XAA), the
+ * Identity Assertion JWT Authorization Grant (ID-JAG) authorization-chaining exchange defined by
+ * [draft-ietf-oauth-identity-assertion-authz-grant](https://datatracker.ietf.org/doc/draft-ietf-oauth-identity-assertion-authz-grant/).
+ *
+ * Cross App Access lets a signed-in user's session in a *requesting app* be used to call a
+ * *resource app*'s API in a different security domain — with no second consent prompt and no
+ * static API key — provided an administrator has configured a trusted connection between the two
+ * apps. The exchange is two steps:
+ *
+ * 1. [start] presents the user's assertion at the **IdP authorization server** and receives a
+ *    short-lived [IdJagAssertion].
+ * 2. [redeem] presents that assertion at the **resource authorization server** and receives a
+ *    short-lived, scoped resource access token.
+ *
+ * ```kotlin
+ * val target = CrossAppAccessTarget.forIssuer("https://resource.example.com") {
+ *     clientSecret = "target-client-secret"
+ * }
+ * val flow = CrossAppAccessFlow.create(idpClient, target).getOrThrow()
+ * val idJag = flow.start(SubjectAssertion.idToken(idToken)).getOrThrow()
+ * val resourceToken = flow.redeem(idJag).getOrThrow()
+ * ```
+ *
+ * If you do not need to keep the intermediate [IdJagAssertion], call [exchange] instead.
+ *
+ * This capability is not appropriate for background or machine-to-machine processing with no
+ * active human user session — use the org's other grant flows for that.
+ */
+interface CrossAppAccessFlow {
+    /**
+     * The **IdP authorization server** client — used for [start], where the ID-JAG is minted.
+     *
+     * ID-JAG issuance events arrive on this client's `events` stream; resource-token events
+     * arrive on [targetClient] instead.
+     */
+    val idpClient: OAuth2Client
+
+    /**
+     * The **resource authorization server** client — used for [redeem], where the ID-JAG is
+     * redeemed for a resource access token.
+     *
+     * Exposed so callers can collect its `events` stream: resource-token issuance is emitted
+     * here, not on [idpClient].
+     */
+    val targetClient: OAuth2Client
+
+    /**
+     * Exchanges [subjectAssertion] for an ID-JAG at the IdP authorization server.
+     *
+     * The audience sent is always the target's resolved issuer; there is no per-call override.
+     *
+     * @param subjectAssertion the signed-in user's assertion to present.
+     * @param scope requested scopes at the target, taking precedence over any configured on the
+     *   target itself. When neither is supplied, this call fails before any network request.
+     * @return [Result.success] with the [IdJagAssertion], or [Result.failure] with a
+     *   [CrossAppAccessException.IdpExchangeFailed] wrapping the underlying cause.
+     */
+    suspend fun start(
+        subjectAssertion: SubjectAssertion,
+        scope: List<String>? = null,
+    ): Result<IdJagAssertion>
+
+    /**
+     * Redeems [idJag] for a resource access token at the resource authorization server.
+     *
+     * Repeatable while [idJag] remains unexpired — this is the renewal path in place of a
+     * refresh token, so a fresh resource access token can be obtained without repeating [start].
+     *
+     * @param idJag a previously obtained (or [IdJagAssertion.restore]d) assertion.
+     * @return [Result.success] with the resource access [TokenInfo], or [Result.failure] with a
+     *   [CrossAppAccessException.TargetRedemptionFailed] wrapping the underlying cause.
+     */
+    suspend fun redeem(idJag: IdJagAssertion): Result<TokenInfo>
+
+    /**
+     * Convenience that runs [start] then [redeem] and returns the resulting resource access
+     * token.
+     *
+     * @param subjectAssertion the signed-in user's assertion to present.
+     * @param scope requested scopes at the target; see [start].
+     * @return [Result.success] with the resource access [TokenInfo], or [Result.failure] from
+     *   whichever step failed.
+     */
+    suspend fun exchange(
+        subjectAssertion: SubjectAssertion,
+        scope: List<String>? = null,
+    ): Result<TokenInfo>
+
+    /**
+     * A diagnostic summary naming both authorization servers in exchange order. Contains only
+     * the two resolved issuer URLs — never an assertion, token, secret, scope, or subject value.
+     * This format is for humans, is not stable across releases, and must not be parsed.
+     */
+    override fun toString(): String
+
+    companion object {
+        /**
+         * Builds the target client from [target] (or adopts one already built), validates that
+         * the resulting flow can actually authenticate at both servers, and returns the flow.
+         *
+         * This is the single validation point for the whole capability: every developer-reachable
+         * rejection — an invalid target shape, a missing target credential, a target that
+         * resolves to [idpClient]'s own issuer — surfaces from here, before any network request.
+         *
+         * @param idpClient the primary client, already configured against the IdP authorization
+         *   server.
+         * @param target the resource authorization server to redeem ID-JAGs at.
+         * @return [Result.success] with the flow, or [Result.failure] with an
+         *   [IllegalArgumentException] describing the configuration problem.
+         */
+        @JvmStatic
+        fun create(
+            idpClient: OAuth2Client,
+            target: CrossAppAccessTarget,
+        ): Result<CrossAppAccessFlow> = CrossAppAccessFlowImpl.create(idpClient, target)
+    }
+}

--- a/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/CrossAppAccessFlowImpl.kt
+++ b/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/CrossAppAccessFlowImpl.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp
+
+import com.okta.authfoundation.client.TokenInfo
+import com.okta.authfoundation.client.kmp.OAuth2Client
+
+/**
+ * Default implementation of [CrossAppAccessFlow].
+ *
+ * @param idpClient the primary client, used for [start].
+ * @param targetClient the resource authorization server client, used for [redeem].
+ */
+internal class CrossAppAccessFlowImpl(
+    override val idpClient: OAuth2Client,
+    override val targetClient: OAuth2Client,
+) : CrossAppAccessFlow {
+    override suspend fun start(
+        subjectAssertion: SubjectAssertion,
+        scope: List<String>?,
+    ): Result<IdJagAssertion> = TODO("implemented in the https://oktainc.atlassian.net/browse/OKTA-1258536")
+
+    override suspend fun redeem(idJag: IdJagAssertion): Result<TokenInfo> = TODO("implemented in the https://oktainc.atlassian.net/browse/OKTA-1258536")
+
+    override suspend fun exchange(
+        subjectAssertion: SubjectAssertion,
+        scope: List<String>?,
+    ): Result<TokenInfo> = TODO("implemented in the https://oktainc.atlassian.net/browse/OKTA-1258536")
+
+    override fun toString(): String = TODO("implemented in the https://oktainc.atlassian.net/browse/OKTA-1258536")
+
+    companion object {
+        fun create(
+            idpClient: OAuth2Client,
+            target: CrossAppAccessTarget,
+        ): Result<CrossAppAccessFlow> = TODO("implemented in the https://oktainc.atlassian.net/browse/OKTA-1258536")
+    }
+}

--- a/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/CrossAppAccessTarget.kt
+++ b/oauth2/src/commonMain/kotlin/com/okta/oauth2/kmp/CrossAppAccessTarget.kt
@@ -1,0 +1,329 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp
+
+import com.okta.authfoundation.client.ClientAssertionProvider
+import com.okta.authfoundation.client.OAuth2ClientBuilder
+import com.okta.authfoundation.client.OAuth2EndpointOverrides
+import com.okta.authfoundation.client.OidcClock
+import com.okta.authfoundation.client.kmp.OAuth2Client
+
+/**
+ * Describes the resource authorization server that a [CrossAppAccessFlow] redeems an ID-JAG at.
+ *
+ * A target is named by exactly one of three mutually exclusive forms — [Issuer],
+ * [AuthorizationServerId], or [Prebuilt] — each reached through its own factory below. Naming a
+ * target by more than one form, or by none, is unrepresentable rather than validated: there is no
+ * single constructor that could accept two identifiers or zero, so there is nothing for a runtime
+ * check to guard against.
+ *
+ * None of the three factories can fail; every developer-reachable validation failure (a malformed
+ * issuer, a missing credential, and so on) surfaces later, from [CrossAppAccessFlow.create], which
+ * is the only place that holds both the primary client and this target's fully-built configuration.
+ */
+sealed class CrossAppAccessTarget {
+    /** Scopes requested at this target, or `null` to rely on a per-call value. */
+    abstract val scope: List<String>?
+
+    /** RFC 8707 resource indicator to send with the first step, or `null` to omit it. */
+    abstract val resource: String?
+
+    /**
+     * A human-readable, credential-free description of this target. Declared `abstract` rather
+     * than inherited, so a future fourth form cannot silently pick up a default implementation
+     * that discloses a credential.
+     */
+    abstract override fun toString(): String
+
+    /**
+     * A target named by its issuer **origin** — scheme, host, and non-default port, with no path.
+     * This is the shape of an org authorization server's issuer.
+     */
+    class Issuer internal constructor(
+        /** The target's issuer origin, e.g. `https://resource.example.com`. */
+        val issuer: String,
+        override val scope: List<String>?,
+        override val resource: String?,
+        /** The client identifier to authenticate with at this target, or `null` to use the primary's. */
+        val clientId: String?,
+        /** The client secret to authenticate with at this target, mutually exclusive with [clientAssertionProvider]. */
+        val clientSecret: String?,
+        /** The client-assertion provider to authenticate with at this target, mutually exclusive with [clientSecret]. */
+        val clientAssertionProvider: ClientAssertionProvider?,
+        /** Explicit endpoint overrides for this target, taking precedence over discovered values. */
+        val endpointOverrides: OAuth2EndpointOverrides?,
+        /** Applied to the target client's builder last, after every setting above. */
+        val clientBuildAction: (OAuth2ClientBuilder.() -> Unit)?,
+    ) : CrossAppAccessTarget() {
+        override fun toString(): String = "CrossAppAccessTarget.Issuer(issuer=$issuer)"
+    }
+
+    /**
+     * A target named by an Okta custom authorization server identifier, resolved against the
+     * **primary** client's org — its scheme, host, and non-default port, plus `/oauth2/<id>`.
+     */
+    class AuthorizationServerId internal constructor(
+        /** The custom authorization server identifier, e.g. `"default"` or a custom AS id. */
+        val authorizationServerId: String,
+        override val scope: List<String>?,
+        override val resource: String?,
+        /** The client identifier to authenticate with at this target, or `null` to use the primary's. */
+        val clientId: String?,
+        /** The client secret to authenticate with at this target, mutually exclusive with [clientAssertionProvider]. */
+        val clientSecret: String?,
+        /** The client-assertion provider to authenticate with at this target, mutually exclusive with [clientSecret]. */
+        val clientAssertionProvider: ClientAssertionProvider?,
+        /** Explicit endpoint overrides for this target, taking precedence over discovered values. */
+        val endpointOverrides: OAuth2EndpointOverrides?,
+        /** Applied to the target client's builder last, after every setting above. */
+        val clientBuildAction: (OAuth2ClientBuilder.() -> Unit)?,
+    ) : CrossAppAccessTarget() {
+        override fun toString(): String = "CrossAppAccessTarget.AuthorizationServerId(authorizationServerId=$authorizationServerId)"
+    }
+
+    /**
+     * A target backed by an [OAuth2Client] the caller already built and owns. Carries no
+     * credential or endpoint settings of its own — those already live on the supplied client's
+     * configuration, which is also where the client-authentication requirement is checked.
+     */
+    class Prebuilt internal constructor(
+        internal val client: OAuth2Client,
+        override val scope: List<String>?,
+        override val resource: String?,
+    ) : CrossAppAccessTarget() {
+        override fun toString(): String = "CrossAppAccessTarget.Prebuilt(issuer=${client.configuration.issuerUrl})"
+    }
+
+    companion object {
+        /**
+         * Names a target by its issuer **origin**.
+         *
+         * The origin must carry no path — a full issuer URL such as
+         * `https://example.okta.com/oauth2/default` should instead be split into its origin and
+         * authorization server id and passed to [forAuthorizationServerId], since a path-bearing
+         * value would otherwise resolve to a different server than the one named.
+         *
+         * @param issuer the target's issuer origin.
+         * @param buildAction optional configuration block for the target's remaining settings.
+         */
+        @JvmStatic
+        @JvmOverloads
+        fun forIssuer(
+            issuer: String,
+            buildAction: (CrossAppAccessTargetBuilder.() -> Unit)? = null,
+        ): Issuer {
+            val builder = CrossAppAccessTargetBuilder()
+            buildAction?.invoke(builder)
+            return Issuer(
+                issuer = issuer,
+                scope = builder.scope,
+                resource = builder.resource,
+                clientId = builder.clientId,
+                clientSecret = builder.clientSecret,
+                clientAssertionProvider = builder.clientAssertionProvider,
+                endpointOverrides = builder.endpointOverrides,
+                clientBuildAction = builder.clientBuildAction
+            )
+        }
+
+        /**
+         * Names a target by an Okta custom authorization server identifier, resolved against the
+         * primary client's own org.
+         *
+         * @param authorizationServerId the custom authorization server identifier.
+         * @param buildAction optional configuration block for the target's remaining settings.
+         */
+        @JvmStatic
+        @JvmOverloads
+        fun forAuthorizationServerId(
+            authorizationServerId: String,
+            buildAction: (CrossAppAccessTargetBuilder.() -> Unit)? = null,
+        ): AuthorizationServerId {
+            val builder = CrossAppAccessTargetBuilder()
+            buildAction?.invoke(builder)
+            return AuthorizationServerId(
+                authorizationServerId = authorizationServerId,
+                scope = builder.scope,
+                resource = builder.resource,
+                clientId = builder.clientId,
+                clientSecret = builder.clientSecret,
+                clientAssertionProvider = builder.clientAssertionProvider,
+                endpointOverrides = builder.endpointOverrides,
+                clientBuildAction = builder.clientBuildAction
+            )
+        }
+
+        /**
+         * Wraps a target [OAuth2Client] the caller already built and owns — for example, one
+         * shared with an app-wide client registry, or one configured with a test-only executor.
+         *
+         * @param targetClient the already-built client for the target authorization server.
+         * @param resource optional RFC 8707 resource indicator to send with the first step.
+         * @param scope optional scopes requested at this target.
+         */
+        @JvmStatic
+        @JvmOverloads
+        fun wrapping(
+            targetClient: OAuth2Client,
+            resource: String? = null,
+            scope: List<String>? = null,
+        ): Prebuilt = Prebuilt(client = targetClient, scope = scope, resource = resource)
+    }
+}
+
+/**
+ * Mutable configuration receiver for [CrossAppAccessTarget.forIssuer] and
+ * [CrossAppAccessTarget.forAuthorizationServerId].
+ *
+ * Public `var` properties are this SDK's accepted builder exception to its public-immutability
+ * rule; the product built from them remains immutable.
+ */
+class CrossAppAccessTargetBuilder internal constructor() {
+    /**
+     * The client identifier to authenticate with at the target only. Never sent on the first
+     * step, whose client identifier is always the primary client's.
+     */
+    var clientId: String? = null
+
+    /**
+     * Scopes requested at the target. Sent as the first step's `scope` when set here or supplied
+     * per call; a per-call value takes precedence over this one.
+     */
+    var scope: List<String>? = null
+
+    /** The client secret to authenticate with at the target, mutually exclusive with [clientAssertionProvider]. */
+    var clientSecret: String? = null
+
+    /** The client-assertion provider to authenticate with at the target, mutually exclusive with [clientSecret]. */
+    var clientAssertionProvider: ClientAssertionProvider? = null
+
+    /** Explicit endpoint overrides for the target, taking precedence over discovered values. */
+    var endpointOverrides: OAuth2EndpointOverrides? = null
+
+    /** RFC 8707 resource indicator to send with the first step. */
+    var resource: String? = null
+
+    /**
+     * Applied to the target client's [OAuth2ClientBuilder] last, after every setting above, so it
+     * wins on conflict. Use this for target-client settings this builder does not name directly
+     * (a test executor, a clock, a cache, and so on).
+     *
+     * Because it is applied last, it can overwrite the credential and identity settings above —
+     * including with the primary client's own credential. Configure the target's credential
+     * through [clientSecret] or [clientAssertionProvider]; reserve this property for settings
+     * those do not cover.
+     */
+    var clientBuildAction: (OAuth2ClientBuilder.() -> Unit)? = null
+}
+
+/**
+ * The ID-JAG assertion produced by [CrossAppAccessFlow.start] and consumed by
+ * [CrossAppAccessFlow.redeem].
+ *
+ * This assertion is reusable, not single-use: it stands in for a refresh token at the target and
+ * may be redeemed more than once before it expires.
+ */
+class IdJagAssertion internal constructor(
+    /** The assertion value itself. Treated as opaque — nothing in this SDK parses it. */
+    val value: String,
+    /** The target authorization server this assertion was minted for. */
+    val audience: String,
+    /** The assertion's lifetime in seconds, as reported by the IdP authorization server. */
+    val expiresIn: Int,
+    /** Epoch seconds, from the SDK clock, at the moment this assertion was received or restored. */
+    val issuedAt: Long,
+    /**
+     * The granted scope as the IdP authorization server returned it, verbatim and
+     * space-delimited — matching how this SDK reports granted scope everywhere else. May be
+     * `null`, since some deployments omit this field entirely.
+     */
+    val scope: String? = null,
+    /** The token type the IdP authorization server reported for this assertion, if any. */
+    val issuedTokenType: String? = null,
+) {
+    /**
+     * Whether this assertion's reported lifetime has elapsed, as of [clock]. Performs no network
+     * call.
+     *
+     * This is a liveness hint, not an authorization decision: it is arithmetic over the lifetime
+     * the server reported at issuance, so it cannot detect server-side revocation. Treat `false`
+     * as "worth attempting", not "known valid" — only the target's own response is authoritative.
+     */
+    fun isExpired(clock: OidcClock): Boolean = clock.currentTimeEpochSecond() >= issuedAt + expiresIn
+
+    override fun toString(): String = "IdJagAssertion(audience=$audience, expiresIn=$expiresIn, issuedAt=$issuedAt)"
+
+    companion object {
+        /**
+         * Reconstructs an assertion the caller previously obtained and persisted, so it can be
+         * redeemed again after a process restart without a new trip to the IdP authorization
+         * server.
+         *
+         * [issuedAt] must be the *original* issuance instant recorded when this assertion was
+         * first obtained — a later value overstates its remaining lifetime.
+         */
+        @JvmStatic
+        @JvmOverloads
+        fun restore(
+            value: String,
+            audience: String,
+            expiresIn: Int,
+            issuedAt: Long,
+            scope: String? = null,
+            issuedTokenType: String? = null,
+        ): IdJagAssertion = IdJagAssertion(value, audience, expiresIn, issuedAt, scope, issuedTokenType)
+    }
+}
+
+/**
+ * A signed-in user's assertion, paired with the subject token type identifier that matches it.
+ *
+ * Pairing the value with its type through a closed set of named factories makes it impossible to
+ * send a token under the wrong type identifier — a value obtained via [idToken] can never be
+ * accidentally labeled as an access token, and vice versa.
+ */
+class SubjectAssertion private constructor(
+    /** The assertion value — the raw token string. */
+    val value: String,
+    /** Which of the three subject forms [value] is. */
+    val type: Type,
+) {
+    /**
+     * The subject forms this SDK can transmit.
+     *
+     * [ID_TOKEN] and [REFRESH_TOKEN] are defined by the governing ID-JAG specification.
+     * [ACCESS_TOKEN] is not — it is an Okta deployment extension, requiring an
+     * administrator-configured delegation link. An ID token is the only universally accepted
+     * default; verify the other two forms against your own deployment before depending on them.
+     */
+    enum class Type { ID_TOKEN, ACCESS_TOKEN, REFRESH_TOKEN }
+
+    override fun toString(): String = "SubjectAssertion(type=$type)"
+
+    companion object {
+        /** Builds a [SubjectAssertion] from an ID token. */
+        @JvmStatic
+        fun idToken(value: String): SubjectAssertion = SubjectAssertion(value, Type.ID_TOKEN)
+
+        /** Builds a [SubjectAssertion] from an access token. An Okta deployment extension. */
+        @JvmStatic
+        fun accessToken(value: String): SubjectAssertion = SubjectAssertion(value, Type.ACCESS_TOKEN)
+
+        /** Builds a [SubjectAssertion] from a refresh token. */
+        @JvmStatic
+        fun refreshToken(value: String): SubjectAssertion = SubjectAssertion(value, Type.REFRESH_TOKEN)
+    }
+}

--- a/oauth2/src/commonTest/kotlin/com/okta/oauth2/kmp/CrossAppAccessTestHarness.kt
+++ b/oauth2/src/commonTest/kotlin/com/okta/oauth2/kmp/CrossAppAccessTestHarness.kt
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp
+
+import com.okta.authfoundation.api.http.ApiExecutor
+import com.okta.authfoundation.api.http.ApiRequest
+import com.okta.authfoundation.api.http.ApiResponse
+
+/**
+ * A fake [ApiExecutor] that dispatches by exact request URL rather than by call order.
+ *
+ * The module's existing per-flow tests use a positional response queue (`allResponses[callIndex %
+ * size]`), which is fragile for a flow that talks to two different hosts: it cannot express "the
+ * target's discovery endpoint was never called", and it would let a request meant for one server
+ * silently reach the other. Routing by URL makes both mistakes visible.
+ */
+internal class RoutingApiExecutor : ApiExecutor {
+    private val queuedResponses = mutableMapOf<String, MutableList<Pair<Int, String>>>()
+    private val singleResponses = mutableMapOf<String, Pair<Int, String>>()
+    private val _capturedRequests = mutableListOf<ApiRequest>()
+
+    /** Every request this executor has received, in order. */
+    val capturedRequests: List<ApiRequest> = _capturedRequests
+
+    /** Requests whose URL exactly equals [url]. */
+    fun requestsTo(url: String): List<ApiRequest> = _capturedRequests.filter { it.url() == url }
+
+    /** Number of requests whose URL exactly equals [url]. */
+    fun countTo(url: String): Int = requestsTo(url).size
+
+    /**
+     * Stubs a single response, returned for every request to [url] (e.g. discovery documents,
+     * which this feature requests at most once per client per test).
+     */
+    fun stub(
+        url: String,
+        statusCode: Int,
+        body: String,
+    ) {
+        singleResponses[url] = statusCode to body
+    }
+
+    /**
+     * Enqueues one response for [url]. Successive calls to [enqueue] for the same [url] are
+     * returned in order — one per request — which is what a re-redemption test needs to return
+     * two distinct resource tokens from two requests to the same token endpoint.
+     */
+    fun enqueue(
+        url: String,
+        statusCode: Int,
+        body: String,
+    ) {
+        queuedResponses.getOrPut(url) { mutableListOf() }.add(statusCode to body)
+    }
+
+    override suspend fun execute(request: ApiRequest): Result<ApiResponse> {
+        _capturedRequests.add(request)
+        val url = request.url()
+        val queued = queuedResponses[url]
+        val (statusCode, body) =
+            if (!queued.isNullOrEmpty()) {
+                queued.removeAt(0)
+            } else {
+                singleResponses[url]
+                    ?: return Result.failure(IllegalStateException("CrossAppAccessTestHarness: no stubbed response for $url"))
+            }
+        return Result.success(fakeResponse(statusCode, body))
+    }
+}
+
+internal fun fakeResponse(
+    statusCode: Int,
+    body: String,
+): ApiResponse =
+    object : ApiResponse {
+        override val statusCode = statusCode
+        override val body = body.toByteArray()
+        override val headers: Map<String, List<String>> = emptyMap()
+        override val contentLength = body.length.toLong()
+        override val contentType = "application/json"
+    }
+
+/** A minimal OIDC discovery document naming [issuer] and a token endpoint at [tokenEndpoint]. */
+internal fun discoveryDocument(
+    issuer: String,
+    tokenEndpoint: String = "$issuer/v1/token",
+    grantTypesSupported: List<String>? = null,
+): String =
+    buildString {
+        append("""{"issuer":"$issuer","authorization_endpoint":"$issuer/v1/authorize","token_endpoint":"$tokenEndpoint"""")
+        if (grantTypesSupported != null) {
+            append(""","grant_types_supported":[${grantTypesSupported.joinToString(",") { "\"$it\"" }}]""")
+        }
+        append("}")
+    }
+
+/** A token-exchange response shaped like an ID-JAG issuance. */
+internal fun idJagResponse(
+    assertion: String = "id-jag-assertion-value",
+    expiresIn: Int = 300,
+    scope: String? = null,
+): String =
+    buildString {
+        append(
+            """{"issued_token_type":"urn:ietf:params:oauth:token-type:id-jag","access_token":"$assertion","token_type":"N_A","expires_in":$expiresIn"""
+        )
+        if (scope != null) append(""","scope":"$scope"""")
+        append("}")
+    }
+
+/** A JWT-bearer response shaped like a resource access token issuance. */
+internal fun resourceTokenResponse(
+    accessToken: String = "resource-access-token",
+    expiresIn: Int = 86400,
+    scope: String? = "chat.read chat.history",
+): String =
+    buildString {
+        append("""{"token_type":"Bearer","access_token":"$accessToken","expires_in":$expiresIn""")
+        if (scope != null) append(""","scope":"$scope"""")
+        append("}")
+    }
+
+/** An authorization-server error response, e.g. `invalid_grant` or `invalid_scope`. */
+internal fun errorResponse(
+    error: String,
+    description: String? = null,
+): String =
+    buildString {
+        append("""{"error":"$error"""")
+        if (description != null) append(""","error_description":"$description"""")
+        append("}")
+    }


### PR DESCRIPTION
Adds the public interface, target descriptor, and error type for the ID-JAG Cross App Access exchange with TODO() bodies, plus a URL-routing fake ApiExecutor that can stub the IdP and resource authorization servers independently. No behavior yet — implementation follows in next set of commits.

RESOLVES: OKTA-1258535