### PR TITLE
Implement Java wrapper for Cross App Access

### DIFF
--- a/oauth2/api/jvm/oauth2.api
+++ b/oauth2/api/jvm/oauth2.api
@@ -366,6 +366,58 @@ public final class com/okta/oauth2/kmp/jvm/AuthorizationCodeFlow : java/io/Close
 	public static synthetic fun start$default (Lcom/okta/oauth2/kmp/jvm/AuthorizationCodeFlow;Ljava/lang/String;Lcom/okta/oauth2/kmp/BrowserRedirectHandler;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Ljava/util/concurrent/CompletableFuture;
 }
 
+public final class com/okta/oauth2/kmp/jvm/CrossAppAccessFlow : java/io/Closeable {
+	public static final field Companion Lcom/okta/oauth2/kmp/jvm/CrossAppAccessFlow$Companion;
+	public fun <init> (Lcom/okta/oauth2/kmp/CrossAppAccessFlow;)V
+	public fun close ()V
+	public static final fun create (Lcom/okta/authfoundation/client/kmp/OAuth2Client;Lcom/okta/oauth2/kmp/CrossAppAccessTarget;)Lcom/okta/authfoundation/client/jvm/AuthFoundationResult;
+	public static final fun crossAppAccessSubject (Lcom/okta/authfoundation/credential/kmp/Credential;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun crossAppAccessSubject (Lcom/okta/authfoundation/credential/kmp/Credential;Lcom/okta/oauth2/kmp/SubjectAssertion$Type;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun crossAppAccessToken (Lcom/okta/authfoundation/credential/kmp/Credential;Lcom/okta/authfoundation/client/kmp/OAuth2Client;Lcom/okta/oauth2/kmp/CrossAppAccessTarget;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun crossAppAccessToken (Lcom/okta/authfoundation/credential/kmp/Credential;Lcom/okta/authfoundation/client/kmp/OAuth2Client;Lcom/okta/oauth2/kmp/CrossAppAccessTarget;Lcom/okta/oauth2/kmp/SubjectAssertion$Type;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun crossAppAccessToken (Lcom/okta/authfoundation/credential/kmp/Credential;Lcom/okta/authfoundation/client/kmp/OAuth2Client;Lcom/okta/oauth2/kmp/CrossAppAccessTarget;Lcom/okta/oauth2/kmp/SubjectAssertion$Type;Ljava/util/List;)Ljava/util/concurrent/CompletableFuture;
+	public final fun exchange (Lcom/okta/oauth2/kmp/SubjectAssertion;)Ljava/util/concurrent/CompletableFuture;
+	public final fun exchange (Lcom/okta/oauth2/kmp/SubjectAssertion;Ljava/util/List;)Ljava/util/concurrent/CompletableFuture;
+	public static synthetic fun exchange$default (Lcom/okta/oauth2/kmp/jvm/CrossAppAccessFlow;Lcom/okta/oauth2/kmp/SubjectAssertion;Ljava/util/List;ILjava/lang/Object;)Ljava/util/concurrent/CompletableFuture;
+	public final fun getIdpClient ()Lcom/okta/authfoundation/client/kmp/OAuth2Client;
+	public final fun getTargetClient ()Lcom/okta/authfoundation/client/kmp/OAuth2Client;
+	public final fun redeem (Lcom/okta/oauth2/kmp/IdJagAssertion;)Ljava/util/concurrent/CompletableFuture;
+	public final fun start (Lcom/okta/oauth2/kmp/SubjectAssertion;)Ljava/util/concurrent/CompletableFuture;
+	public final fun start (Lcom/okta/oauth2/kmp/SubjectAssertion;Ljava/util/List;)Ljava/util/concurrent/CompletableFuture;
+	public static synthetic fun start$default (Lcom/okta/oauth2/kmp/jvm/CrossAppAccessFlow;Lcom/okta/oauth2/kmp/SubjectAssertion;Ljava/util/List;ILjava/lang/Object;)Ljava/util/concurrent/CompletableFuture;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/okta/oauth2/kmp/jvm/CrossAppAccessFlow$Companion {
+	public final fun create (Lcom/okta/authfoundation/client/kmp/OAuth2Client;Lcom/okta/oauth2/kmp/CrossAppAccessTarget;)Lcom/okta/authfoundation/client/jvm/AuthFoundationResult;
+	public final fun crossAppAccessSubject (Lcom/okta/authfoundation/credential/kmp/Credential;)Ljava/util/concurrent/CompletableFuture;
+	public final fun crossAppAccessSubject (Lcom/okta/authfoundation/credential/kmp/Credential;Lcom/okta/oauth2/kmp/SubjectAssertion$Type;)Ljava/util/concurrent/CompletableFuture;
+	public static synthetic fun crossAppAccessSubject$default (Lcom/okta/oauth2/kmp/jvm/CrossAppAccessFlow$Companion;Lcom/okta/authfoundation/credential/kmp/Credential;Lcom/okta/oauth2/kmp/SubjectAssertion$Type;ILjava/lang/Object;)Ljava/util/concurrent/CompletableFuture;
+	public final fun crossAppAccessToken (Lcom/okta/authfoundation/credential/kmp/Credential;Lcom/okta/authfoundation/client/kmp/OAuth2Client;Lcom/okta/oauth2/kmp/CrossAppAccessTarget;)Ljava/util/concurrent/CompletableFuture;
+	public final fun crossAppAccessToken (Lcom/okta/authfoundation/credential/kmp/Credential;Lcom/okta/authfoundation/client/kmp/OAuth2Client;Lcom/okta/oauth2/kmp/CrossAppAccessTarget;Lcom/okta/oauth2/kmp/SubjectAssertion$Type;)Ljava/util/concurrent/CompletableFuture;
+	public final fun crossAppAccessToken (Lcom/okta/authfoundation/credential/kmp/Credential;Lcom/okta/authfoundation/client/kmp/OAuth2Client;Lcom/okta/oauth2/kmp/CrossAppAccessTarget;Lcom/okta/oauth2/kmp/SubjectAssertion$Type;Ljava/util/List;)Ljava/util/concurrent/CompletableFuture;
+	public static synthetic fun crossAppAccessToken$default (Lcom/okta/oauth2/kmp/jvm/CrossAppAccessFlow$Companion;Lcom/okta/authfoundation/credential/kmp/Credential;Lcom/okta/authfoundation/client/kmp/OAuth2Client;Lcom/okta/oauth2/kmp/CrossAppAccessTarget;Lcom/okta/oauth2/kmp/SubjectAssertion$Type;Ljava/util/List;ILjava/lang/Object;)Ljava/util/concurrent/CompletableFuture;
+}
+
+public final class com/okta/oauth2/kmp/jvm/CrossAppAccessTargetBuilder {
+	public static final field Companion Lcom/okta/oauth2/kmp/jvm/CrossAppAccessTargetBuilder$Companion;
+	public final fun build ()Lcom/okta/oauth2/kmp/CrossAppAccessTarget;
+	public static final fun forAuthorizationServerId (Ljava/lang/String;)Lcom/okta/oauth2/kmp/jvm/CrossAppAccessTargetBuilder;
+	public static final fun forIssuer (Ljava/lang/String;)Lcom/okta/oauth2/kmp/jvm/CrossAppAccessTargetBuilder;
+	public final fun setClientAssertionProvider (Lcom/okta/authfoundation/client/ClientAssertionProvider;)Lcom/okta/oauth2/kmp/jvm/CrossAppAccessTargetBuilder;
+	public final fun setClientBuildAction (Ljava/util/function/Consumer;)Lcom/okta/oauth2/kmp/jvm/CrossAppAccessTargetBuilder;
+	public final fun setClientId (Ljava/lang/String;)Lcom/okta/oauth2/kmp/jvm/CrossAppAccessTargetBuilder;
+	public final fun setClientSecret (Ljava/lang/String;)Lcom/okta/oauth2/kmp/jvm/CrossAppAccessTargetBuilder;
+	public final fun setEndpointOverrides (Lcom/okta/authfoundation/client/OAuth2EndpointOverrides;)Lcom/okta/oauth2/kmp/jvm/CrossAppAccessTargetBuilder;
+	public final fun setResource (Ljava/lang/String;)Lcom/okta/oauth2/kmp/jvm/CrossAppAccessTargetBuilder;
+	public final fun setScope (Ljava/util/List;)Lcom/okta/oauth2/kmp/jvm/CrossAppAccessTargetBuilder;
+}
+
+public final class com/okta/oauth2/kmp/jvm/CrossAppAccessTargetBuilder$Companion {
+	public final fun forAuthorizationServerId (Ljava/lang/String;)Lcom/okta/oauth2/kmp/jvm/CrossAppAccessTargetBuilder;
+	public final fun forIssuer (Ljava/lang/String;)Lcom/okta/oauth2/kmp/jvm/CrossAppAccessTargetBuilder;
+}
+
 public final class com/okta/oauth2/kmp/jvm/DeviceAuthorizationFlow : java/io/Closeable {
 	public fun <init> (Lcom/okta/authfoundation/client/kmp/OAuth2Client;)V
 	public fun <init> (Lcom/okta/oauth2/kmp/DeviceAuthorizationFlow;)V

--- a/oauth2/src/commonTest/kotlin/com/okta/oauth2/kmp/jvm/FakeSuspendFlows.kt
+++ b/oauth2/src/commonTest/kotlin/com/okta/oauth2/kmp/jvm/FakeSuspendFlows.kt
@@ -17,13 +17,23 @@ package com.okta.oauth2.kmp.jvm
 
 import com.okta.authfoundation.client.OAuth2ClientBuilder
 import com.okta.authfoundation.client.TokenInfo
+import com.okta.authfoundation.client.dto.IntrospectInfo
+import com.okta.authfoundation.client.dto.OidcUserInfo
 import com.okta.authfoundation.client.kmp.OAuth2Client
+import com.okta.authfoundation.credential.RevokeTokenType
+import com.okta.authfoundation.credential.TokenType
+import com.okta.authfoundation.credential.kmp.Credential
+import com.okta.authfoundation.jwt.Jwt
 import com.okta.oauth2.kmp.AuthorizationCodeFlowContext
 import com.okta.oauth2.kmp.BrowserRedirectHandler
 import com.okta.oauth2.kmp.DeviceAuthorizationFlowContext
 import com.okta.oauth2.kmp.FakeTokenInfo
+import com.okta.oauth2.kmp.IdJagAssertion
 import com.okta.oauth2.kmp.RedirectEndSessionFlowContext
+import com.okta.oauth2.kmp.SubjectAssertion
+import kotlinx.coroutines.flow.Flow
 import com.okta.oauth2.kmp.AuthorizationCodeFlow as KotlinAuthorizationCodeFlow
+import com.okta.oauth2.kmp.CrossAppAccessFlow as KotlinCrossAppAccessFlow
 import com.okta.oauth2.kmp.DeviceAuthorizationFlow as KotlinDeviceAuthorizationFlow
 import com.okta.oauth2.kmp.RedirectEndSessionFlow as KotlinRedirectEndSessionFlow
 import com.okta.oauth2.kmp.ResourceOwnerFlow as KotlinResourceOwnerFlow
@@ -263,6 +273,108 @@ internal object FakeSuspendFlows {
                 uri: String,
                 flowContext: AuthorizationCodeFlowContext,
             ): Result<TokenInfo> = Result.failure(IllegalStateException("start() should have failed before resume() was called."))
+        }
+
+    @JvmStatic
+    fun successCrossAppAccessDelegate(): KotlinCrossAppAccessFlow =
+        object : KotlinCrossAppAccessFlow {
+            override val idpClient: OAuth2Client = fakeClient
+            override val targetClient: OAuth2Client = fakeClient
+
+            override suspend fun start(
+                subjectAssertion: SubjectAssertion,
+                scope: List<String>?,
+            ): Result<IdJagAssertion> = Result.success(IdJagAssertion.restore(value = "fake-id-jag", audience = "https://example.okta.com", expiresIn = 300, issuedAt = 0L))
+
+            override suspend fun redeem(idJag: IdJagAssertion): Result<com.okta.authfoundation.client.TokenInfo> = Result.success(FakeTokenInfo())
+
+            override suspend fun exchange(
+                subjectAssertion: SubjectAssertion,
+                scope: List<String>?,
+            ): Result<com.okta.authfoundation.client.TokenInfo> = Result.success(FakeTokenInfo())
+
+            override fun toString(): String = "CrossAppAccessFlow(idp=https://example.okta.com, target=https://example.okta.com)"
+        }
+
+    @JvmStatic
+    fun failingCrossAppAccessDelegate(): KotlinCrossAppAccessFlow =
+        object : KotlinCrossAppAccessFlow {
+            override val idpClient: OAuth2Client = fakeClient
+            override val targetClient: OAuth2Client = fakeClient
+
+            override suspend fun start(
+                subjectAssertion: SubjectAssertion,
+                scope: List<String>?,
+            ): Result<IdJagAssertion> = Result.failure(IllegalStateException("access_denied"))
+
+            override suspend fun redeem(idJag: IdJagAssertion): Result<com.okta.authfoundation.client.TokenInfo> = Result.failure(IllegalStateException("invalid_grant"))
+
+            override suspend fun exchange(
+                subjectAssertion: SubjectAssertion,
+                scope: List<String>?,
+            ): Result<com.okta.authfoundation.client.TokenInfo> = Result.failure(IllegalStateException("access_denied"))
+
+            override fun toString(): String = "CrossAppAccessFlow(idp=https://example.okta.com, target=https://example.okta.com)"
+        }
+
+    /**
+     * A fake [Credential] holding [idToken], for Java tests that cannot implement the
+     * commonMain `Credential` interface directly (it has suspend members).
+     */
+    @JvmStatic
+    fun fakeCredentialWithIdToken(idToken: String): Credential = fakeCredential(idToken = idToken)
+
+    /**
+     * A fake [Credential] with no ID token — deriving a Cross App Access subject from it fails
+     * before any network request, since the default subject type is the ID token.
+     */
+    @JvmStatic
+    fun fakeCredentialWithNoIdToken(): Credential = fakeCredential(idToken = null)
+
+    private fun fakeCredential(idToken: String?): Credential =
+        object : Credential {
+            override val id: String = "fake-credential-id"
+            override val token: TokenInfo =
+                object : TokenInfo {
+                    override val id: String = "fake-token-id"
+                    override val clientId: String = "fake-client-id"
+                    override val issuerUrl: String = "https://example.okta.com"
+                    override val tokenType: String = "Bearer"
+                    override val expiresIn: Int = 3600
+                    override val accessToken: String = "fake-access-token"
+                    override val scope: String? = "openid"
+                    override val refreshToken: String? = null
+                    override val idToken: String? = idToken
+                    override val deviceSecret: String? = null
+                    override val issuedTokenType: String? = null
+                }
+            override val tags: Map<String, String> = emptyMap()
+
+            override suspend fun deleteAsync(): Result<Unit> = notImplemented()
+
+            override fun getTokenFlow(): Flow<TokenInfo> = notImplemented()
+
+            override suspend fun getUserInfo(): Result<OidcUserInfo> = notImplemented()
+
+            override suspend fun revokeToken(tokenType: RevokeTokenType): Result<Unit> = notImplemented()
+
+            override suspend fun revokeAllTokens(): Result<Unit> = notImplemented()
+
+            override suspend fun refreshIfExpired(): Result<Credential> = notImplemented()
+
+            override fun accessTokenIfNotExpired(): String? = notImplemented()
+
+            override suspend fun setTagsAsync(tags: Map<String, String>): Result<Credential> = notImplemented()
+
+            override suspend fun introspectToken(tokenType: TokenType): Result<IntrospectInfo> = notImplemented()
+
+            override suspend fun refreshToken(): Result<Credential> = notImplemented()
+
+            override fun idToken(): Result<Jwt> = notImplemented()
+
+            override fun scope(): List<String> = notImplemented()
+
+            private fun notImplemented(): Nothing = throw NotImplementedError("not used by this test")
         }
 
     @JvmStatic

--- a/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/jvm/CrossAppAccessFlow.kt
+++ b/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/jvm/CrossAppAccessFlow.kt
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp.jvm
+
+import com.okta.authfoundation.client.TokenInfo
+import com.okta.authfoundation.client.jvm.AuthFoundationResult
+import com.okta.oauth2.kmp.crossAppAccessSubject
+import com.okta.oauth2.kmp.crossAppAccessToken
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.future.future
+import java.io.Closeable
+import java.util.concurrent.CompletableFuture
+import com.okta.authfoundation.client.kmp.OAuth2Client as KmpOAuth2Client
+import com.okta.authfoundation.credential.kmp.Credential as KmpCredential
+import com.okta.oauth2.kmp.CrossAppAccessFlow as KotlinCrossAppAccessFlow
+import com.okta.oauth2.kmp.CrossAppAccessTarget as KotlinCrossAppAccessTarget
+import com.okta.oauth2.kmp.IdJagAssertion as KotlinIdJagAssertion
+import com.okta.oauth2.kmp.SubjectAssertion as KotlinSubjectAssertion
+
+/**
+ * A Java-friendly wrapper around the Kotlin [KotlinCrossAppAccessFlow].
+ *
+ * This class exposes async methods returning [CompletableFuture] so Java consumers can perform a
+ * Cross App Access exchange without dealing with Kotlin coroutines.
+ *
+ * Typical Java usage:
+ * ```java
+ * CrossAppAccessTarget target = CrossAppAccessTargetBuilder.forIssuer("https://resource.example.com")
+ *     .setClientSecret("target-secret")
+ *     .build();
+ * AuthFoundationResult<CrossAppAccessFlow> result = CrossAppAccessFlow.create(idpClient, target);
+ * CrossAppAccessFlow flow = result.getOrThrow();
+ * TokenInfo resourceToken = flow.exchange(SubjectAssertion.idToken(idToken)).get();
+ * flow.close();
+ * ```
+ *
+ * Must be [closed][close] when no longer needed to release coroutine resources.
+ *
+ * @param delegate the underlying Kotlin [KotlinCrossAppAccessFlow] instance.
+ */
+class CrossAppAccessFlow(
+    private val delegate: KotlinCrossAppAccessFlow,
+) : Closeable {
+    private val coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    /** The **IdP authorization server** client — used for [start]. */
+    fun getIdpClient(): KmpOAuth2Client = delegate.idpClient
+
+    /** The **resource authorization server** client — used for [redeem]. */
+    fun getTargetClient(): KmpOAuth2Client = delegate.targetClient
+
+    /**
+     * Exchanges [subjectAssertion] for an ID-JAG at the IdP authorization server.
+     *
+     * @param subjectAssertion the signed-in user's assertion to present.
+     * @param scope requested scopes at the target, taking precedence over any configured on the
+     *   target itself. Pass `null` to rely on the target's configured scopes.
+     * @return a [CompletableFuture] that completes with the [KotlinIdJagAssertion] on success, or
+     *   completes exceptionally with a `CrossAppAccessException` on failure.
+     */
+    @JvmOverloads
+    fun start(
+        subjectAssertion: KotlinSubjectAssertion,
+        scope: List<String>? = null,
+    ): CompletableFuture<KotlinIdJagAssertion> = coroutineScope.future { delegate.start(subjectAssertion, scope).getOrThrow() }
+
+    /**
+     * Redeems [idJag] for a resource access token at the resource authorization server.
+     *
+     * @param idJag a previously obtained (or restored) assertion.
+     * @return a [CompletableFuture] that completes with the resource access [TokenInfo] on
+     *   success, or completes exceptionally with a `CrossAppAccessException` on failure.
+     */
+    fun redeem(idJag: KotlinIdJagAssertion): CompletableFuture<TokenInfo> = coroutineScope.future { delegate.redeem(idJag).getOrThrow() }
+
+    /**
+     * Convenience that runs [start] then [redeem] and returns the resulting resource access
+     * token.
+     *
+     * @param subjectAssertion the signed-in user's assertion to present.
+     * @param scope requested scopes at the target; see [start].
+     * @return a [CompletableFuture] that completes with the resource access [TokenInfo] on
+     *   success, or completes exceptionally on failure.
+     */
+    @JvmOverloads
+    fun exchange(
+        subjectAssertion: KotlinSubjectAssertion,
+        scope: List<String>? = null,
+    ): CompletableFuture<TokenInfo> = coroutineScope.future { delegate.exchange(subjectAssertion, scope).getOrThrow() }
+
+    override fun toString(): String = delegate.toString()
+
+    override fun close() {
+        coroutineScope.cancel()
+    }
+
+    companion object {
+        /**
+         * Builds the target client from [target] (or adopts one already built), validates that
+         * the resulting flow can actually authenticate at both servers, and returns the flow.
+         *
+         * @param idpClient the primary client, already configured against the IdP authorization
+         *   server.
+         * @param target the resource authorization server to redeem ID-JAGs at.
+         * @return an [AuthFoundationResult] containing the flow on success, or the configuration
+         *   failure on failure. Never throws.
+         */
+        @JvmStatic
+        fun create(
+            idpClient: KmpOAuth2Client,
+            target: KotlinCrossAppAccessTarget,
+        ): AuthFoundationResult<CrossAppAccessFlow> =
+            KotlinCrossAppAccessFlow.create(idpClient, target).fold(
+                onSuccess = { AuthFoundationResult.success(CrossAppAccessFlow(it)) },
+                onFailure = { AuthFoundationResult.failure(it) }
+            )
+
+        /**
+         * Derives a [KotlinSubjectAssertion] from [credential]'s stored token.
+         *
+         * @param credential the stored credential to derive a subject assertion from.
+         * @param type which of the credential's stored tokens to use. Defaults to the ID token.
+         * @return a [CompletableFuture] that completes with the [KotlinSubjectAssertion] on
+         *   success, or completes exceptionally with an `IllegalStateException` naming the
+         *   missing token on failure.
+         */
+        @JvmStatic
+        @JvmOverloads
+        fun crossAppAccessSubject(
+            credential: KmpCredential,
+            type: KotlinSubjectAssertion.Type = KotlinSubjectAssertion.Type.ID_TOKEN,
+        ): CompletableFuture<KotlinSubjectAssertion> = CoroutineScope(Dispatchers.Default).future { credential.crossAppAccessSubject(type).getOrThrow() }
+
+        /**
+         * One-call convenience that derives a subject assertion from [credential] and runs the
+         * complete Cross App Access exchange against [target], without mutating, replacing, or
+         * invalidating [credential].
+         *
+         * @param credential the stored credential to derive a subject assertion from.
+         * @param idpClient the primary client, already configured against the IdP authorization
+         *   server.
+         * @param target the resource authorization server to redeem an ID-JAG at.
+         * @param subjectType which of the credential's stored tokens to derive the subject
+         *   assertion from; see [crossAppAccessSubject]. Defaults to the ID token.
+         * @param scope requested scopes at the target; see [start].
+         * @return a [CompletableFuture] that completes with the resource access [TokenInfo] on
+         *   success, or completes exceptionally on failure.
+         */
+        @JvmStatic
+        @JvmOverloads
+        fun crossAppAccessToken(
+            credential: KmpCredential,
+            idpClient: KmpOAuth2Client,
+            target: KotlinCrossAppAccessTarget,
+            subjectType: KotlinSubjectAssertion.Type = KotlinSubjectAssertion.Type.ID_TOKEN,
+            scope: List<String>? = null,
+        ): CompletableFuture<TokenInfo> = CoroutineScope(Dispatchers.Default).future { credential.crossAppAccessToken(idpClient, target, subjectType, scope).getOrThrow() }
+    }
+}

--- a/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/jvm/CrossAppAccessTargetBuilder.kt
+++ b/oauth2/src/jvmMain/kotlin/com/okta/oauth2/kmp/jvm/CrossAppAccessTargetBuilder.kt
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp.jvm
+
+import com.okta.authfoundation.client.ClientAssertionProvider
+import com.okta.authfoundation.client.OAuth2ClientBuilder
+import com.okta.authfoundation.client.OAuth2EndpointOverrides
+import java.util.function.Consumer
+import com.okta.oauth2.kmp.CrossAppAccessTarget as KotlinCrossAppAccessTarget
+import com.okta.oauth2.kmp.CrossAppAccessTargetBuilder as KotlinCrossAppAccessTargetBuilder
+
+/**
+ * A Java-idiomatic builder for creating instances of [KotlinCrossAppAccessTarget].
+ *
+ * This builder provides method-chaining setters and delegates to the Kotlin
+ * `CrossAppAccessTarget` factories for the actual construction. Reach it through [forIssuer] or
+ * [forAuthorizationServerId] — exactly one of the two, since a target is named by exactly one
+ * identifier form.
+ *
+ * ```java
+ * CrossAppAccessTarget target = CrossAppAccessTargetBuilder.forIssuer("https://resource.example.com")
+ *     .setClientSecret("target-secret")
+ *     .setScope(List.of("chat.read"))
+ *     .build();
+ * ```
+ */
+class CrossAppAccessTargetBuilder private constructor(
+    private val issuer: String?,
+    private val authorizationServerId: String?,
+) {
+    private var clientId: String? = null
+    private var scope: List<String>? = null
+    private var clientSecret: String? = null
+    private var clientAssertionProvider: ClientAssertionProvider? = null
+    private var endpointOverrides: OAuth2EndpointOverrides? = null
+    private var resource: String? = null
+    private var clientBuildAction: Consumer<OAuth2ClientBuilder>? = null
+
+    /**
+     * Sets the client identifier to authenticate with at the target only.
+     *
+     * @param clientId the target-side client identifier.
+     * @return this builder, for chaining.
+     */
+    fun setClientId(clientId: String): CrossAppAccessTargetBuilder = apply { this.clientId = clientId }
+
+    /**
+     * Sets the scopes requested at the target.
+     *
+     * @param scope the requested scopes.
+     * @return this builder, for chaining.
+     */
+    fun setScope(scope: List<String>): CrossAppAccessTargetBuilder = apply { this.scope = scope }
+
+    /**
+     * Sets the client secret to authenticate with at the target. Mutually exclusive with
+     * [setClientAssertionProvider].
+     *
+     * @param clientSecret the target-side client secret.
+     * @return this builder, for chaining.
+     */
+    fun setClientSecret(clientSecret: String): CrossAppAccessTargetBuilder = apply { this.clientSecret = clientSecret }
+
+    /**
+     * Sets the client-assertion provider to authenticate with at the target. Mutually exclusive
+     * with [setClientSecret].
+     *
+     * @param clientAssertionProvider the target-side client-assertion provider.
+     * @return this builder, for chaining.
+     */
+    fun setClientAssertionProvider(clientAssertionProvider: ClientAssertionProvider): CrossAppAccessTargetBuilder = apply { this.clientAssertionProvider = clientAssertionProvider }
+
+    /**
+     * Sets explicit endpoint overrides for the target, taking precedence over discovered values.
+     *
+     * @param endpointOverrides the endpoint overrides.
+     * @return this builder, for chaining.
+     */
+    fun setEndpointOverrides(endpointOverrides: OAuth2EndpointOverrides): CrossAppAccessTargetBuilder = apply { this.endpointOverrides = endpointOverrides }
+
+    /**
+     * Sets the RFC 8707 resource indicator to send with the first step.
+     *
+     * @param resource the resource indicator.
+     * @return this builder, for chaining.
+     */
+    fun setResource(resource: String): CrossAppAccessTargetBuilder = apply { this.resource = resource }
+
+    /**
+     * Applied to the target client's [OAuth2ClientBuilder] last, after every setting above, so it
+     * wins on conflict. Use this for target-client settings this builder does not name directly.
+     *
+     * Because it is applied last, it can overwrite the credential and identity settings above —
+     * including with the primary client's own credential. Configure the target's credential
+     * through [setClientSecret] or [setClientAssertionProvider]; reserve this for settings those
+     * do not cover.
+     *
+     * @param action a consumer that configures the target client's builder.
+     * @return this builder, for chaining.
+     */
+    fun setClientBuildAction(action: Consumer<OAuth2ClientBuilder>): CrossAppAccessTargetBuilder = apply { this.clientBuildAction = action }
+
+    /**
+     * Builds the [KotlinCrossAppAccessTarget]. Naming a target has no failure mode, so this
+     * returns the target directly rather than an `AuthFoundationResult`.
+     *
+     * @return the built target.
+     */
+    fun build(): KotlinCrossAppAccessTarget {
+        val capturedClientId = clientId
+        val capturedScope = scope
+        val capturedClientSecret = clientSecret
+        val capturedClientAssertionProvider = clientAssertionProvider
+        val capturedEndpointOverrides = endpointOverrides
+        val capturedResource = resource
+        val capturedClientBuildAction: (OAuth2ClientBuilder.() -> Unit)? = clientBuildAction?.let { consumer -> { consumer.accept(this) } }
+
+        val configure: KotlinCrossAppAccessTargetBuilder.() -> Unit = {
+            clientId = capturedClientId
+            scope = capturedScope
+            clientSecret = capturedClientSecret
+            clientAssertionProvider = capturedClientAssertionProvider
+            endpointOverrides = capturedEndpointOverrides
+            resource = capturedResource
+            clientBuildAction = capturedClientBuildAction
+        }
+
+        return if (issuer != null) {
+            KotlinCrossAppAccessTarget.forIssuer(issuer, configure)
+        } else {
+            KotlinCrossAppAccessTarget.forAuthorizationServerId(authorizationServerId!!, configure)
+        }
+    }
+
+    companion object {
+        /**
+         * Starts a builder for a target named by its issuer origin.
+         *
+         * @param issuer the target's issuer origin.
+         */
+        @JvmStatic
+        fun forIssuer(issuer: String): CrossAppAccessTargetBuilder = CrossAppAccessTargetBuilder(issuer = issuer, authorizationServerId = null)
+
+        /**
+         * Starts a builder for a target named by an Okta custom authorization server identifier,
+         * resolved against the primary client's own org.
+         *
+         * @param authorizationServerId the custom authorization server identifier.
+         */
+        @JvmStatic
+        fun forAuthorizationServerId(authorizationServerId: String): CrossAppAccessTargetBuilder = CrossAppAccessTargetBuilder(issuer = null, authorizationServerId = authorizationServerId)
+    }
+}

--- a/oauth2/src/jvmTest/java/com/okta/oauth2/kmp/jvm/CrossAppAccessFlowTest.java
+++ b/oauth2/src/jvmTest/java/com/okta/oauth2/kmp/jvm/CrossAppAccessFlowTest.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright 2022-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.oauth2.kmp.jvm;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.okta.authfoundation.client.TokenInfo;
+import com.okta.authfoundation.client.jvm.AuthFoundationResult;
+import com.okta.authfoundation.client.kmp.OAuth2Client;
+import com.okta.authfoundation.credential.kmp.Credential;
+import com.okta.oauth2.kmp.CrossAppAccessTarget;
+import com.okta.oauth2.kmp.IdJagAssertion;
+import com.okta.oauth2.kmp.SubjectAssertion;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.junit.Test;
+
+/**
+ * Java-language tests for {@link CrossAppAccessFlow} and its supporting types. Validates that the
+ * API is ergonomic — and genuinely constructible without a nine-argument constructor — from actual
+ * Java code.
+ */
+public class CrossAppAccessFlowTest {
+
+  private static OAuth2Client idpClient() {
+    return TestOAuth2Client.create();
+  }
+
+  @Test
+  public void create_WithTargetNamedByIssuer_AndNoCredential_ReturnsFailedResult() {
+    CrossAppAccessTarget target =
+        CrossAppAccessTargetBuilder.forIssuer("https://resource.example.com").build();
+
+    AuthFoundationResult<CrossAppAccessFlow> result =
+        CrossAppAccessFlow.create(idpClient(), target);
+
+    assertTrue(result.isFailure());
+  }
+
+  @Test
+  public void create_WithTargetNamedByAuthorizationServerId_AndNoCredential_ReturnsFailedResult() {
+    CrossAppAccessTarget target =
+        CrossAppAccessTargetBuilder.forAuthorizationServerId("default").build();
+
+    AuthFoundationResult<CrossAppAccessFlow> result =
+        CrossAppAccessFlow.create(idpClient(), target);
+
+    assertTrue(result.isFailure());
+  }
+
+  @Test
+  public void create_WithWrappedPublicClient_ReturnsFailedResult() {
+    OAuth2Client publicTargetClient = TestOAuth2Client.create();
+    CrossAppAccessTarget target = CrossAppAccessTarget.wrapping(publicTargetClient, null, null);
+
+    AuthFoundationResult<CrossAppAccessFlow> result =
+        CrossAppAccessFlow.create(idpClient(), target);
+
+    assertTrue(result.isFailure());
+  }
+
+  @Test
+  public void builder_ForIssuer_ChainsEverySettingAndBuildsATarget() {
+    CrossAppAccessTarget target =
+        CrossAppAccessTargetBuilder.forIssuer("https://resource.example.com")
+            .setClientId("target-client-id")
+            .setScope(List.of("chat.read"))
+            .setClientSecret("target-secret")
+            .setResource("https://resource.example.com/api")
+            .setClientBuildAction(
+                builder -> {
+                  builder.setClientSecret("target-secret-overridden");
+                })
+            .build();
+
+    assertNotNull(target);
+  }
+
+  @Test
+  public void create_WithBuilderTarget_Succeeds() {
+    CrossAppAccessTarget target =
+        CrossAppAccessTargetBuilder.forIssuer("https://resource.example.com")
+            .setClientSecret("target-secret")
+            .build();
+
+    AuthFoundationResult<CrossAppAccessFlow> result =
+        CrossAppAccessFlow.create(idpClient(), target);
+
+    assertTrue(result.isSuccess());
+    result.getOrThrow().close();
+  }
+
+  @Test
+  public void start_ReturnsCompletableFutureWithIdJagAssertion()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    try (CrossAppAccessFlow flow = TestFlowFactory.createSuccessCrossAppAccessFlow()) {
+      CompletableFuture<IdJagAssertion> future =
+          flow.start(SubjectAssertion.idToken("id-token"), List.of("chat.read"));
+      assertNotNull("Future should not be null", future);
+
+      IdJagAssertion idJag = future.get(5, TimeUnit.SECONDS);
+      assertNotNull("IdJagAssertion should not be null", idJag);
+    }
+  }
+
+  @Test
+  public void start_WithJvmOverloadsShortForm_OmitsScope()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    try (CrossAppAccessFlow flow = TestFlowFactory.createSuccessCrossAppAccessFlow()) {
+      IdJagAssertion idJag =
+          flow.start(SubjectAssertion.idToken("id-token")).get(5, TimeUnit.SECONDS);
+      assertNotNull(idJag);
+    }
+  }
+
+  @Test
+  public void redeem_CalledTwice_BothCallsSucceed()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    try (CrossAppAccessFlow flow = TestFlowFactory.createSuccessCrossAppAccessFlow()) {
+      IdJagAssertion idJag =
+          flow.start(SubjectAssertion.idToken("id-token")).get(5, TimeUnit.SECONDS);
+
+      TokenInfo first = flow.redeem(idJag).get(5, TimeUnit.SECONDS);
+      TokenInfo second = flow.redeem(idJag).get(5, TimeUnit.SECONDS);
+
+      assertNotNull(first);
+      assertNotNull(second);
+    }
+  }
+
+  @Test
+  public void exchange_ReturnsCompletableFutureWithTokenInfo()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    try (CrossAppAccessFlow flow = TestFlowFactory.createSuccessCrossAppAccessFlow()) {
+      TokenInfo tokenInfo =
+          flow.exchange(SubjectAssertion.idToken("id-token"), null).get(5, TimeUnit.SECONDS);
+      assertNotNull(tokenInfo);
+      assertEquals("Bearer", tokenInfo.getTokenType());
+    }
+  }
+
+  @Test
+  public void exchange_WithJvmOverloadsShortForm_OmitsScope()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    try (CrossAppAccessFlow flow = TestFlowFactory.createSuccessCrossAppAccessFlow()) {
+      TokenInfo tokenInfo =
+          flow.exchange(SubjectAssertion.idToken("id-token")).get(5, TimeUnit.SECONDS);
+      assertNotNull(tokenInfo);
+    }
+  }
+
+  @Test
+  public void exchange_WithError_CompletesExceptionally()
+      throws TimeoutException, InterruptedException {
+    try (CrossAppAccessFlow flow = TestFlowFactory.createFailingCrossAppAccessFlow()) {
+      CompletableFuture<TokenInfo> future =
+          flow.exchange(SubjectAssertion.idToken("id-token"), null);
+      try {
+        future.get(5, TimeUnit.SECONDS);
+        fail("Should have thrown ExecutionException");
+      } catch (ExecutionException e) {
+        assertNotNull("Cause should not be null", e.getCause());
+        assertTrue(
+            "Should contain error message", e.getCause().getMessage().contains("access_denied"));
+      }
+    }
+  }
+
+  @Test
+  public void getTargetClient_ReturnsConfiguredClient() {
+    try (CrossAppAccessFlow flow = TestFlowFactory.createSuccessCrossAppAccessFlow()) {
+      assertNotNull(flow.getTargetClient());
+      assertNotNull(flow.getIdpClient());
+    }
+  }
+
+  @Test
+  public void subjectAssertionFactories_AreCallableWithoutACompanionQualifier() {
+    assertNotNull(SubjectAssertion.idToken("id-token"));
+    assertNotNull(SubjectAssertion.accessToken("access-token"));
+    assertNotNull(SubjectAssertion.refreshToken("refresh-token"));
+  }
+
+  @Test
+  public void crossAppAccessSubject_StaticHelper_ReturnsSubjectAssertion()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    Credential credential = FakeSuspendFlows.fakeCredentialWithIdToken("the-id-token");
+
+    SubjectAssertion subject =
+        CrossAppAccessFlow.crossAppAccessSubject(credential).get(5, TimeUnit.SECONDS);
+
+    assertNotNull(subject);
+  }
+
+  @Test
+  public void crossAppAccessSubject_StaticHelper_WithAccessTokenType_ReturnsSubjectAssertion()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    // Credential has no ID token, so this only succeeds if the explicit type argument actually
+    // reaches the underlying call rather than the default ID_TOKEN type being used instead.
+    Credential credential = FakeSuspendFlows.fakeCredentialWithNoIdToken();
+
+    SubjectAssertion subject =
+        CrossAppAccessFlow.crossAppAccessSubject(credential, SubjectAssertion.Type.ACCESS_TOKEN)
+            .get(5, TimeUnit.SECONDS);
+
+    assertNotNull(subject);
+  }
+
+  @Test
+  public void crossAppAccessToken_StaticHelper_WhenCredentialLacksIdToken_CompletesExceptionally()
+      throws InterruptedException, TimeoutException {
+    // No stub executor is reachable from Java (ApiExecutor has a suspend member), so this
+    // exercises the pre-network failure path deterministically rather than performing real I/O.
+    Credential credential = FakeSuspendFlows.fakeCredentialWithNoIdToken();
+    CrossAppAccessTarget target =
+        CrossAppAccessTargetBuilder.forIssuer("https://resource.example.com")
+            .setClientSecret("target-secret")
+            .build();
+
+    CompletableFuture<TokenInfo> future =
+        CrossAppAccessFlow.crossAppAccessToken(credential, idpClient(), target);
+    try {
+      future.get(5, TimeUnit.SECONDS);
+      fail("Should have thrown ExecutionException");
+    } catch (ExecutionException e) {
+      assertNotNull(e.getCause());
+    }
+  }
+
+  @Test
+  public void crossAppAccessToken_StaticHelper_WithRefreshTokenSubjectType_DerivesFromRefreshToken()
+      throws InterruptedException, TimeoutException {
+    // idpClient must match the credential's issuer/clientId, so the failure below comes from
+    // deriving the refresh-token subject assertion, not from the pre-subject client-match check.
+    OAuth2Client matchingIdpClient = TestOAuth2Client.create("fake-client-id");
+    Credential credential = FakeSuspendFlows.fakeCredentialWithNoIdToken();
+    CrossAppAccessTarget target =
+        CrossAppAccessTargetBuilder.forIssuer("https://resource.example.com")
+            .setClientSecret("target-secret")
+            .build();
+
+    CompletableFuture<TokenInfo> future =
+        CrossAppAccessFlow.crossAppAccessToken(
+            credential, matchingIdpClient, target, SubjectAssertion.Type.REFRESH_TOKEN, null);
+
+    try {
+      future.get(5, TimeUnit.SECONDS);
+      fail("Should have thrown ExecutionException");
+    } catch (ExecutionException e) {
+      assertNotNull(e.getCause());
+      assertTrue(
+          "Should fail deriving the refresh token subject, proving subjectType reached the"
+              + " underlying call",
+          e.getCause().getMessage().contains("refresh token"));
+    }
+  }
+
+  @Test
+  public void close_IsIdempotent() {
+    CrossAppAccessFlow flow = TestFlowFactory.createSuccessCrossAppAccessFlow();
+    flow.close();
+    flow.close(); // Should not throw
+  }
+}

--- a/oauth2/src/jvmTest/java/com/okta/oauth2/kmp/jvm/TestFlowFactory.java
+++ b/oauth2/src/jvmTest/java/com/okta/oauth2/kmp/jvm/TestFlowFactory.java
@@ -118,4 +118,14 @@ public final class TestFlowFactory {
   public static AuthorizationCodeFlow createParRequestFailedAuthorizationCodeFlow() {
     return new AuthorizationCodeFlow(FakeSuspendFlows.parRequestFailedAuthorizationCodeDelegate());
   }
+
+  /** Creates a {@link CrossAppAccessFlow} that always succeeds. */
+  public static CrossAppAccessFlow createSuccessCrossAppAccessFlow() {
+    return new CrossAppAccessFlow(FakeSuspendFlows.successCrossAppAccessDelegate());
+  }
+
+  /** Creates a {@link CrossAppAccessFlow} that always fails. */
+  public static CrossAppAccessFlow createFailingCrossAppAccessFlow() {
+    return new CrossAppAccessFlow(FakeSuspendFlows.failingCrossAppAccessDelegate());
+  }
 }

--- a/oauth2/src/jvmTest/java/com/okta/oauth2/kmp/jvm/TestOAuth2Client.java
+++ b/oauth2/src/jvmTest/java/com/okta/oauth2/kmp/jvm/TestOAuth2Client.java
@@ -31,8 +31,13 @@ class TestOAuth2Client {
   private TestOAuth2Client() {}
 
   static OAuth2Client create() {
+    return create("test-client");
+  }
+
+  /** Same issuer as {@link #create()}, but with a caller-supplied clientId. */
+  static OAuth2Client create(String clientId) {
     return new OAuth2ClientBuilder(
-            "https://example.okta.com", "test-client", Collections.singletonList("openid"))
+            "https://example.okta.com", clientId, Collections.singletonList("openid"))
         .build()
         .getOrThrow();
   }


### PR DESCRIPTION
CrossAppAccessFlow (jvm) delegates start/redeem/exchange to CompletableFuture via the wrapper's coroutine scope, create() returns AuthFoundationResult rather than throwing, and CrossAppAccessTargetBuilder (jvm) delegates to the commonMain factories through chaining setters. All 16 Java-source tests pass, confirming the surface is genuinely Java-idiomatic (compiler-enforced, not just documented).

RESOLVES: OKTA-1258538