### PR TITLE
Fix refresh token immediately reporting as expired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@
   `String?` and only forwarded to the underlying KMP builder when set, diverging from
   `OAuth2ClientConfiguration.clientSecret`'s actual non-null `String` type (default `""`). It's now
   tracked as `String = ""` and always forwarded.
+- `accessTokenIfNotExpired()` on the KMP credential path always returned `null` immediately after
+  `refreshToken()`. `CredentialImpl.replaceToken()` built the refreshed `TokenData` without an
+  explicit `issuedAt`, falling back to `TokenData`'s conservative "worst case" default
+  (`now - expiresIn`), which computes the refreshed token's expiration as the instant of the
+  refresh itself. `replaceToken()` now passes the actual refresh time as `issuedAt` (#431).
 
 ## web-authentication-ui Unreleased
 

--- a/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/credential/kmp/CredentialImpl.kt
+++ b/auth-foundation/src/commonMain/kotlin/com/okta/authfoundation/credential/kmp/CredentialImpl.kt
@@ -246,7 +246,8 @@ class CredentialImpl internal constructor(
                 idToken = newToken.idToken,
                 deviceSecret = newToken.deviceSecret ?: token.deviceSecret,
                 issuedTokenType = newToken.issuedTokenType,
-                configuration = token.configuration
+                configuration = token.configuration,
+                issuedAt = token.configuration.clock.currentTimeEpochSecond()
             )
         val updated = dataSource.replaceToken(rekeyed)
         val snapshotToken = updated ?: token

--- a/auth-foundation/src/commonTest/kotlin/com/okta/authfoundation/credential/kmp/CredentialTokenLifecycleTest.kt
+++ b/auth-foundation/src/commonTest/kotlin/com/okta/authfoundation/credential/kmp/CredentialTokenLifecycleTest.kt
@@ -324,6 +324,19 @@ class CredentialTokenLifecycleTest {
             assertNotEquals(credential.token.accessToken, snapshot.token.accessToken)
         }
 
+    // Regression test for OKTA-1261812 / GitHub #431: a freshly refreshed token must not
+    // report as expired the instant it's issued, even with a clock that hasn't advanced.
+    @Test
+    fun refreshToken_SuccessfulResponse_NewTokenNotImmediatelyExpired() =
+        runTest {
+            val body = """{"token_type":"Bearer","expires_in":7200,"access_token":"new-at","scope":"openid","refresh_token":"new-rt"}"""
+            val credential = createCredential(createClient(successExecutor(body)))
+
+            val snapshot = credential.refreshToken().getOrThrow()
+
+            assertEquals("new-at", snapshot.accessTokenIfNotExpired())
+        }
+
     @Test
     fun refreshIfExpired_ValidToken_ReturnsSameInstance() =
         runTest {


### PR DESCRIPTION
Fix accessTokenIfNotExpired() returning null after refreshToken()

CredentialImpl.replaceToken() built the refreshed TokenData without an explicit issuedAt, falling back to TokenData's conservative "worst case" default (now - expiresIn). That default computes the refreshed token's expiration as the instant of the refresh itself, so accessTokenIfNotExpired() treats it as already expired. Pass the actual refresh time as issuedAt instead, matching the assumption the initial-login path already makes.

Fixes #431.
RESOLVES: OKTA-1261812