### PR TITLE
OKTA-1261937 Release auth-foundation, oauth2, web-authentication-ui, and bom 3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Use the BOM to keep versions aligned:
 
 ```kotlin
 dependencies {
-    implementation(platform("com.okta.kotlin:bom:3.0.0"))
+    implementation(platform("com.okta.kotlin:bom:3.1.0"))
     implementation("com.okta.kotlin:auth-foundation")
     implementation("com.okta.kotlin:oauth2")
     implementation("com.okta.kotlin:web-authentication-ui")
@@ -87,7 +87,7 @@ The BOM is a Gradle `java-platform`, which publishes as a standard Maven BOM —
         <dependency>
             <groupId>com.okta.kotlin</groupId>
             <artifactId>bom</artifactId>
-            <version>3.0.0</version>
+            <version>3.1.0</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>

--- a/auth-foundation/README.md
+++ b/auth-foundation/README.md
@@ -21,7 +21,7 @@ AuthFoundation is the core Okta Mobile Kotlin module for Kotlin Multiplatform au
 
 ```kotlin
 dependencies {
-    implementation(platform("com.okta.kotlin:bom:3.0.0"))
+    implementation(platform("com.okta.kotlin:bom:3.1.0"))
     implementation("com.okta.kotlin:auth-foundation")
 }
 ```

--- a/buildSrc/src/main/java/Configuration.kt
+++ b/buildSrc/src/main/java/Configuration.kt
@@ -2,10 +2,10 @@ import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import java.util.Properties
 
-const val BOM_VERSION = "3.0.0"
-const val AUTH_FOUNDATION_VERSION = "3.0.0"
-const val OAUTH2_VERSION = "3.0.0"
-const val WEB_AUTHENTICATION_UI_VERSION = "3.0.0"
+const val BOM_VERSION = "3.1.0"
+const val AUTH_FOUNDATION_VERSION = "3.1.0"
+const val OAUTH2_VERSION = "3.1.0"
+const val WEB_AUTHENTICATION_UI_VERSION = "3.1.0"
 const val LEGACY_TOKEN_MIGRATION_VERSION = "2.0.4"
 const val IDX_KOTLIN_VERSION = "3.1.1"
 const val IDX_NATIVE_AUTH_VERSION = "3.1.0"

--- a/oauth2/README.md
+++ b/oauth2/README.md
@@ -40,7 +40,7 @@ Each flow follows a consistent pattern:
 
 ```kotlin
 dependencies {
-    implementation(platform("com.okta.kotlin:bom:3.0.0"))
+    implementation(platform("com.okta.kotlin:bom:3.1.0"))
     implementation("com.okta.kotlin:auth-foundation")
     implementation("com.okta.kotlin:oauth2")
 }

--- a/okta-direct-auth/README.md
+++ b/okta-direct-auth/README.md
@@ -44,7 +44,7 @@ Unlike browser-based authentication flows, Direct Authentication gives you full 
 
 ```kotlin
 dependencies {
-    implementation(platform("com.okta.kotlin:bom:3.0.0"))
+    implementation(platform("com.okta.kotlin:bom:3.1.0"))
     implementation("com.okta.kotlin:auth-foundation")
     implementation("com.okta.kotlin:okta-direct-auth")
 }

--- a/okta-idx-kotlin/README.md
+++ b/okta-idx-kotlin/README.md
@@ -32,7 +32,7 @@ Add the `Okta IDX Kotlin` dependency to your `build.gradle.kts` file:
 
 ```kotlin
 dependencies {
-    implementation(platform("com.okta.kotlin:bom:3.0.0"))
+    implementation(platform("com.okta.kotlin:bom:3.1.0"))
     implementation("com.okta.kotlin:okta-idx-kotlin")
 }
 ```

--- a/web-authentication-ui/README.md
+++ b/web-authentication-ui/README.md
@@ -20,7 +20,7 @@ This module is **Android only**.
 
 ```kotlin
 dependencies {
-    implementation(platform("com.okta.kotlin:bom:3.0.0"))
+    implementation(platform("com.okta.kotlin:bom:3.1.0"))
     implementation("com.okta.kotlin:auth-foundation")
     implementation("com.okta.kotlin:oauth2")
     implementation("com.okta.kotlin:web-authentication-ui")


### PR DESCRIPTION
OKTA-1261937

Bumps `auth-foundation`, `oauth2`, `web-authentication-ui`, and `bom` from `3.0.0` to `3.1.0` in lockstep, and updates the `bom` coordinate referenced in each module's README (including `okta-idx-kotlin` and `okta-direct-auth`, which are constrained by the bom but not themselves released this cycle).

No breaking changes this cycle — see `CHANGELOG.md`'s `## Unreleased` sections for `auth-foundation`, `web-authentication-ui`, and `oauth2` for what's shipping (PAR support, client assertion support, Chrome Auth Tab support, jvm wrapper parity fixes, and bug fixes). The CHANGELOG stays `Unreleased` until the release is tagged and published.

Verified locally:
- `spotlessCheck`
- `testDebugUnitTest`
- `:okta-direct-auth:testAndroidHostTest :auth-foundation:testAndroidHostTest :oauth2:testAndroidHostTest`
- `:checkLegacyAbi`
- Cross-checked ABI diff against `auth-foundation@3.0.0`/`oauth2@3.0.0`/`web-authentication-ui@3.0.0` to confirm the CHANGELOG covers everything shipping.